### PR TITLE
chore: use commit SHA as version if not release

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,29 +3,25 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:af3215cd158218c92f0706bb32f67b0ce3d37da4c4d135e7ed5e2dc36a90fca5"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a368813c5e648fee92e5f6c30e3944ff9d5e8895"
 
 [[projects]]
   branch = "master"
+  digest = "1:65796e5fdb94d94bc0ee6bc422aa3541dbe69ed4da275cb5a27f8fa141f4e35c"
   name = "github.com/GeertJohan/go.rice"
   packages = [
     ".",
-    "embedded"
+    "embedded",
   ]
+  pruneopts = "UT"
   revision = "c02ca9a983da5807ddf7d796784928f5be4afd09"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/aead/chacha20"
-  packages = [
-    ".",
-    "chacha"
-  ]
-  revision = "c8d29375923a8e1d2a0f0dc0fc1d8a0aba5b97ba"
-
-[[projects]]
+  digest = "1:9ede7940cd19ac5d92896381abac71954feb57608b617152e48112c3dc667e87"
   name = "github.com/asdine/storm"
   packages = [
     ".",
@@ -33,55 +29,50 @@
     "codec/json",
     "index",
     "internal",
-    "q"
+    "q",
   ]
-  revision = "68fc73b635f890fe7ba2f3b15ce80c85b28a744f"
-  version = "v2.0.2"
+  pruneopts = "UT"
+  revision = "bda68dab90fc908ee5dbccb36400edf4f54972d6"
+  version = "v2.1.1"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/bifurcation/mint"
-  packages = [
-    ".",
-    "syntax"
-  ]
-  revision = "340be3ae8c0ff8edce24cf59e7acdb1432bd5ce5"
-
-[[projects]]
+  digest = "1:68eae87f8e5391e83ed2f7568e727709c598672f9c8390460241dcc1c2db2d34"
   name = "github.com/chaseadamsio/goorgeous"
   packages = ["."]
+  pruneopts = "UT"
   revision = "dcf1ef873b8987bf12596fe6951c48347986eb2f"
   version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/codahale/aesnicheck"
-  packages = ["."]
-  revision = "349fcc471aaccc29cd074e1275f1a494323826cd"
-
-[[projects]]
+  digest = "1:c28625428387b63dd7154eb857f51e700465cfbf7c06f619e71f2da33cefe47e"
   name = "github.com/coreos/bbolt"
   packages = ["."]
+  pruneopts = "UT"
   revision = "583e8937c61f1af6513608ccc75c97b6abdf4ff9"
   version = "v1.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:5fd5c4d4282935b7a575299494f2c09e9d2cacded7815c83aff7c1602aff3154"
   name = "github.com/daaku/go.zipexe"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a5fe2436ffcb3236e175e5149162b41cd28bd27d"
 
 [[projects]]
+  digest = "1:bb2130e54ac8ea3ff78312ca365ce3b8a23423ed362530551bdceaccfa4d8e77"
   name = "github.com/dgrijalva/jwt-go"
   packages = [
     ".",
-    "request"
+    "request",
   ]
-  revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
-  version = "v3.1.0"
+  pruneopts = "UT"
+  revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
+  version = "v3.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:988cfde37f089c50ba1ac8a1032c3f81d2ac0359e1872093b946a30139665eb6"
   name = "github.com/dsnet/compress"
   packages = [
     ".",
@@ -89,341 +80,316 @@
     "bzip2/internal/sais",
     "internal",
     "internal/errors",
-    "internal/prefix"
+    "internal/prefix",
   ]
+  pruneopts = "UT"
   revision = "cc9eb1d7ad760af14e8f918698f745e80377af4f"
 
 [[projects]]
   branch = "master"
+  digest = "1:50a46ab1d5edbbdd55125b4d37f1bf503d0807c26461f9ad7b358d6006641d09"
   name = "github.com/flynn/go-shlex"
   packages = ["."]
+  pruneopts = "UT"
   revision = "3f9db97f856818214da2e1057f8ad84803971cff"
 
 [[projects]]
