### PR TITLE
use ParseFromRequest instead of ParseFromRequestWithClaims

### DIFF
--- a/http/auth.go
+++ b/http/auth.go
@@ -54,7 +54,7 @@ func withUser(fn handleFunc) handleFunc {
 		}
 
 		var tk authToken
-		token, err := request.ParseFromRequestWithClaims(r, &extractor{}, &tk, keyFunc)
+		token, err := request.ParseFromRequest(r, &extractor{}, keyFunc, request.WithClaims(&tk))
 
 		if err != nil || !token.Valid {
 			return http.StatusForbidden, nil


### PR DESCRIPTION
Use `ParseFromRequest` instead of `ParseFromRequestWithClaims` because `ParseFromRequestWithClaims` function is `DEPRECATED`.

Godoc: [https://godoc.org/github.com/dgrijalva/jwt-go/request#ParseFromRequestWithClaims](https://godoc.org/github.com/dgrijalva/jwt-go/request#ParseFromRequestWithClaims)
Source code [https://github.com/dgrijalva/jwt-go/blob/master/request/request.go#L43](https://github.com/dgrijalva/jwt-go/blob/master/request/request.go#L43)
