### PR TITLE
fix: remove default rules

### DIFF
--- a/caddy/parser/parser.go
+++ b/caddy/parser/parser.go
@@ -38,11 +38,7 @@ func Parse(c *caddy.Controller, plugin string) ([]*filebrowser.FileBrowser, erro
 			Commands:      []string{"git", "svn", "hg"},
 			CSS:           "",
 			ViewMode:      "mosaic",
-			Rules: []*filebrowser.Rule{{
-				Regex:  true,
-				Allow:  false,
-				Regexp: &filebrowser.Regexp{Raw: "\\/\\..+"},
-			}},
+			Rules:         []*filebrowser.Rule{},
 		}
 
 		baseURL := "/"


### PR DESCRIPTION
Removes the default rule that blocks the access to dotfiles. The user has the option to add it or remove it.