### PR TITLE
Update download names file for weak clients

### DIFF
--- a/http/public.go
+++ b/http/public.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/filebrowser/filebrowser/v2/files"
 )
@@ -10,7 +11,10 @@ var withHashFile = func(fn handleFunc) handleFunc {
 	return func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
 		link, err := d.store.Share.GetByHash(r.URL.Path)
 		if err != nil {
-			return errToStatus(err), err
+			link, err = d.store.Share.GetByHash(ifPathWithName(r))
+			if err != nil {
+				return errToStatus(err), err
+			}
 		}
 
 		user, err := d.store.Users.Get(d.server.Root, link.UserID)
@@ -34,6 +38,12 @@ var withHashFile = func(fn handleFunc) handleFunc {
 		d.raw = file
 		return fn(w, r, d)
 	}
+}
+
+func ifPathWithName(r *http.Request) string {
+	pathElements := strings.Split(r.URL.Path, "/")
+	id := pathElements[len(pathElements)-2]
+	return id
 }
 
 var publicShareHandler = withHashFile(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {


### PR DESCRIPTION
**Description**

The change is very simple.
With a pore HTTP client which I have to use.

The client save the file directly with the ID.

For example if the path is: `/api/public/dl/MEEuZK-v`
Than the file will be saved as `MEEuZK-v` without any extension which is not very useful.

To prevent this I added the sanitized `file name` after the `ID` in the path to make it look like this: `/api/public/dl/MEEuZK-v/file-name.txt` and the file is now saved as `file-name.txt` in case the client does not read the `file name` from header.

The path is a but longer but I don't think this is very important.

I don't understand what the pull request is saying about `frontend`. :confused: 
But I have the corresponding changes on `frontend` on my repo.