### PR TITLE
fix309: merge CMD in the dockerfile to ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,4 @@ EXPOSE 80
 
 COPY Docker.json /config.json
 
-ENTRYPOINT ["/filebrowser"]
-CMD ["--config", "/config.json"]
+ENTRYPOINT ["/filebrowser", "--config", "/config.json"]


### PR DESCRIPTION
Fix #309.

This PR moves `"--config", "/config.json"` in the Dockerfile from CMD to ENTRYPOINT, in order to prevent these arguments being overriden.

Note that right now Viper does not support multiple config files:

> https://github.com/spf13/viper#reading-config-files
> Viper can search multiple paths, but currently a single Viper instance only supports a single configuration file.

Therefore, if a user provides an additional `-c` flag, parameters in `.config.json` are completely ignored. Only the last passed config file will be used.

Something like spf13/viper#442 would be really useful in this use case.