+  digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:402c1a5e502d338e285ade7820bcd7bc6d860a262e1809eee5b1c34ef7692627"
   name = "github.com/gohugoio/hugo"
   packages = ["parser"]
+  pruneopts = "UT"
   revision = "25e88ccabe9b04c42ffb43528c86743f623fac46"
   version = "v0.36.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
   name = "github.com/golang/snappy"
   packages = ["."]
-  revision = "553a641470496b2327abcac10b36396bd98e45c9"
+  pruneopts = "UT"
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
+  digest = "1:43dd08a10854b2056e615d1b1d22ac94559d822e1f8b6fcc92c1a1057e85188e"
   name = "github.com/gorilla/websocket"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:837e92fe1b970f26d25d35c755106d86ba45717d11374c4f344654baa4add7b3"
   name = "github.com/hacdias/fileutils"
   packages = ["."]
+  pruneopts = "UT"
   revision = "76b1c6ab906773727a1ce2f7fb22830685166f85"
 
 [[projects]]
   branch = "master"
+  digest = "1:a6c3d669d54b94899aa207bb3da0a38f4d3054e396a80cae2ed7634e2843c1ba"
   name = "github.com/hacdias/varutils"
   packages = ["."]
+  pruneopts = "UT"
   revision = "82d3b57f667a756cfc4b1535951b46878881f3e1"
 
 [[projects]]
   branch = "master"
-  name = "github.com/hashicorp/go-syslog"
-  packages = ["."]
-  revision = "326bf4a7f709d263f964a6a96558676b103f3534"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/hashicorp/golang-lru"
-  packages = [
-    ".",
-    "simplelru"
-  ]
-  revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
-
-[[projects]]
-  branch = "master"
+  digest = "1:a361611b8c8c75a1091f00027767f7779b29cb37c456a71b8f2604c88057ab40"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
     "hcl/ast",
     "hcl/parser",
+    "hcl/printer",
     "hcl/scanner",
     "hcl/strconv",
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
-  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
+  pruneopts = "UT"
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
   branch = "master"
+  digest = "1:caf6db28595425c0e0f2301a00257d11712f65c1878e12cffc42f6b9a9cf3f23"
   name = "github.com/kardianos/osext"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ae77be60afb1dcacde03767a8c37337fad28ac14"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/lucas-clemente/aes12"
-  packages = ["."]
-  revision = "cd47fb39b79f867c6e4e5cd39cf7abd799f71670"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/lucas-clemente/fnv128a"
-  packages = ["."]
-  revision = "393af48d391698c6ae4219566bfbdfef67269997"
-
-[[projects]]
-  name = "github.com/lucas-clemente/quic-go"
-  packages = [
-    ".",
-    "h2quic",
-    "internal/ackhandler",
-    "internal/congestion",
-    "internal/crypto",
-    "internal/flowcontrol",
-    "internal/handshake",
-    "internal/protocol",
-    "internal/utils",
-    "internal/wire",
-    "qerr"
-  ]
-  revision = "30851b9a3b4e958490b476fe72adafa67641361a"
-  version = "v0.7.0"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/lucas-clemente/quic-go-certificates"
-  packages = ["."]
-  revision = "d2f86524cced5186554df90d92529757d22c1cb6"
-
-[[projects]]
+  digest = "1:c568d7727aa262c32bdf8a3f7db83614f7af0ed661474b24588de635c20024c7"
   name = "github.com/magiconair/properties"
   packages = ["."]
-  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
-  version = "v1.7.6"
+  pruneopts = "UT"
+  revision = "c2353362d570a7bfa228149c62842019201cfb71"
+  version = "v1.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:4bceeb937bfdd1fc2c545c685c43fdad909d78508b308b318e79db6b8fd6c792"
   name = "github.com/maruel/natural"
   packages = ["."]
+  pruneopts = "UT"
   revision = "dbcb3e2e8cf10eb839718ba666ef1e21b1c8b847"
 
 [[projects]]
