### PR TITLE
Ensure that the config path provided through flags is used

### DIFF
--- a/cmd/filebrowser/main.go
+++ b/cmd/filebrowser/main.go
@@ -117,9 +117,6 @@ func setupViper() {
 	viper.BindPFlag("AlternativeRecaptcha", flag.Lookup("alternative-recaptcha"))
 	viper.BindPFlag("ReCaptchaKey", flag.Lookup("recaptcha-key"))
 	viper.BindPFlag("ReCaptchaSecret", flag.Lookup("recaptcha-secret"))
-
-	viper.SetConfigName("filebrowser")
-	viper.AddConfigPath(".")
 }
 
 func printVersion() {
@@ -137,16 +134,15 @@ func main() {
 
 	// Add a configuration file if set.
 	if config != "" {
-		ext := filepath.Ext(config)
-		dir := filepath.Dir(config)
-		config = strings.TrimSuffix(config, ext)
-
-		if dir != "" {
+		cfg := strings.TrimSuffix(config, filepath.Ext(config))
+		if dir := filepath.Dir(cfg); dir != "" {
 			viper.AddConfigPath(dir)
-			config = strings.TrimPrefix(config, dir)
+			cfg = strings.TrimPrefix(cfg, dir)
 		}
-
-		viper.SetConfigName(config)
+		viper.SetConfigName(cfg)
+	} else {
+		viper.SetConfigName("filebrowser")
+		viper.AddConfigPath(".")
 	}
 
 	// Read configuration from a file if exists.

--- a/cmd/filebrowser/main.go
+++ b/cmd/filebrowser/main.go
@@ -124,14 +124,7 @@ func printVersion() {
 	os.Exit(0)
 }
 
-func main() {
-	setupViper()
-	flag.Parse()
-
-	if showVer {
-		printVersion()
-	}
-
+func initConfig() {
 	// Add a configuration file if set.
 	if config != "" {
 		cfg := strings.TrimSuffix(config, filepath.Ext(config))
@@ -152,6 +145,17 @@ func main() {
 			panic(err)
 		}
 	}
+}
+
+func main() {
+	setupViper()
+	flag.Parse()
+
+	if showVer {
+		printVersion()
+	}
+
+	initConfig();
 
 	// Set up process log before anything bad happens.
 	switch viper.GetString("Logger") {


### PR DESCRIPTION
Close #461.

The root path (`.`) was automatically added to viper. As a result, when using the Docker image, if the user provided a different path for the config file, but with the same filename, the default file in the image (`/config.json`) was used instead of the one provided by the user.

This PR ensures that no default search path is added when the user provides the config through a flag.

Also, the viper initialization is moved to a function.