### PR TITLE
feat: handle subtitles for video streaming

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -166,9 +166,9 @@ func apiHandler(c *fb.Context, w http.ResponseWriter, r *http.Request) (int, err
 	case "share":
 		code, err = shareHandler(c, w, r)
 	case "subtitles":
-                code, err = subtitlesHandler(c, w, r)
+		code, err = subtitlesHandler(c, w, r)
 	case "subtitle":
-                code, err = subtitleHandler(c, w, r)
+		code, err = subtitleHandler(c, w, r)
 	default:
 		code = http.StatusNotFound
 	}

--- a/http/http.go
+++ b/http/http.go
@@ -137,7 +137,7 @@ func apiHandler(c *fb.Context, w http.ResponseWriter, r *http.Request) (int, err
 		}
 	}
 
-	if c.Router == "checksum" || c.Router == "download" {
+	if c.Router == "checksum" || c.Router == "download" || c.Router == "subtitle" || c.Router == "subtitles" {
 		var err error
 		c.File, err = fb.GetInfo(r.URL, c.FileBrowser, c.User)
 		if err != nil {
@@ -165,6 +165,10 @@ func apiHandler(c *fb.Context, w http.ResponseWriter, r *http.Request) (int, err
 		code, err = settingsHandler(c, w, r)
 	case "share":
 		code, err = shareHandler(c, w, r)
+	case "subtitles":
+                code, err = subtitlesHandler(c, w, r)
+	case "subtitle":
+                code, err = subtitleHandler(c, w, r)
 	default:
 		code = http.StatusNotFound
 	}

--- a/http/subtitle.go
+++ b/http/subtitle.go
@@ -1,0 +1,83 @@
+package http
+
+import (
+	"os"
+    	"io/ioutil"
+	"net/http"
+    	"path/filepath"
+    	"regexp"
+	"bytes"
+	fb "github.com/filebrowser/filebrowser"
+)
+
+func subtitlesHandler(c *fb.Context, w http.ResponseWriter, r *http.Request) (int, error) {
+	files, err := ReadDir(filepath.Dir(c.File.Path))
+	if(err != nil) {
+		return http.StatusInternalServerError, err
+	}
+	var subtitles = make([]map[string]string, 0)
+	for _, file := range files {
+	ext := filepath.Ext(file.Name())
+		if(ext == ".vtt" || ext == ".srt") {
+        		var sub map[string]string = make(map[string]string)
+        		sub["src"] = filepath.Dir(c.File.Path) + "/" + file.Name()
+        		sub["kind"] = "subtitles"
+        		sub["label"] = file.Name()
+        		subtitles = append(subtitles, sub)
+		}
+    	}
+        return renderJSON(w, subtitles)
+}
+
+func subtitleHandler(c *fb.Context, w http.ResponseWriter, r *http.Request) (int, error) {
+        str, err := CleanSubtitle(c.File.Path)
+      	if err != nil {
+        	return http.StatusInternalServerError, err
+        }
+
+	file, err := os.Open(c.File.Path)
+        defer file.Close()
+
+        if err != nil {
+                return http.StatusInternalServerError, err
+        }
+
+        stat, err := file.Stat()
+        if err != nil {
+                return http.StatusInternalServerError, err
+        }
+
+        w.Header().Set("Content-Disposition", "inline")
+        w.Header().Set("Content-Type", "text/vtt")
+        http.ServeContent(w, r, stat.Name(), stat.ModTime(), bytes.NewReader([]byte(str)))
+
+        return 0, nil
+
+}
+
+func CleanSubtitle(filename string) (string, error) {
+	b, err := ioutil.ReadFile(filename)
+        if(err != nil) {
+		return "", err
+	}
+	str := string(b) // convert content to a 'string'
+	ext := filepath.Ext(filename)
+	if(ext == ".srt") {
+        	re := regexp.MustCompile("([0-9]{2}:[0-9]{2}:[0-9]{2}),([0-9]{3})")
+        	str = "WEBVTT\n\n" + re.ReplaceAllString(str, "$1.$2")
+	}
+	return str, err
+} 
+
+func ReadDir(dirname string) ([]os.FileInfo, error) {
+    	f, err := os.Open(dirname)
+    	if err != nil {
+        	return nil, err
+    	}
+    	list, err := f.Readdir(-1)
+    	f.Close()
+    	if err != nil {
+        	return nil, err
+    	}
+    	return list, nil
+}

--- a/http/subtitle.go
+++ b/http/subtitle.go
@@ -1,83 +1,83 @@
 package http
 
 import (
-	"os"
-    	"io/ioutil"
-	"net/http"
-    	"path/filepath"
-    	"regexp"
 	"bytes"
 	fb "github.com/filebrowser/filebrowser"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
 )
 
 func subtitlesHandler(c *fb.Context, w http.ResponseWriter, r *http.Request) (int, error) {
 	files, err := ReadDir(filepath.Dir(c.File.Path))
-	if(err != nil) {
+	if err != nil {
 		return http.StatusInternalServerError, err
 	}
 	var subtitles = make([]map[string]string, 0)
 	for _, file := range files {
-	ext := filepath.Ext(file.Name())
-		if(ext == ".vtt" || ext == ".srt") {
-        		var sub map[string]string = make(map[string]string)
-        		sub["src"] = filepath.Dir(c.File.Path) + "/" + file.Name()
-        		sub["kind"] = "subtitles"
-        		sub["label"] = file.Name()
-        		subtitles = append(subtitles, sub)
+		ext := filepath.Ext(file.Name())
+		if ext == ".vtt" || ext == ".srt" {
+			var sub map[string]string = make(map[string]string)
+			sub["src"] = filepath.Dir(c.File.Path) + "/" + file.Name()
+			sub["kind"] = "subtitles"
+			sub["label"] = file.Name()
+			subtitles = append(subtitles, sub)
 		}
-    	}
-        return renderJSON(w, subtitles)
+	}
+	return renderJSON(w, subtitles)
 }
 
 func subtitleHandler(c *fb.Context, w http.ResponseWriter, r *http.Request) (int, error) {
-        str, err := CleanSubtitle(c.File.Path)
-      	if err != nil {
-        	return http.StatusInternalServerError, err
-        }
+	str, err := CleanSubtitle(c.File.Path)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
 
 	file, err := os.Open(c.File.Path)
-        defer file.Close()
+	defer file.Close()
 
-        if err != nil {
-                return http.StatusInternalServerError, err
-        }
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
 
-        stat, err := file.Stat()
-        if err != nil {
-                return http.StatusInternalServerError, err
-        }
+	stat, err := file.Stat()
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
 
-        w.Header().Set("Content-Disposition", "inline")
-        w.Header().Set("Content-Type", "text/vtt")
-        http.ServeContent(w, r, stat.Name(), stat.ModTime(), bytes.NewReader([]byte(str)))
+	w.Header().Set("Content-Disposition", "inline")
+	w.Header().Set("Content-Type", "text/vtt")
+	http.ServeContent(w, r, stat.Name(), stat.ModTime(), bytes.NewReader([]byte(str)))
 
-        return 0, nil
+	return 0, nil
 
 }
 
 func CleanSubtitle(filename string) (string, error) {
 	b, err := ioutil.ReadFile(filename)
-        if(err != nil) {
+	if err != nil {
 		return "", err
 	}
 	str := string(b) // convert content to a 'string'
 	ext := filepath.Ext(filename)
-	if(ext == ".srt") {
-        	re := regexp.MustCompile("([0-9]{2}:[0-9]{2}:[0-9]{2}),([0-9]{3})")
-        	str = "WEBVTT\n\n" + re.ReplaceAllString(str, "$1.$2")
+	if ext == ".srt" {
+		re := regexp.MustCompile("([0-9]{2}:[0-9]{2}:[0-9]{2}),([0-9]{3})")
+		str = "WEBVTT\n\n" + re.ReplaceAllString(str, "$1.$2")
 	}
 	return str, err
-} 
+}
 
 func ReadDir(dirname string) ([]os.FileInfo, error) {
-    	f, err := os.Open(dirname)
-    	if err != nil {
-        	return nil, err
-    	}
-    	list, err := f.Readdir(-1)
-    	f.Close()
-    	if err != nil {
-        	return nil, err
-    	}
-    	return list, nil
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+	list, err := f.Readdir(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
 }


### PR DESCRIPTION
#460 

Hello there,
Here my little contribution to this project =)

Frontend part is on his own PR : https://github.com/filebrowser/frontend/pull/18

I hope my code fulfill your requirements, if not, I'll change what's needed =) 

To test it : Just have .srt or .vtt file in the same folder of your video, if your browser supports html5 track tag, it will be automatically added

Html5 standard and only recognized subtitle format is WebVTT (.vtt). 
Since .vtt and .srt are nearly constructed in the same manner, and that .srt is way more used than .vtt, I have handled a simple srt to vtt conversion (replace coma in times with dot and add WEBVTT header to the top of the file)