### PR TITLE
Chores and version subcommand

### DIFF
--- a/cmd/cmds.go
+++ b/cmd/cmds.go
@@ -11,10 +11,11 @@ func init() {
 }
 
 var cmdsCmd = &cobra.Command{
-	Use:   "cmds",
-	Short: "Command runner management utility",
-	Long:  `Command runner management utility.`,
-	Args:  cobra.NoArgs,
+	Use:     "cmds",
+	Version: rootCmd.Version,
+	Short:   "Command runner management utility",
+	Long:    `Command runner management utility.`,
+	Args:    cobra.NoArgs,
 }
 
 func printEvents(m map[string][]string) {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,10 +20,11 @@ func init() {
 }
 
 var configCmd = &cobra.Command{
-	Use:   "config",
-	Short: "Configuration management utility",
-	Long:  `Configuration management utility.`,
-	Args:  cobra.NoArgs,
+	Use:     "config",
+	Version: rootCmd.Version,
+	Short:   "Configuration management utility",
+	Long:    `Configuration management utility.`,
+	Args:    cobra.NoArgs,
 }
 
 func addConfigFlags(flags *pflag.FlagSet) {

--- a/cmd/hash.go
+++ b/cmd/hash.go
@@ -12,10 +12,11 @@ func init() {
 }
 
 var hashCmd = &cobra.Command{
-	Use:   "hash <password>",
-	Short: "Hashes a password",
-	Long:  `Hashes a password using bcrypt algorithm.`,
-	Args:  cobra.ExactArgs(1),
+	Use:     "hash <password>",
+	Version: rootCmd.Version,
+	Short:   "Hashes a password",
+	Long:    `Hashes a password using bcrypt algorithm.`,
+	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		pwd, err := users.HashPwd(args[0])
 		checkErr(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,8 @@ import (
 	"github.com/filebrowser/filebrowser/v2/settings"
 	"github.com/filebrowser/filebrowser/v2/storage"
 	"github.com/filebrowser/filebrowser/v2/users"
-	"github.com/mitchellh/go-homedir"
+	"github.com/filebrowser/filebrowser/v2/version"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	v "github.com/spf13/viper"
@@ -29,6 +30,9 @@ var (
 
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	rootCmd.SetVersionTemplate("File Browser version {{printf \"%s\" .Version}}\n")
+
 	flags := rootCmd.Flags()
 	persistent := rootCmd.PersistentFlags()
 
@@ -87,12 +91,13 @@ func mustGetStringViperFlag(flags *pflag.FlagSet, key string) string {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "filebrowser",
-	Short: "A stylish web-based file browser",
+	Use:     "filebrowser",
+	Short:   "A stylish web-based file browser",
+	Version: version.Version,
 	Long: `File Browser CLI lets you create the database to use with File Browser,
 manage your users and all the configurations without acessing the
 web interface.
-	
+
 If you've never run File Browser, you'll need to have a database for
 it. Don't worry: you don't need to setup a separate database server.
 We're using Bolt DB which is a single file database and all managed

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -18,8 +18,9 @@ func init() {
 }
 
 var rulesCmd = &cobra.Command{
-	Use:   "rules",
-	Short: "Rules management utility",
+	Use:     "rules",
+	Version: rootCmd.Version,
+	Short:   "Rules management utility",
 	Long: `On each subcommand you'll have available at least two flags:
 "username" and "id". You must either set only one of them
 or none. If you set one of them, the command will apply to

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -14,8 +14,9 @@ func init() {
 }
 
 var upgradeCmd = &cobra.Command{
-	Use:   "upgrade",
-	Short: "Upgrades an old configuration",
+	Use:     "upgrade",
+	Version: rootCmd.Version,
+	Short:   "Upgrades an old configuration",
 	Long: `Upgrades an old configuration. This command DOES NOT
 import share links because they are incompatible with
 this version.`,

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -18,10 +18,11 @@ func init() {
 }
 
 var usersCmd = &cobra.Command{
-	Use:   "users",
-	Short: "Users management utility",
-	Long:  `Users management utility.`,
-	Args:  cobra.NoArgs,
+	Use:     "users",
+	Version: rootCmd.Version,
+	Short:   "Users management utility",
+	Long:    `Users management utility.`,
+	Args:    cobra.NoArgs,
 }
 
 func printUsers(users []*users.User) {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -19,8 +19,7 @@ import (
 
 func checkErr(err error) {
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,20 +1,32 @@
 package cmd
 
 import (
-	"fmt"
+	"text/template"
 
-	"github.com/filebrowser/filebrowser/v2/version"
 	"github.com/spf13/cobra"
 )
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	cmdsCmd.AddCommand(versionCmd)
+	configCmd.AddCommand(versionCmd)
+	hashCmd.AddCommand(versionCmd)
+	upgradeCmd.AddCommand(versionCmd)
+	rulesCmd.AddCommand(versionCmd)
+	usersCmd.AddCommand(versionCmd)
 }
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the version number",
+	Short: "Print the version number of File Browser",
+	Long:  `All software has versions. This is File Browser's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("File Browser Version " + version.Version)
+		// https://github.com/spf13/cobra/issues/724
+		t := template.New("version")
+		template.Must(t.Parse(rootCmd.VersionTemplate()))
+		err := t.Execute(rootCmd.OutOrStdout(), rootCmd)
+		if err != nil {
+			rootCmd.Println(err)
+		}
 	},
 }

--- a/storage/bolt/users.go
+++ b/storage/bolt/users.go
@@ -12,32 +12,29 @@ type usersBackend struct {
 	db *storm.DB
 }
 
-func (st usersBackend) GetByID(id uint) (*users.User, error) {
-	user := &users.User{}
-	err := st.db.One("ID", id, user)
-	if err == storm.ErrNotFound {
-		return nil, errors.ErrNotExist
+func (st usersBackend) GetBy(i interface{}) (user *users.User, err error) {
+	user = &users.User{}
+
+	var arg string
+	switch i.(type) {
+	case uint:
+		arg = "ID"
+	case string:
+		arg = "Username"
+	default:
+		return nil, errors.ErrInvalidDataType
 	}
 
+	err = st.db.One(arg, i, user)
+
 	if err != nil {
+		if err == storm.ErrNotFound {
+			return nil, errors.ErrNotExist
+		}
 		return nil, err
 	}
 
-	return user, nil
-}
-
-func (st usersBackend) GetByUsername(username string) (*users.User, error) {
-	user := &users.User{}
-	err := st.db.One("Username", username, user)
-	if err == storm.ErrNotFound {
-		return nil, errors.ErrNotExist
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	return user, nil
+	return
 }
 
 func (st usersBackend) Gets() ([]*users.User, error) {
@@ -82,7 +79,7 @@ func (st usersBackend) DeleteByID(id uint) error {
 }
 
 func (st usersBackend) DeleteByUsername(username string) error {
-	user, err := st.GetByUsername(username)
+	user, err := st.GetBy(username)
 	if err != nil {
 		return err
 	}

--- a/users/storage.go
+++ b/users/storage.go
@@ -9,8 +9,7 @@ import (
 
 // StorageBackend is the interface to implement for a users storage.
 type StorageBackend interface {
-	GetByID(uint) (*User, error)
-	GetByUsername(string) (*User, error)
+	GetBy(interface{}) (*User, error)
 	Gets() ([]*User, error)
 	Save(u *User) error
 	Update(u *User, fields ...string) error
@@ -36,27 +35,13 @@ func NewStorage(back StorageBackend) *Storage {
 // Get allows you to get a user by its name or username. The provided
 // id must be a string for username lookup or a uint for id lookup. If id
 // is neither, a ErrInvalidDataType will be returned.
-func (s *Storage) Get(baseScope string, id interface{}) (*User, error) {
-	var (
-		user *User
-		err  error
-	)
-
-	switch id.(type) {
-	case string:
-		user, err = s.back.GetByUsername(id.(string))
-	case uint:
-		user, err = s.back.GetByID(id.(uint))
-	default:
-		return nil, errors.ErrInvalidDataType
-	}
-
+func (s *Storage) Get(baseScope string, id interface{}) (user *User, err error) {
+	user, err = s.back.GetBy(id)
 	if err != nil {
-		return nil, err
+		return
 	}
-
 	user.Clean(baseScope)
-	return user, err
+	return
 }
 
 // Gets gets a list of all users.


### PR DESCRIPTION
The first commit reduces code duplication in `users/storage.go` and `storage/bolt/users.go`. The second commit enables `--version` flags and `version` subcommands for the root command and all level-1 subcommands. The third commit replaces `fmt.Println(err); os.Exit(1)` with `log.Fatal(err)` as a general quiting procedure.