### PR TITLE
fix: strip baseurl

### DIFF
--- a/http/data.go
+++ b/http/data.go
@@ -64,9 +64,5 @@ func handle(fn handleFunc, prefix string, storage *storage.Storage, server *sett
 		}
 	})
 
-	if prefix == "" {
-		return handler
-	}
-
 	return http.StripPrefix(prefix, handler)
 }

--- a/http/http.go
+++ b/http/http.go
@@ -59,9 +59,5 @@ func NewHandler(storage *storage.Storage, server *settings.Server) (http.Handler
 	public.PathPrefix("/dl").Handler(monkey(publicDlHandler, "/api/public/dl/")).Methods("GET")
 	public.PathPrefix("/share").Handler(monkey(publicShareHandler, "/api/public/share/")).Methods("GET")
 
-	if server.BaseURL == "" {
-		return r, nil
-	}
-
 	return http.StripPrefix(server.BaseURL, r), nil
 }

--- a/http/http.go
+++ b/http/http.go
@@ -59,5 +59,9 @@ func NewHandler(storage *storage.Storage, server *settings.Server) (http.Handler
 	public.PathPrefix("/dl").Handler(monkey(publicDlHandler, "/api/public/dl/")).Methods("GET")
 	public.PathPrefix("/share").Handler(monkey(publicShareHandler, "/api/public/share/")).Methods("GET")
 
-	return r, nil
+	if server.BaseURL == "" {
+		return r, nil
+	}
+
+	return http.StripPrefix(server.BaseURL, r), nil
 }


### PR DESCRIPTION
Strips Base URL so requests match correctly. I removed the optimization in the second line because it seems [Go already does it](https://golang.org/src/net/http/server.go?s=60947:60997#L1982)!