### PR TITLE
feat: make server options a struct

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -98,8 +98,8 @@ func python(fn pythonFunc, cfg pythonConfig) cobraFunc {
 		if os.IsNotExist(err) {
 			data.hadDB = false
 
-			if !cfg.noDB || !cfg.allowNoDB {
-				log.Fatal(path + " does not exid.store. Please run 'filebrowser config init' fird.store.")
+			if !cfg.noDB && !cfg.allowNoDB {
+				log.Fatal(path + " does not exist. Please run 'filebrowser config init' first.")
 			}
 		} else if err != nil {
 			panic(err)

--- a/http/auth.go
+++ b/http/auth.go
@@ -67,7 +67,7 @@ func withUser(fn handleFunc) handleFunc {
 			w.Header().Add("X-Renew-Token", "true")
 		}
 
-		d.user, err = d.store.Users.Get(d.settings.Root, tk.User.ID)
+		d.user, err = d.store.Users.Get(d.server.Root, tk.User.ID)
 		if err != nil {
 			return http.StatusInternalServerError, err
 		}
@@ -91,7 +91,7 @@ var loginHandler = func(w http.ResponseWriter, r *http.Request, d *data) (int, e
 		return http.StatusInternalServerError, err
 	}
 
-	user, err := auther.Auth(r, d.store.Users, d.Settings.Root)
+	user, err := auther.Auth(r, d.store.Users, d.server.Root)
 	if err == os.ErrPermission {
 		return http.StatusForbidden, nil
 	} else if err != nil {

--- a/http/data.go
+++ b/http/data.go
@@ -16,6 +16,7 @@ type handleFunc func(w http.ResponseWriter, r *http.Request, d *data) (int, erro
 type data struct {
 	*runner.Runner
 	settings *settings.Settings
+	server   *settings.Server
 	store    *storage.Storage
 	user     *users.User
 	raw      interface{}
@@ -38,7 +39,7 @@ func (d *data) Check(path string) bool {
 	return true
 }
 
-func handle(fn handleFunc, prefix string, storage *storage.Storage) http.Handler {
+func handle(fn handleFunc, prefix string, storage *storage.Storage, server *settings.Server) http.Handler {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		settings, err := storage.Settings.Get()
 		if err != nil {
@@ -50,6 +51,7 @@ func handle(fn handleFunc, prefix string, storage *storage.Storage) http.Handler
 			Runner:   &runner.Runner{Settings: settings},
 			store:    storage,
 			settings: settings,
+			server:   server,
 		})
 
 		if status != 0 {

--- a/http/http.go
+++ b/http/http.go
@@ -3,6 +3,7 @@ package http
 import (
 	"net/http"
 
+	"github.com/filebrowser/filebrowser/v2/settings"
 	"github.com/filebrowser/filebrowser/v2/storage"
 	"github.com/gorilla/mux"
 )
@@ -12,47 +13,51 @@ type modifyRequest struct {
 	Which []string `json:"which"` // Answer to: which fields?
 }
 
-func NewHandler(storage *storage.Storage) (http.Handler, error) {
+func NewHandler(storage *storage.Storage, server *settings.Server) (http.Handler, error) {
 	r := mux.NewRouter()
 
-	index, static := getStaticHandlers(storage)
+	index, static := getStaticHandlers(storage, server)
+
+	monkey := func(fn handleFunc, prefix string) http.Handler {
+		return handle(fn, prefix, storage, server)
+	}
 
 	r.PathPrefix("/static").Handler(static)
 	r.NotFoundHandler = index
 
 	api := r.PathPrefix("/api").Subrouter()
 
-	api.Handle("/login", handle(loginHandler, "", storage))
-	api.Handle("/signup", handle(signupHandler, "", storage))
-	api.Handle("/renew", handle(renewHandler, "", storage))
+	api.Handle("/login", monkey(loginHandler, ""))
+	api.Handle("/signup", monkey(signupHandler, ""))
+	api.Handle("/renew", monkey(renewHandler, ""))
 
 	users := api.PathPrefix("/users").Subrouter()
-	users.Handle("", handle(usersGetHandler, "", storage)).Methods("GET")
-	users.Handle("", handle(userPostHandler, "", storage)).Methods("POST")
-	users.Handle("/{id:[0-9]+}", handle(userPutHandler, "", storage)).Methods("PUT")
-	users.Handle("/{id:[0-9]+}", handle(userGetHandler, "", storage)).Methods("GET")
-	users.Handle("/{id:[0-9]+}", handle(userDeleteHandler, "", storage)).Methods("DELETE")
+	users.Handle("", monkey(usersGetHandler, "")).Methods("GET")
+	users.Handle("", monkey(userPostHandler, "")).Methods("POST")
+	users.Handle("/{id:[0-9]+}", monkey(userPutHandler, "")).Methods("PUT")
+	users.Handle("/{id:[0-9]+}", monkey(userGetHandler, "")).Methods("GET")
+	users.Handle("/{id:[0-9]+}", monkey(userDeleteHandler, "")).Methods("DELETE")
 
-	api.PathPrefix("/resources").Handler(handle(resourceGetHandler, "/api/resources", storage)).Methods("GET")
-	api.PathPrefix("/resources").Handler(handle(resourceDeleteHandler, "/api/resources", storage)).Methods("DELETE")
-	api.PathPrefix("/resources").Handler(handle(resourcePostPutHandler, "/api/resources", storage)).Methods("POST")
-	api.PathPrefix("/resources").Handler(handle(resourcePostPutHandler, "/api/resources", storage)).Methods("PUT")
-	api.PathPrefix("/resources").Handler(handle(resourcePatchHandler, "/api/resources", storage)).Methods("PATCH")
+	api.PathPrefix("/resources").Handler(monkey(resourceGetHandler, "/api/resources")).Methods("GET")
+	api.PathPrefix("/resources").Handler(monkey(resourceDeleteHandler, "/api/resources")).Methods("DELETE")
+	api.PathPrefix("/resources").Handler(monkey(resourcePostPutHandler, "/api/resources")).Methods("POST")
+	api.PathPrefix("/resources").Handler(monkey(resourcePostPutHandler, "/api/resources")).Methods("PUT")
+	api.PathPrefix("/resources").Handler(monkey(resourcePatchHandler, "/api/resources")).Methods("PATCH")
 
-	api.PathPrefix("/share").Handler(handle(shareGetsHandler, "/api/share", storage)).Methods("GET")
-	api.PathPrefix("/share").Handler(handle(sharePostHandler, "/api/share", storage)).Methods("POST")
-	api.PathPrefix("/share").Handler(handle(shareDeleteHandler, "/api/share", storage)).Methods("DELETE")
+	api.PathPrefix("/share").Handler(monkey(shareGetsHandler, "/api/share")).Methods("GET")
+	api.PathPrefix("/share").Handler(monkey(sharePostHandler, "/api/share")).Methods("POST")
+	api.PathPrefix("/share").Handler(monkey(shareDeleteHandler, "/api/share")).Methods("DELETE")
 
-	api.Handle("/settings", handle(settingsGetHandler, "", storage)).Methods("GET")
-	api.Handle("/settings", handle(settingsPutHandler, "", storage)).Methods("PUT")
+	api.Handle("/settings", monkey(settingsGetHandler, "")).Methods("GET")
+	api.Handle("/settings", monkey(settingsPutHandler, "")).Methods("PUT")
 
-	api.PathPrefix("/raw").Handler(handle(rawHandler, "/api/raw", storage)).Methods("GET")
-	api.PathPrefix("/command").Handler(handle(commandsHandler, "/api/command", storage)).Methods("GET")
-	api.PathPrefix("/search").Handler(handle(searchHandler, "/api/search", storage)).Methods("GET")
+	api.PathPrefix("/raw").Handler(monkey(rawHandler, "/api/raw")).Methods("GET")
+	api.PathPrefix("/command").Handler(monkey(commandsHandler, "/api/command")).Methods("GET")
+	api.PathPrefix("/search").Handler(monkey(searchHandler, "/api/search")).Methods("GET")
 
 	public := api.PathPrefix("/public").Subrouter()
-	public.PathPrefix("/dl").Handler(handle(publicDlHandler, "/api/public/dl/", storage)).Methods("GET")
-	public.PathPrefix("/share").Handler(handle(publicShareHandler, "/api/public/share/", storage)).Methods("GET")
+	public.PathPrefix("/dl").Handler(monkey(publicDlHandler, "/api/public/dl/")).Methods("GET")
+	public.PathPrefix("/share").Handler(monkey(publicShareHandler, "/api/public/share/")).Methods("GET")
 
 	return r, nil
 }

--- a/http/public.go
+++ b/http/public.go
@@ -13,7 +13,7 @@ var withHashFile = func(fn handleFunc) handleFunc {
 			return errToStatus(err), err
 		}
 
-		user, err := d.store.Users.Get(d.settings.Root, link.UserID)
+		user, err := d.store.Users.Get(d.server.Root, link.UserID)
 		if err != nil {
 			return errToStatus(err), err
 		}

--- a/http/share.go
+++ b/http/share.go
@@ -56,7 +56,7 @@ var sharePostHandler = withPermShare(func(w http.ResponseWriter, r *http.Request
 		var err error
 		s, err = d.store.Share.GetPermanent(r.URL.Path, d.user.ID)
 		if err == nil {
-			w.Write([]byte(d.settings.BaseURL + "/share/" + s.Hash))
+			w.Write([]byte(d.server.BaseURL + "/share/" + s.Hash))
 			return 0, nil
 		}
 	}

--- a/http/users.go
+++ b/http/users.go
@@ -61,7 +61,7 @@ func withSelfOrAdmin(fn handleFunc) handleFunc {
 }
 
 var usersGetHandler = withAdmin(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
-	users, err := d.store.Users.Gets(d.settings.Root)
+	users, err := d.store.Users.Gets(d.server.Root)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
@@ -78,7 +78,7 @@ var usersGetHandler = withAdmin(func(w http.ResponseWriter, r *http.Request, d *
 })
 
 var userGetHandler = withSelfOrAdmin(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
-	u, err := d.store.Users.Get(d.settings.Root, d.raw.(uint))
+	u, err := d.store.Users.Get(d.server.Root, d.raw.(uint))
 	if err == errors.ErrNotExist {
 		return http.StatusNotFound, err
 	}
@@ -147,7 +147,7 @@ var userPutHandler = withSelfOrAdmin(func(w http.ResponseWriter, r *http.Request
 			req.Data.Password, err = users.HashPwd(req.Data.Password)
 		} else {
 			var suser *users.User
-			suser, err = d.store.Users.Get(d.settings.Root, d.raw.(uint))
+			suser, err = d.store.Users.Get(d.server.Root, d.raw.(uint))
 			req.Data.Password = suser.Password
 		}
 

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -8,8 +8,6 @@ type AuthMethod string
 // Settings contain the main settings of the application.
 type Settings struct {
 	Key        []byte              `json:"key"`
-	BaseURL    string              `json:"baseURL"`
-	Root       string              `json:"root"`
 	Signup     bool                `json:"signup"`
 	Defaults   UserDefaults        `json:"defaults"`
 	AuthMethod AuthMethod          `json:"authMethod"`
@@ -17,6 +15,17 @@ type Settings struct {
 	Commands   map[string][]string `json:"commands"`
 	Shell      []string            `json:"shell"`
 	Rules      []rules.Rule        `json:"rules"`
+}
+
+// Server specific settings.
+type Server struct {
+	Root    string `json:"root"`
+	BaseURL string `json:"baseURL"`
+	TLSKey  string `json:"tlsKey"`
+	TLSCert string `json:"tlsCert"`
+	Port    string `json:"port"`
+	Address string `json:"address"`
+	Log     string `json:"log"`
 }
 
 // GetRules implements rules.Provider.

--- a/settings/storage.go
+++ b/settings/storage.go
@@ -12,6 +12,8 @@ import (
 type StorageBackend interface {
 	Get() (*Settings, error)
 	Save(*Settings) error
+	GetServer() (*Server, error)
+	SaveServer(*Server) error
 }
 
 // Storage is a settings storage.
@@ -39,8 +41,6 @@ var defaultEvents = []string{
 
 // Save saves the settings for the current instance.
 func (s *Storage) Save(set *Settings) error {
-	set.BaseURL = strings.TrimSuffix(set.BaseURL, "/")
-
 	if len(set.Key) == 0 {
 		return errors.ErrEmptyKey
 	}
@@ -85,4 +85,15 @@ func (s *Storage) Save(set *Settings) error {
 	}
 
 	return nil
+}
+
+// GetServer wraps StorageBackend.GetServer.
+func (s *Storage) GetServer() (*Server, error) {
+	return s.back.GetServer()
+}
+
+// SaveServer wraps StorageBackend.SaveServer and adds some verification.
+func (s *Storage) SaveServer(ser *Server) error {
+	ser.BaseURL = strings.TrimSuffix(ser.BaseURL, "/")
+	return s.back.SaveServer(ser)
 }

--- a/storage/bolt/config.go
+++ b/storage/bolt/config.go
@@ -17,3 +17,12 @@ func (s settingsBackend) Get() (*settings.Settings, error) {
 func (s settingsBackend) Save(settings *settings.Settings) error {
 	return save(s.db, "settings", settings)
 }
+
+func (s settingsBackend) GetServer() (*settings.Server, error) {
+	server := &settings.Server{}
+	return server, get(s.db, "server", server)
+}
+
+func (s settingsBackend) SaveServer(server *settings.Server) error {
+	return save(s.db, "server", server)
+}

--- a/storage/bolt/importer/conf.go
+++ b/storage/bolt/importer/conf.go
@@ -33,7 +33,7 @@ type oldAuth struct {
 }
 
 type oldConf struct {
-	Port      int     `json:"port" yaml:"port" toml:"port"`
+	Port      string     `json:"port" yaml:"port" toml:"port"`
 	BaseURL   string  `json:"baseURL" yaml:"baseURL" toml:"baseURL"`
 	Log       string  `json:"log" yaml:"log" toml:"log"`
 	Address   string  `json:"address" yaml:"address" toml:"address"`
@@ -47,7 +47,7 @@ type oldConf struct {
 }
 
 var defaults = &oldConf{
-	Port: 0,
+	Port: "0",
 	Log:  "stdout",
 	Defaults: oldDefs{
 		Commands:      []string{"git", "svn", "hg"},
@@ -110,7 +110,6 @@ func importConf(db *storm.DB, path string, sto *storage.Storage) error {
 
 	s := &settings.Settings{
 		Key:     key,
-		BaseURL: cfg.BaseURL,
 		Signup:  false,
 		Defaults: settings.UserDefaults{
 			Scope:    cfg.Defaults.Scope,
@@ -128,6 +127,13 @@ func importConf(db *storm.DB, path string, sto *storage.Storage) error {
 				Download: true,
 			},
 		},
+	}
+
+	server := &settings.Server{
+		BaseURL : cfg.BaseURL,
+		Port : cfg.Port,
+		Address : cfg.Address,
+		Log : cfg.Log,
 	}
 
 	var auther auth.Auther
@@ -155,6 +161,11 @@ func importConf(db *storm.DB, path string, sto *storage.Storage) error {
 	}
 
 	err = sto.Settings.Save(s)
+	if err != nil {
+		return err
+	}
+
+	err = sto.Settings.SaveServer(server)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This makes server options a struct and decouples it from `Settings`. We want, in the future, to save this to the DB (already implemented `Settings.SaveServer` and `Settings.GetServer`). Although, right now, Viper has a bug where `IsSet` always returns true when binding to a flag.

In the meanwhile, all server options (root, baseurl, tlscert, tlskey, ...) shall be given through config file, env variables or flags. Although we want to find a proper way to merge the current config given by the user with the one in the DB.