### PR TITLE
http: download: improvement for range support and I/O

### DIFF
--- a/http/download.go
+++ b/http/download.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -86,24 +85,18 @@ func downloadFileHandler(c *fm.Context, w http.ResponseWriter, r *http.Request) 
 		return http.StatusInternalServerError, err
 	}
 
-	if r.URL.Query().Get("inline") == "true" {
-		w.Header().Set("Content-Disposition", "inline")
-
-		_, err = io.Copy(w, file)
-		if err != nil {
-			return http.StatusInternalServerError, err
-		}
-
-		return 0, nil
-	}
-
 	stat, err := file.Stat()
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
 
-	// As per RFC6266 section 4.3
-	w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.QueryEscape(c.File.Name))
+	if r.URL.Query().Get("inline") == "true" {
+		w.Header().Set("Content-Disposition", "inline")
+	} else {
+		// As per RFC6266 section 4.3
+		w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.QueryEscape(c.File.Name))
+	}
+
 	http.ServeContent(w, r, stat.Name(), stat.ModTime(), file)
 
 	return 0, nil


### PR DESCRIPTION
The main benefit of [http.ServeContent](https://golang.org/pkg/net/http/#ServeContent)  over io.Copy is that it handles Range requests properly, sets the MIME type, and handles If-Match, If-Unmodified-Since, If-None-Match, If-Modified-Since, and If-Range requests. This is helpful when downloading under an unstable network condition where a download connection may be cut off. With http.ServeContent, suspended downloading process can be resumed properly.

[http.ServeFile](https://golang.org/pkg/net/http/#ServeFile) is just a wrapper over http.ServeContent which handles path resolve.

In downloadHandler, it's a bit hard to adopt http.ServeContent, but at the moment it's not necessary to store the archived filed in the first place; it's an overhead that we can reduce.

NOTE: try to reproduce #303 to make sure the stream is properly adopted.