+  digest = "1:f17bcb6a3694fe34b29fa9f0d93e1984450f6854b66c2df49524ba9541f9952d"
   name = "github.com/mholt/archiver"
   packages = ["."]
+  pruneopts = "UT"
   revision = "26cf5bb32d07aa4e8d0de15f56ce516f4641d7df"
 
 [[projects]]
+  digest = "1:fa577f7189e08bb551a16f655bb53ef27e1bebf0280e523f651eeced0cd98514"
   name = "github.com/mholt/caddy"
   packages = [
     ".",
     "caddyfile",
-    "caddyhttp/httpserver",
-    "caddyhttp/staticfiles",
-    "caddytls"
   ]
-  revision = "d3f338ddab9ee24b376b5c9c51e202581e2d43ba"
-  version = "v0.10.11"
-
-[[projects]]
-  name = "github.com/miekg/dns"
-  packages = ["."]
-  revision = "5364553f1ee9cddc7ac8b62dce148309c386695b"
-  version = "v1.0.4"
+  pruneopts = "UT"
+  revision = "2922d09bef3c504dde66bc12f7441668fcef6a20"
+  version = "v0.10.14"
 
 [[projects]]
   branch = "master"
+  digest = "1:5ab79470a1d0fb19b041a624415612f8236b3c06070161a910562f2b2d064355"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
+  pruneopts = "UT"
+  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
   branch = "master"
+  digest = "1:3bdb4203c03569a564d6a4bd54d84315575cebb2d76471f8676f8ee8c402005e"
   name = "github.com/nwaples/rardecode"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e06696f847aeda6f39a8f0b7cdff193b7690aef6"
 
 [[projects]]
+  digest = "1:95741de3af260a92cc5c7f3f3061e85273f5a81b5db20d4bd68da74bd521675e"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
-  version = "v1.1.0"
+  pruneopts = "UT"
+  revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
+  version = "v1.2.0"
 
 [[projects]]
+  digest = "1:29803f52611cbcc1dfe55b456e9fdac362af7248b3d29d7ea1bec0a12e71dff4"
   name = "github.com/pierrec/lz4"
+  packages = [
+    ".",
+    "internal/xxh32",
+  ]
+  pruneopts = "UT"
+  revision = "1958fd8fff7f115e79725b1288e0b878b3e06b00"
+  version = "v2.0.3"
+
+[[projects]]
+  digest = "1:ed615c5430ecabbb0fb7629a182da65ecee6523900ac1ac932520860878ffcad"
+  name = "github.com/robfig/cron"
   packages = ["."]
-  revision = "2fcda4cb7018ce05a25959d2fe08c83e3329f169"
+  pruneopts = "UT"
+  revision = "b41be1df696709bb6395fe435af20370037c0b4c"
   version = "v1.1"
 
 [[projects]]
-  name = "github.com/pierrec/xxHash"
-  packages = ["xxHash32"]
-  revision = "f051bb7f1d1aaf1b5a665d74fb6b0217712c69f7"
-  version = "v0.1.1"
-
-[[projects]]
-  name = "github.com/robfig/cron"
-  packages = ["."]
-  revision = "b024fc5ea0e34bc3f83d9941c8d60b0622bfaca4"
-  version = "v1"
-
-[[projects]]
+  digest = "1:8bc629776d035c003c7814d4369521afe67fdb8efc4b5f66540d29343b98cf23"
   name = "github.com/russross/blackfriday"
   packages = ["."]
-  revision = "4048872b16cc0fc2c5fd9eacf0ed2c2fedaa0c8c"
-  version = "v1.5"
+  pruneopts = "UT"
+  revision = "55d61fa8aa702f59229e6cff85793c22e580eaf5"
+  version = "v1.5.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:def689e73e9252f6f7fe66834a76751a41b767e03daab299e607e7226c58a855"
   name = "github.com/shurcooL/sanitized_anchor_name"
   packages = ["."]
+  pruneopts = "UT"
   revision = "86672fcb3f950f35f2e675df2240550f2a50762f"
 
 [[projects]]
