### PR TITLE
http: download: use PathEscape instead of QueryEscape

### DIFF
--- a/http/download.go
+++ b/http/download.go
@@ -71,7 +71,7 @@ func downloadHandler(c *fm.Context, w http.ResponseWriter, r *http.Request) (int
 	}
 	name += extension
 
-	w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.QueryEscape(name))
+	w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.PathEscape(name))
 	err := ar.Write(w, files)
 
 	return 0, err
@@ -94,7 +94,7 @@ func downloadFileHandler(c *fm.Context, w http.ResponseWriter, r *http.Request) 
 		w.Header().Set("Content-Disposition", "inline")
 	} else {
 		// As per RFC6266 section 4.3
-		w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.QueryEscape(c.File.Name))
+		w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.PathEscape(c.File.Name))
 	}
 
 	http.ServeContent(w, r, stat.Name(), stat.ModTime(), file)


### PR DESCRIPTION
Sorry it was my mistake.

For example `file+name with space` should be escaped into `file+name%20with%20space` (PathEscape) instead of `file%2Bname+with+space` (QueryEscape), which causes wrong unescaped filename.