### PR TITLE
fix small text file been recognize as blob issue

### DIFF
--- a/file.go
+++ b/file.go
@@ -222,14 +222,14 @@ func (i *File) GetFileType(checkContent bool) error {
 
 		// Only the first 512 bytes are used to sniff the content type.
 		buffer := make([]byte, 512)
-		_, err = file.Read(buffer)
+		n, err := file.Read(buffer)
 		if err != nil && err != io.EOF {
 			return err
 		}
 
 		// Tries to get the file mimetype using its first
 		// 512 bytes.
-		mimetype = http.DetectContentType(buffer)
+		mimetype = http.DetectContentType(buffer[:n])
 	}
 
 	if strings.HasPrefix(mimetype, "video") {


### PR DESCRIPTION
**Description**

relate to #314 

I've realize it's some go file can't edit, and some file can.
During read the code, I think the problem is at `GetFileType` method.

After this change, the go file(even it's small) can be correctly recognize, and I have tested it.

Test by using two go file, one is small then 512 bytes, the other is over 512 bytes, this change make both file editable through UI.