+  digest = "1:bd1ae00087d17c5a748660b8e89e1043e1e5479d0fea743352cda2f8dd8c4f84"
   name = "github.com/spf13/afero"
   packages = [
     ".",
-    "mem"
+    "mem",
   ]
-  revision = "bb8f1927f2a9d3ab41c9340aa034f6b803f4359c"
-  version = "v1.0.2"
+  pruneopts = "UT"
+  revision = "787d034dfe70e44075ccc060d346146ef53270ad"
+  version = "v1.1.1"
 
 [[projects]]
+  digest = "1:516e71bed754268937f57d4ecb190e01958452336fa73dbac880894164e91c1f"
   name = "github.com/spf13/cast"
   packages = ["."]
+  pruneopts = "UT"
   revision = "8965335b8c7107321228e3e3702cab9832751bac"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:080e5f630945ad754f4b920e60b4d3095ba0237ebf88dc462eb28002932e3805"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
+  digest = "1:9424f440bba8f7508b69414634aef3b2b3a877e522d8a4624692412805407bb7"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
-  version = "v1.0.0"
+  pruneopts = "UT"
+  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
+  version = "v1.0.1"
 
 [[projects]]
+  digest = "1:4fc8a61287ccfb4286e1ca5ad2ce3b0b301d746053bf44ac38cf34e40ae10372"
   name = "github.com/spf13/viper"
   packages = ["."]
-  revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
-  version = "v1.0.0"
+  pruneopts = "UT"
+  revision = "907c19d40d9a6c9bb55f040ff4ae45271a4754b9"
+  version = "v1.1.0"
 
 [[projects]]
+  digest = "1:4aeb3860275fa1fd60cccfb5a6ef85da438bf17402e1e84412ade4d4b55066a0"
   name = "github.com/ulikunitz/xz"
   packages = [
     ".",
     "internal/hash",
     "internal/xlog",
-    "lzma"
+    "lzma",
   ]
+  pruneopts = "UT"
   revision = "0c6b41e72360850ca4f98dc341fd999726ea007f"
   version = "v0.5.4"
 
 [[projects]]
-  name = "github.com/xenolf/lego"
-  packages = ["acme"]
-  revision = "67c86d860a797ce2483f50d9174d4ed24984bef2"
-  version = "v0.4.1"
-
-[[projects]]
   branch = "master"
+  digest = "1:1ecf2a49df33be51e757d0033d5d51d5f784f35f68e5a38f797b2d3f03357d71"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
     "blowfish",
-    "curve25519",
-    "ed25519",
-    "ed25519/internal/edwards25519",
-    "hkdf",
-    "ocsp"
   ]
-  revision = "49796115aa4b964c318aad4f3084fdb41e9aa067"
+  pruneopts = "UT"
+  revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
 
 [[projects]]
   branch = "master"
-  name = "golang.org/x/net"
-  packages = [
-    "bpf",
-    "http2",
-    "http2/hpack",
-    "idna",
-    "internal/iana",
-    "internal/socket",
-    "ipv4",
-    "ipv6",
-    "lex/httplex",
-    "publicsuffix"
-  ]
-  revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
-
-[[projects]]
-  branch = "master"
+  digest = "1:76b5ca88193bf744f729c2fde12151b24364ffaca3fd092069d9ca2ea6e1f999"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "88d2dcc510266da9f7f8c7f34e1940716cab5f5c"
+  pruneopts = "UT"
+  revision = "904bdc257025c7b3f43c19360ad3ab85783fad78"
 
 [[projects]]
