### PR TITLE
feat: remove version subcommands and flags

### DIFF
--- a/cmd/cmds.go
+++ b/cmd/cmds.go
@@ -11,11 +11,10 @@ func init() {
 }
 
 var cmdsCmd = &cobra.Command{
-	Use:     "cmds",
-	Version: rootCmd.Version,
-	Short:   "Command runner management utility",
-	Long:    `Command runner management utility.`,
-	Args:    cobra.NoArgs,
+	Use:   "cmds",
+	Short: "Command runner management utility",
+	Long:  `Command runner management utility.`,
+	Args:  cobra.NoArgs,
 }
 
 func printEvents(m map[string][]string) {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,11 +20,10 @@ func init() {
 }
 
 var configCmd = &cobra.Command{
-	Use:     "config",
-	Version: rootCmd.Version,
-	Short:   "Configuration management utility",
-	Long:    `Configuration management utility.`,
-	Args:    cobra.NoArgs,
+	Use:   "config",
+	Short: "Configuration management utility",
+	Long:  `Configuration management utility.`,
+	Args:  cobra.NoArgs,
 }
 
 func addConfigFlags(flags *pflag.FlagSet) {

--- a/cmd/hash.go
+++ b/cmd/hash.go
@@ -12,11 +12,10 @@ func init() {
 }
 
 var hashCmd = &cobra.Command{
-	Use:     "hash <password>",
-	Version: rootCmd.Version,
-	Short:   "Hashes a password",
-	Long:    `Hashes a password using bcrypt algorithm.`,
-	Args:    cobra.ExactArgs(1),
+	Use:   "hash <password>",
+	Short: "Hashes a password",
+	Long:  `Hashes a password using bcrypt algorithm.`,
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		pwd, err := users.HashPwd(args[0])
 		checkErr(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,6 @@ import (
 	"github.com/filebrowser/filebrowser/v2/settings"
 	"github.com/filebrowser/filebrowser/v2/storage"
 	"github.com/filebrowser/filebrowser/v2/users"
-	"github.com/filebrowser/filebrowser/v2/version"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -55,9 +54,8 @@ func addServerFlags(flags *pflag.FlagSet) {
 }
 
 var rootCmd = &cobra.Command{
-	Use:     "filebrowser",
-	Version: version.Version,
-	Short:   "A stylish web-based file browser",
+	Use:   "filebrowser",
+	Short: "A stylish web-based file browser",
 	Long: `File Browser CLI lets you create the database to use with File Browser,
 manage your users and all the configurations without acessing the
 web interface.

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -19,7 +19,6 @@ func init() {
 
 var rulesCmd = &cobra.Command{
 	Use:     "rules",
-	Version: rootCmd.Version,
 	Short:   "Rules management utility",
 	Long: `On each subcommand you'll have available at least two flags:
 "username" and "id". You must either set only one of them

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -14,9 +14,8 @@ func init() {
 }
 
 var upgradeCmd = &cobra.Command{
-	Use:     "upgrade",
-	Version: rootCmd.Version,
-	Short:   "Upgrades an old configuration",
+	Use:   "upgrade",
+	Short: "Upgrades an old configuration",
 	Long: `Upgrades an old configuration. This command DOES NOT
 import share links because they are incompatible with
 this version.`,

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -18,11 +18,10 @@ func init() {
 }
 
 var usersCmd = &cobra.Command{
-	Use:     "users",
-	Version: rootCmd.Version,
-	Short:   "Users management utility",
-	Long:    `Users management utility.`,
-	Args:    cobra.NoArgs,
+	Use:   "users",
+	Short: "Users management utility",
+	Long:  `Users management utility.`,
+	Args:  cobra.NoArgs,
 }
 
 func printUsers(users []*users.User) {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,32 +1,20 @@
 package cmd
 
 import (
-	"text/template"
+	"fmt"
 
+	"github.com/filebrowser/filebrowser/v2/version"
 	"github.com/spf13/cobra"
 )
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-	cmdsCmd.AddCommand(versionCmd)
-	configCmd.AddCommand(versionCmd)
-	hashCmd.AddCommand(versionCmd)
-	upgradeCmd.AddCommand(versionCmd)
-	rulesCmd.AddCommand(versionCmd)
-	usersCmd.AddCommand(versionCmd)
 }
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the version number of File Browser",
-	Long:  `All software has versions. This is File Browser's`,
+	Short: "Print the version number",
 	Run: func(cmd *cobra.Command, args []string) {
-		// https://github.com/spf13/cobra/issues/724
-		t := template.New("version")
-		template.Must(t.Parse(rootCmd.VersionTemplate()))
-		err := t.Execute(rootCmd.OutOrStdout(), rootCmd)
-		if err != nil {
-			rootCmd.Println(err)
-		}
+		fmt.Println("File Browser Version " + version.Version)
 	},
 }


### PR DESCRIPTION
Revert `version` changes introduced on #618. Let's keep the code and help clean without flags and commands wandering around for no reason.