### PR TITLE
chore: add more architectures and arm versions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,14 @@ build:
     - 386
     - arm
     - arm64
+    - mips
+    - mips64
+    - mipsle
+    - mips64le
+  goarm:
+    - 5
+    - 6
+    - 7
   ignore:
     - goos: openbsd
       goarch: arm


### PR DESCRIPTION
Closes #357.

I'm always skeptical when adding more architectures. Yesterday, to release 1.7.0, I had to remove the MIPS arch because it was failing for some weird reason.

Anyway, @Equim-chan, review and merge 😄 