+  digest = "1:8029e9743749d4be5bc9f7d42ea1659471767860f0cdc34d37c3111bd308a295"
   name = "golang.org/x/text"
   packages = [
-    "collate",
-    "collate/build",
-    "internal/colltab",
     "internal/gen",
-    "internal/tag",
     "internal/triegen",
     "internal/ucd",
-    "language",
-    "secure/bidirule",
     "transform",
-    "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:c805e517269b0ba4c21ded5836019ed7d16953d4026cb7d00041d039c7906be9"
   name = "gopkg.in/natefinch/lumberjack.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a96e63847dc3c67d17befa69c303767e2f84e54f"
   version = "v2.1"
 
 [[projects]]
-  name = "gopkg.in/square/go-jose.v1"
-  packages = [
-    ".",
-    "cipher",
-    "json"
-  ]
-  revision = "aa2e30fdd1fe9dd3394119af66451ae790d50e0d"
-  version = "v1.1.0"
-
-[[projects]]
+  branch = "v2"
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "7f97868eec74b32b0982dd158a51a446d1da7eb5"
-  version = "v2.1.1"
+  pruneopts = "UT"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1f68bed4490068370884abaa296aa651c27b3f2e0d0451a1ab567f059d44f820"
+  input-imports = [
+    "github.com/GeertJohan/go.rice",
+    "github.com/GeertJohan/go.rice/embedded",
+    "github.com/asdine/storm",
+    "github.com/asdine/storm/q",
+    "github.com/dgrijalva/jwt-go",
+    "github.com/dgrijalva/jwt-go/request",
+    "github.com/gohugoio/hugo/parser",
+    "github.com/gorilla/websocket",
+    "github.com/hacdias/fileutils",
+    "github.com/hacdias/varutils",
+    "github.com/maruel/natural",
+    "github.com/mholt/archiver",
+    "github.com/mholt/caddy",
+    "github.com/mitchellh/mapstructure",
+    "github.com/robfig/cron",
+    "github.com/spf13/pflag",
+    "github.com/spf13/viper",
+    "golang.org/x/crypto/bcrypt",
+    "gopkg.in/natefinch/lumberjack.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/build/build.sh
+++ b/build/build.sh
@@ -6,7 +6,18 @@ cd $(dirname $0)/..
 
 dep ensure -vendor-only
 
+if [ "$COMMIT_SHA" != "" ]; then
+  echo "Set version to ($COMMIT_SHA)"
+  sed -i.bak "s|(untracked)|($COMMIT_SHA)|g" filebrowser.go
+fi
+
+echo "Build cmd/filebrowser"
 cd cmd/filebrowser
 CGO_ENABLED=0 go build -a
 cd ../..
 cp cmd/filebrowser/filebrowser ./
+
+if [ "$COMMIT_SHA" != "" ]; then
+  echo "Reset version to (untracked)"
+  sed -i "s|($COMMIT_SHA)|(untracked)|g" filebrowser.go
+fi

--- a/build/build_all.sh
+++ b/build/build_all.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -e
-
 cd $(dirname $0)/..
 
 if [ -d "rice-box.go" ]; then
@@ -17,10 +15,17 @@ if [ "$USE_DOCKER" != "" ]; then
     WDIR="/go/src/github.com/filebrowser/filebrowser"
   fi;
 
+  if [ "$(command -v git)" != "" ]; then
+    COMMIT_SHA="$(git rev-parse HEAD | cut -c1-8)"
+  else
+    COMMIT_SHA="untracked"
+  fi
+
   $(command -v winpty) docker run -it \
     --name filebrowser-tmp \
     -v /$(pwd):/src:z \
     -w /${WDIR} \
+    -e COMMIT_SHA=$COMMIT_SHA \
     filebrowser/dev \
     sh -c "\
       cp -r //src/* /$WDIR && \
@@ -42,6 +47,7 @@ if [ "$USE_DOCKER" != "" ]; then
   fi
   docker rm -f filebrowser-tmp
 else
+  set -e
   ./build/build_assets.sh
   ./build/build.sh
 fi


### PR DESCRIPTION
This PR replaces the `(untracked)` version with the first eight characters of the commit that is being built when `USE_DOCKER="true" ./build/build_all.sh` is used. If executed outside of a docker container envvar `COMMIT_SHA` can be set to any value and that will be used.

Since `build.sh` is not executed when commits are tagged, this does not apply to releses.

Also, `dep ensure --update` was executed in order to update `Gopkg.lock`.