### PR TITLE
feat: require hashed password and add hash command

### DIFF
--- a/cmd/hash.go
+++ b/cmd/hash.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/filebrowser/filebrowser/v2/users"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(hashCmd)
+}
+
+var hashCmd = &cobra.Command{
+	Use:   "hash <password>",
+	Short: "Hashes a password",
+	Long:  `Hashes a password using bcrypt algorithm.`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		pwd, err := users.HashPwd(args[0])
+		checkErr(err)
+		fmt.Println(pwd)
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ func init() {
 	vaddP(f, "scope", "s", ".", "scope to prepend to a user's scope when it is relative")
 	vaddP(f, "baseurl", "b", "", "base url")
 	vadd(f, "username", "admin", "username for the first user when using quick config")
-	vadd(f, "password", "admin", "password for the first user when using quick config")
+	vadd(f, "password", "", "hashed password for the first user when using quick config (default \"admin\")")
 
 	if err := v.BindPFlags(f); err != nil {
 		panic(err)
@@ -197,12 +197,15 @@ func quickSetup(cmd *cobra.Command) {
 
 	username := v.GetString("username")
 	password := v.GetString("password")
+
+	if password == "" {
+		password, err = users.HashPwd("admin")
+		checkErr(err)
+	}
+
 	if username == "" || password == "" {
 		checkErr(errors.New("username and password cannot be empty during quick setup"))
 	}
-
-	password, err = users.HashPwd(password)
-	checkErr(err)
 
 	user := &users.User{
 		Username:     username,


### PR DESCRIPTION
This reverts to asking for a hashed password. It makes sense in the root command since it will be used more often and this way the password doesn't lay around in plain text.