### PR TITLE
Create directory of database if it does not exist

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -62,24 +62,20 @@ type pythonData struct {
 
 func dbExists(path string) (bool, error) {
 	stat, err := os.Stat(path)
+	if err == nil {
+		return stat.Size() != 0, nil
+	}
 
 	if os.IsNotExist(err) {
 		d := filepath.Dir(path)
 		_, err = os.Stat(d)
-		if !os.IsNotExist(err) {
-			return false, err
+		if os.IsNotExist(err) {
+			os.MkdirAll(d, 0700)
+			return false, nil
 		}
-		os.MkdirAll(d, 0700)
-		return false, nil
-	} else if err != nil {
-		return false, err
 	}
 
-	if stat.Size() == 0 {
-		return false, nil
-	}
-
-	return true, nil
+	return false, err
 }
 
 func python(fn pythonFunc, cfg pythonConfig) cobraFunc {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -64,6 +64,12 @@ func dbExists(path string) (bool, error) {
 	stat, err := os.Stat(path)
 
 	if os.IsNotExist(err) {
+		d := filepath.Dir(path)
+		_, err = os.Stat(d)
+		if !os.IsNotExist(err) {
+			return false, err
+		}
+		os.MkdirAll(d, 0700)
 		return false, nil
 	} else if err != nil {
 		return false, err


### PR DESCRIPTION
If the directory where the database is to be created does not exist, `storm.Open(path)` fails:

``` bash
# ./filebrowser -d /nonexist/db.db
2019/01/30 21:07:57 open /nonexist/db.db: no such file or directory
```

This PR adds the directory with `MkdirAll`, which is functionally equivalent to `mkdir -p`.