### PR TITLE
Make --auth.method parameter optional when changing auth parameters Fixes: #715

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -72,7 +72,7 @@ func getAuthentication(flags *pflag.FlagSet, defaults ...interface{}) (settings.
 		}
 
 		if header == "" {
-			panic(nerrors.New("you must set the flag 'auth.header' for method 'proxy'"))
+			checkErr(nerrors.New("you must set the flag 'auth.header' for method 'proxy'"))
 		}
 
 		auther = &auth.ProxyAuth{Header: header}
@@ -99,7 +99,7 @@ func getAuthentication(flags *pflag.FlagSet, defaults ...interface{}) (settings.
 		}
 
 		if key == "" || secret == "" {
-			panic(nerrors.New("you must set the flag 'recaptcha.key' and 'recaptcha.secret' for method 'json'"))
+			checkErr(nerrors.New("you must set the flag 'recaptcha.key' and 'recaptcha.secret' for method 'json'"))
 		}
 
 		jsonAuth.ReCaptcha = &auth.ReCaptcha{

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -46,14 +46,20 @@ func addConfigFlags(flags *pflag.FlagSet) {
 
 func getAuthentication(flags *pflag.FlagSet, defaults ...interface{}) (settings.AuthMethod, auth.Auther) {
 	method := settings.AuthMethod(mustGetString(flags, "auth.method"))
+
 	var defaultAuther map[string]interface{}
-	for _, arg := range defaults {
-		switch def := arg.(type) {
-		case *settings.Settings:
-			method = settings.AuthMethod(def.AuthMethod)
-		case auth.Auther:
-			ms, _ := json.Marshal(def)
-			json.Unmarshal(ms, &defaultAuther)
+	if len(defaults) > 0 {
+		if hasAuth := defaults[0]; hasAuth != true {
+			for _, arg := range defaults {
+				switch def := arg.(type) {
+				case *settings.Settings:
+					method = settings.AuthMethod(def.AuthMethod)
+				case auth.Auther:
+					ms, err := json.Marshal(def)
+					checkErr(err)
+					json.Unmarshal(ms, &defaultAuther)
+				}
+			}
 		}
 	}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -44,8 +44,11 @@ func addConfigFlags(flags *pflag.FlagSet) {
 	flags.Bool("branding.disableExternal", false, "disable external links such as GitHub links")
 }
 
-func getAuthentication(flags *pflag.FlagSet) (settings.AuthMethod, auth.Auther) {
+func getAuthentication(flags *pflag.FlagSet, defaults ...*settings.Settings) (settings.AuthMethod, auth.Auther) {
 	method := settings.AuthMethod(mustGetString(flags, "auth.method"))
+	if len(defaults) > 0 {
+		method = defaults[0].AuthMethod
+	}
 
 	var auther auth.Auther
 	if method == auth.MethodProxyAuth {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -46,7 +46,6 @@ func addConfigFlags(flags *pflag.FlagSet) {
 
 func getAuthentication(flags *pflag.FlagSet, defaults ...interface{}) (settings.AuthMethod, auth.Auther) {
 	method := settings.AuthMethod(mustGetString(flags, "auth.method"))
-
 	var defaultAuther map[string]interface{}
 	for _, arg := range defaults {
 		switch def := arg.(type) {
@@ -79,7 +78,6 @@ func getAuthentication(flags *pflag.FlagSet, defaults ...interface{}) (settings.
 
 	if method == auth.MethodJSONAuth {
 		jsonAuth := &auth.JSONAuth{}
-
 		host := mustGetString(flags, "recaptcha.host")
 		key := mustGetString(flags, "recaptcha.key")
 		secret := mustGetString(flags, "recaptcha.secret")

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -70,12 +70,14 @@ func getAuthentication(flags *pflag.FlagSet, defaults ...*settings.Settings) (se
 		key := mustGetString(flags, "recaptcha.key")
 		secret := mustGetString(flags, "recaptcha.secret")
 
-		if key != "" && secret != "" {
-			jsonAuth.ReCaptcha = &auth.ReCaptcha{
-				Host:   host,
-				Key:    key,
-				Secret: secret,
-			}
+		if key == "" || secret == "" {
+			panic(nerrors.New("you must set the flag 'recaptcha.key' and 'recaptcha.secret' for method 'json'"))
+		}
+
+		jsonAuth.ReCaptcha = &auth.ReCaptcha{
+			Host:   host,
+			Key:    key,
+			Secret: secret,
 		}
 
 		auther = jsonAuth

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -71,6 +71,10 @@ you want to change. Other options will remain unchanged.`,
 		} else {
 			auther, err = d.store.Auth.Get(set.AuthMethod)
 			checkErr(err)
+			// check if there are new flags for existing auth method
+			set.AuthMethod, auther = getAuthentication(flags, set)
+			err = d.store.Auth.Save(auther)
+			checkErr(err)
 		}
 
 		err = d.store.Settings.Save(set)

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"strings"
 
-	"github.com/filebrowser/filebrowser/v2/auth"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -63,20 +62,15 @@ you want to change. Other options will remain unchanged.`,
 
 		getUserDefaults(flags, &set.Defaults, false)
 
-		var auther auth.Auther
-		if hasAuth {
-			set.AuthMethod, auther = getAuthentication(flags)
-			err = d.store.Auth.Save(auther)
-			checkErr(err)
-		} else {
-			auther, err = d.store.Auth.Get(set.AuthMethod)
-			checkErr(err)
-			// check if there are new flags for existing auth method
-			set.AuthMethod, auther = getAuthentication(flags, set, auther)
-			err = d.store.Auth.Save(auther)
-			checkErr(err)
-		}
+		// read the defaults
+		auther, err := d.store.Auth.Get(set.AuthMethod)
+		checkErr(err)
 
+		// check if there are new flags for existing auth method
+		set.AuthMethod, auther = getAuthentication(flags, hasAuth, set, auther)
+
+		err = d.store.Auth.Save(auther)
+		checkErr(err)
 		err = d.store.Settings.Save(set)
 		checkErr(err)
 		err = d.store.Settings.SaveServer(ser)

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -72,7 +72,7 @@ you want to change. Other options will remain unchanged.`,
 			auther, err = d.store.Auth.Get(set.AuthMethod)
 			checkErr(err)
 			// check if there are new flags for existing auth method
-			set.AuthMethod, auther = getAuthentication(flags, set)
+			set.AuthMethod, auther = getAuthentication(flags, set, auther)
 			err = d.store.Auth.Save(auther)
 			checkErr(err)
 		}


### PR DESCRIPTION
**Description**
If user does not specify auth.method but gives authentication specific parameters, it will read the default auth.method then will update the related authentication parameters if that parameters belong to default auth.method.

Forexample:
if user gives 
`filebrowser config set --recaptcha.key=key --recaptcha.secret=secret`
and the default auth.method is 'json' it will only update the values but if the default value is 'proxy' it will panic and wants you to pass proxy related parameters. 

This logic is also same for proxy auth method. 
