### PR TITLE
Update .dockerignore to ignore the .git directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 testdata/
 .github/
+.git/


### PR DESCRIPTION
This results in a smaller build context being sent to the Docker daemon and therefore also in a faster build process. No need for the git-history and metadata to be used by Docker.