### PR TITLE
fix multi-select files download error when filename contains '+'

### DIFF
--- a/lib/http/download.go
+++ b/lib/http/download.go
@@ -30,7 +30,7 @@ func downloadHandler(c *fb.Context, w http.ResponseWriter, r *http.Request) (int
 	if len(names) != 0 {
 		for _, name := range names {
 			// Unescape the name.
-			name, err := url.QueryUnescape(name)
+			name, err := url.QueryUnescape(strings.Replace(name, "+", "%2B", -1))
 			if err != nil {
 				return http.StatusInternalServerError, err
 			}


### PR DESCRIPTION
Description
Fix #547: File name contains the symbol "+", multi-select file download error. 
Replace + with %2B first to avoid being treated as a space 