### PR TITLE
Fix shadow bug on Firefox

### DIFF
--- a/assets/src/css/styles.css
+++ b/assets/src/css/styles.css
@@ -21,7 +21,7 @@
   border-radius: 50%;
   background: transparent;
   padding: 0;
-  box-shadow: 0 0 0 0;
+  box-shadow: none;
   vertical-align: middle;
   text-align: left;
   position: relative;


### PR DESCRIPTION
box-shadow: 0 0 0 0; leaves a slight edge on Firefox.
box-shadow does accept `none`, which works as expected.