### PR TITLE
http: header: fix wrong header

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -86,7 +86,7 @@ func serve(c *fm.Context, w http.ResponseWriter, r *http.Request) (int, error) {
 
 	// Any other request should show the index.html file.
 	w.Header().Set("x-frame-options", "SAMEORIGIN")
-	w.Header().Set("x-content-type", "nosniff")
+	w.Header().Set("x-content-type-options", "nosniff")
 	w.Header().Set("x-xss-protection", "1; mode=block")
 
 	return renderFile(c, w, "index.html")


### PR DESCRIPTION
`X-Content-Type` should be `X-Content-Type-Options`
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options