### PR TITLE
feat: per-user auto directory creation

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -89,6 +89,7 @@ func printSettings(ser *settings.Server, set *settings.Settings, auther auth.Aut
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
 	fmt.Fprintf(w, "Sign up:\t%t\n", set.Signup)
+	fmt.Fprintf(w, "Create User Dir:\t%t\n", set.CreateUserDir)
 	fmt.Fprintf(w, "Auth method:\t%s\n", set.AuthMethod)
 	fmt.Fprintf(w, "Shell:\t%s\t\n", strings.Join(set.Shell, " "))
 	fmt.Fprintln(w, "\nBranding:")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -215,6 +215,7 @@ func quickSetup(flags *pflag.FlagSet, d pythonData) {
 	set := &settings.Settings{
 		Key:    generateKey(),
 		Signup: false,
+		CreateUserDir: false,
 		Defaults: settings.UserDefaults{
 			Scope:  ".",
 			Locale: "en",

--- a/cmd/users_add.go
+++ b/cmd/users_add.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/filebrowser/filebrowser/v2/settings"
 	"github.com/filebrowser/filebrowser/v2/users"
 	"github.com/spf13/cobra"
 )
@@ -30,6 +31,19 @@ var usersAddCmd = &cobra.Command{
 		}
 
 		s.Defaults.Apply(user)
+
+		servSettings, err := d.store.Settings.GetServer()
+		checkErr(err)
+		//since getUserDefaults() polluted s.Defaults.Scope
+		//which makes the Scope not the one saved in the db
+		//we need the right s.Defaults.Scope here
+		s2, err := d.store.Settings.Get()
+		checkErr(err)
+
+		userHome, err := settings.CreateUserDir(user.Username, user.Scope, servSettings.Root, s2)
+		checkErr(err)
+		user.Scope = userHome
+
 		err = d.store.Users.Save(user)
 		checkErr(err)
 		printUsers([]*users.User{user})

--- a/http/settings.go
+++ b/http/settings.go
@@ -10,6 +10,7 @@ import (
 
 type settingsData struct {
 	Signup   bool                  `json:"signup"`
+	CreateUserDir   bool           `json:"createUserDir"`
 	Defaults settings.UserDefaults `json:"defaults"`
 	Rules    []rules.Rule          `json:"rules"`
 	Branding settings.Branding     `json:"branding"`
@@ -20,6 +21,7 @@ type settingsData struct {
 var settingsGetHandler = withAdmin(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
 	data := &settingsData{
 		Signup:   d.settings.Signup,
+		CreateUserDir: d.settings.CreateUserDir,
 		Defaults: d.settings.Defaults,
 		Rules:    d.settings.Rules,
 		Branding: d.settings.Branding,
@@ -38,6 +40,7 @@ var settingsPutHandler = withAdmin(func(w http.ResponseWriter, r *http.Request, 
 	}
 
 	d.settings.Signup = req.Signup
+	d.settings.CreateUserDir = req.CreateUserDir
 	d.settings.Defaults = req.Defaults
 	d.settings.Rules = req.Rules
 	d.settings.Branding = req.Branding

--- a/http/users.go
+++ b/http/users.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"encoding/json"
+	"github.com/filebrowser/filebrowser/v2/settings"
+	"log"
 	"net/http"
 	"sort"
 	"strconv"
@@ -118,6 +120,14 @@ var userPostHandler = withAdmin(func(w http.ResponseWriter, r *http.Request, d *
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
+
+	userHome,err := settings.CreateUserDir(req.Data.Username, req.Data.Scope, d.server.Root, d.settings)
+	if err != nil {
+		log.Printf("create user: failed to mkdir user home dir: [%s]", userHome)
+		return http.StatusInternalServerError, err
+	}
+	req.Data.Scope = userHome
+	log.Printf("user: %s, home dir: [%s].", req.Data.Username, userHome)
 
 	err = d.store.Users.Save(req.Data)
 	if err != nil {

--- a/settings/dir.go
+++ b/settings/dir.go
@@ -1,0 +1,77 @@
+package settings
+
+import (
+	"errors"
+	"github.com/spf13/afero"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var (
+	invalidFilenameChars = regexp.MustCompile(`[^0-9A-Za-z@_\-.]`)
+
+	dashes = regexp.MustCompile(`[\-]+`)
+)
+
+func CreateUserDir(username, userScope, serverRoot string, settings *Settings) (string, error) {
+	var err error
+	userScope = strings.TrimSpace(userScope)
+	if userScope == "" || userScope == "./"  {
+		userScope = "."
+	}
+
+	if !settings.CreateUserDir {
+		return userScope, nil
+	}
+
+	fs := afero.NewBasePathFs(afero.NewOsFs(), serverRoot)
+
+	//use the default auto create logic only if specific scope is not the default scope
+	if userScope != settings.Defaults.Scope {
+		//try create the dir, for example: settings.Defaults.Scope == "." and userScope == "./foo"
+		if userScope != "." {
+			err = fs.MkdirAll(userScope, os.ModePerm)
+			if err != nil {
+				log.Printf("create user: failed to mkdir user home dir: [%s]", userScope)
+			}
+		}
+		return userScope, err
+	}
+
+	//clean username first
+	username = cleanUsername(username)
+	if username == "" || username == "-" || username == "." {
+		log.Printf("create user: invalid user for home dir creation: [%s]", username)
+		return "", errors.New("invalid user for home dir creation")
+	}
+
+	//create default user dir
+	userHomeBase := settings.Defaults.Scope + string(os.PathSeparator) + "users"
+	userHome := userHomeBase + string(os.PathSeparator) + username
+	err = fs.MkdirAll(userHome, os.ModePerm)
+	if err != nil {
+		log.Printf("create user: failed to mkdir user home dir: [%s]", userHome)
+	} else {
+		log.Printf("create user: mkdir user home dir: [%s] successfully.", userHome)
+	}
+	return userHome,err
+}
+
+
+func cleanUsername(s string) string {
+
+	// Remove any trailing space to avoid ending on -
+	s = strings.Trim(s, " ")
+
+	s = strings.Replace(s, "..", "", -1)
+
+	// Replace all characters which not in the list `0-9A-Za-z@_\-.` with a dash
+	s = invalidFilenameChars.ReplaceAllString(s, "-")
+
+	// Remove any multiple dashes caused by replacements above
+	s = dashes.ReplaceAllString(s, "-")
+
+	return s
+}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -14,6 +14,7 @@ type AuthMethod string
 type Settings struct {
 	Key        []byte              `json:"key"`
 	Signup     bool                `json:"signup"`
+	CreateUserDir   bool           `json:"createUserDir"`
 	Defaults   UserDefaults        `json:"defaults"`
 	AuthMethod AuthMethod          `json:"authMethod"`
 	Branding   Branding            `json:"branding"`


### PR DESCRIPTION
Per-user auto directory creation 

**Description**
as #657  mentioned  
auto create user directory while creating new user.

**Limitation**
1. this logic **DOES NOT** work when edit an exists user.
2. this logic **DOES NOT** work when public user register on frontend page.
3. this logic **ONLY WORK** when admin is creating a new user on the user management page.

there are 2 conditions we need to consider
 when creating a new user (with auto dir creation enabled):
1.  user scope == global default user scope
2. user scope != global default user scope

### condition 1.1
for example: 
add new user `foo` and leave the scope dir to the default  user scope  `.` ,  
and `auto directory creation ` option was enabled, 

suggest if we have the following startup command:
```
/path-to/filebrowser_amd64 -r /media
```

then the user's default scope dir will be:
```
./users/foo
```

and the real path on the system will be:
```
/media/users/foo
```

### condition 1.2
another condition is the default user scope != server root path, but user scope = default user scope
for example:
we set the `default user scope` to `./bar` under `Global settings`
when we add a user `foo` and `auto directory creation ` option was enabled,
the user's default scope dir will be:
```
./bar/users/foo
```

and the real path on the system will be:
```
/media/bar/users/foo
```

### condition 2
for example: 
add new user `foo` and set  the scope dir  to `./special` ,  and leave global settings  `default  user scope` still   `.`
we do create the dir this time , but do not follow the default path creation logic.
the user's default scope dir will be:
```
./special
```

and the real path on the system will be:
```
/media/special
```

![image](https://user-images.githubusercontent.com/41882455/52988260-7d364680-3439-11e9-9a7d-fdb157667af3.png)


frontend assets PR is at  https://github.com/filebrowser/frontend/pull/102
