### PR TITLE
feat: adds support for unix sockets

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -101,6 +101,7 @@ func printSettings(ser *settings.Server, set *settings.Settings, auther auth.Aut
 	fmt.Fprintf(w, "\tPort:\t%s\n", ser.Port)
 	fmt.Fprintf(w, "\tBase URL:\t%s\n", ser.BaseURL)
 	fmt.Fprintf(w, "\tRoot:\t%s\n", ser.Root)
+	fmt.Fprintf(w, "\tSocket:\t%s\n", ser.Socket)
 	fmt.Fprintf(w, "\tAddress:\t%s\n", ser.Address)
 	fmt.Fprintf(w, "\tTLS Cert:\t%s\n", ser.TLSCert)
 	fmt.Fprintf(w, "\tTLS Key:\t%s\n", ser.TLSKey)

--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -43,6 +43,7 @@ override the options.`,
 
 		ser := &settings.Server{
 			Address: mustGetString(flags, "address"),
+			Socket:  mustGetString(flags, "socket"),
 			Root:    mustGetString(flags, "root"),
 			BaseURL: mustGetString(flags, "baseurl"),
 			TLSKey:  mustGetString(flags, "key"),

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -34,6 +34,8 @@ you want to change. Other options will remain unchanged.`,
 				ser.BaseURL = mustGetString(flags, flag.Name)
 			case "root":
 				ser.Root = mustGetString(flags, flag.Name)
+			case "socket":
+				ser.Socket = mustGetString(flags, flag.Name)
 			case "cert":
 				ser.TLSCert = mustGetString(flags, flag.Name)
 			case "key":

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,13 +2,16 @@ package cmd
 
 import (
 	"crypto/tls"
+	"errors"
 	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/filebrowser/filebrowser/v2/auth"
 	fbhttp "github.com/filebrowser/filebrowser/v2/http"
@@ -50,6 +53,7 @@ func addServerFlags(flags *pflag.FlagSet) {
 	flags.StringP("cert", "t", "", "tls certificate")
 	flags.StringP("key", "k", "", "tls key")
 	flags.StringP("root", "r", ".", "root to prepend to relative paths")
+	flags.String("socket", "", "socket to listen to (cannot be used with address, port, cert nor key flags)")
 	flags.StringP("baseurl", "b", "", "base url")
 }
 
@@ -109,7 +113,10 @@ user created with the credentials from options "username" and "password".`,
 
 		var listener net.Listener
 
-		if server.TLSKey != "" && server.TLSCert != "" {
+		if server.Socket != "" {
+			listener, err = net.Listen("unix", server.Socket)
+			checkErr(err)
+		} else if server.TLSKey != "" && server.TLSCert != "" {
 			cer, err := tls.LoadX509KeyPair(server.TLSCert, server.TLSKey)
 			checkErr(err)
 			listener, err = tls.Listen("tcp", adr, &tls.Config{Certificates: []tls.Certificate{cer}})
@@ -119,14 +126,27 @@ user created with the credentials from options "username" and "password".`,
 			checkErr(err)
 		}
 
+		sigc := make(chan os.Signal, 1)
+		signal.Notify(sigc, os.Interrupt, os.Kill, syscall.SIGTERM)
+		go cleanupHandler(listener, sigc)
+
 		handler, err := fbhttp.NewHandler(d.store, server)
 		checkErr(err)
+
+		defer listener.Close()
 
 		log.Println("Listening on", listener.Addr().String())
 		if err := http.Serve(listener, handler); err != nil {
 			log.Fatal(err)
 		}
 	}, pythonConfig{allowNoDB: true}),
+}
+
+func cleanupHandler(listener net.Listener, c chan os.Signal) {
+	sig := <-c
+	log.Printf("Caught signal %s: shutting down.", sig)
+	listener.Close()
+	os.Exit(0)
 }
 
 func getRunParams(flags *pflag.FlagSet, st *storage.Storage) *settings.Server {
@@ -141,24 +161,45 @@ func getRunParams(flags *pflag.FlagSet, st *storage.Storage) *settings.Server {
 		server.BaseURL = val
 	}
 
-	if val, set := getParamB(flags, "address"); set {
-		server.Address = val
-	}
-
-	if val, set := getParamB(flags, "port"); set {
-		server.Port = val
-	}
-
 	if val, set := getParamB(flags, "log"); set {
 		server.Log = val
 	}
 
+	isSocketSet := false
+	isAddrSet := false
+
+	if val, set := getParamB(flags, "address"); set {
+		server.Address = val
+		isAddrSet = isAddrSet || set
+	}
+
+	if val, set := getParamB(flags, "port"); set {
+		server.Port = val
+		isAddrSet = isAddrSet || set
+	}
+
 	if val, set := getParamB(flags, "key"); set {
 		server.TLSKey = val
+		isAddrSet = isAddrSet || set
 	}
 
 	if val, set := getParamB(flags, "cert"); set {
 		server.TLSCert = val
+		isAddrSet = isAddrSet || set
+	}
+
+	if val, set := getParamB(flags, "socket"); set {
+		server.Socket = val
+		isSocketSet = isSocketSet || set
+	}
+
+	if isAddrSet && isSocketSet {
+		checkErr(errors.New("--socket flag cannot be used with --adress, --port, --key nor --cert"))
+	}
+
+	// Do not use saved Socket if address was manually set.
+	if isAddrSet && server.Socket != "" {
+		server.Socket = ""
 	}
 
 	return server

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,7 +127,7 @@ user created with the credentials from options "username" and "password".`,
 		}
 
 		sigc := make(chan os.Signal, 1)
-		signal.Notify(sigc, os.Interrupt, os.Kill, syscall.SIGTERM)
+		signal.Notify(sigc, os.Interrupt, syscall.SIGTERM)
 		go cleanupHandler(listener, sigc)
 
 		handler, err := fbhttp.NewHandler(d.store, server)

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -32,6 +32,7 @@ func (s *Settings) GetRules() []rules.Rule {
 type Server struct {
 	Root    string `json:"root"`
 	BaseURL string `json:"baseURL"`
+	Socket  string `json:"socket"`
 	TLSKey  string `json:"tlsKey"`
 	TLSCert string `json:"tlsCert"`
 	Port    string `json:"port"`


### PR DESCRIPTION
Adds support to listen to unix sockets through the `--socket` flag. It can be persisted into the database with `config set --socket=/sth.socket`. 

Flags `--address`, `--port`, `--cert` and `--key` cannot be used with `--socket`. Although all of them can be persisted to the database. Socket takes precedence if set in the database and the user doesn't use any flags.

Closes #584.

@tux456, would you like to review this PR?