### PR TITLE
fix: no db error when db size is 0

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -72,7 +72,7 @@ func dbExists(path string) (bool, error) {
 	}
 
 	if stat.Size() == 0 {
-		return true, nil
+		return false, nil
 	}
 
 	return true, nil

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -62,29 +62,43 @@ type pythonData struct {
 	store *storage.Storage
 }
 
+func dbExists(path string) (bool, error) {
+	stat, err := os.Stat(path)
+
+	if os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	if stat.Size() == 0 {
+		return true, nil
+	}
+
+	return true, nil
+}
+
 func python(fn pythonFunc, cfg pythonConfig) cobraFunc {
 	return func(cmd *cobra.Command, args []string) {
 		data := pythonData{hadDB: true}
 
 		path := getParam(cmd.Flags(), "database")
-		_, err := os.Stat(path)
+		exists, err := dbExists(path)
 
-		if os.IsNotExist(err) {
-			data.hadDB = false
-
-			if !cfg.noDB && !cfg.allowNoDB {
-				log.Fatal(path + " does not exist. Please run 'filebrowser config init' first.")
-			}
-		} else if err != nil {
+		if err != nil {
 			panic(err)
-		} else if err == nil && cfg.noDB {
+		} else if exists && cfg.noDB {
 			log.Fatal(path + " already exists")
+		} else if !exists && !cfg.noDB && !cfg.allowNoDB {
+			log.Fatal(path + " does not exist. Please run 'filebrowser config init' first.")
 		}
 
+		data.hadDB = exists
 		db, err := storm.Open(path)
 		checkErr(err)
 		defer db.Close()
-		data.store = bolt.NewStorage(db)
+		data.store, err = bolt.NewStorage(db)
+		checkErr(err)
 		fn(cmd, args, data)
 	}
 }

--- a/storage/bolt/bolt.go
+++ b/storage/bolt/bolt.go
@@ -10,16 +10,21 @@ import (
 )
 
 // NewStorage creates a storage.Storage based on Bolt DB.
-func NewStorage(db *storm.DB) *storage.Storage {
+func NewStorage(db *storm.DB) (*storage.Storage, error) {
 	users := users.NewStorage(usersBackend{db: db})
 	share := share.NewStorage(shareBackend{db: db})
 	settings := settings.NewStorage(settingsBackend{db: db})
 	auth := auth.NewStorage(authBackend{db: db}, users)
+
+	err := save(db, "version", 2)
+	if err != nil {
+		return nil, err
+	}
 
 	return &storage.Storage{
 		Auth:     auth,
 		Users:    users,
 		Share:    share,
 		Settings: settings,
-	}
+	}, nil
 }

--- a/storage/bolt/importer/importer.go
+++ b/storage/bolt/importer/importer.go
@@ -19,7 +19,10 @@ func Import(oldDB, oldConf, newDB string) error {
 	}
 	defer new.Close()
 
-	sto := bolt.NewStorage(new)
+	sto, err := bolt.NewStorage(new)
+	if err != nil {
+		return err
+	}
 
 	err = importUsers(old, sto)
 	if err != nil {


### PR DESCRIPTION
Fixes the error where File Browser would fail when the DB existed with size 0. This closes #628.

@1138-4EB I decided not to check the version for now since it's the first time we're adding that info. Only the next time we change the DB structure we'll use that value as reference to know how to upgrade.

I did not check it because the users running rc1 would have some issues with it.