### PR TITLE
chore: disable gosec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ jobs:
               -D vetshadow \
               -D errcheck \
               -D golint \
-              -D gas
+              -D gas \
+              -D gosec
   build:
     docker:
       - image: circleci/golang:1.10


### PR DESCRIPTION
Yes, I like gosec and I find it useful, but it is complaining because we're using MD5... We need that.