### PR TITLE
prevent maliciously constructed parameters caused panic

### DIFF
--- a/http/public.go
+++ b/http/public.go
@@ -40,8 +40,15 @@ var withHashFile = func(fn handleFunc) handleFunc {
 	}
 }
 
+// ref to https://github.com/filebrowser/filebrowser/pull/727
+// `/api/public/dl/MEEuZK-v/file-name.txt` for old browsers to save file with correct name
 func ifPathWithName(r *http.Request) string {
 	pathElements := strings.Split(r.URL.Path, "/")
+	// prevent maliciously constructed parameters like `/api/public/dl/XZzCDnK2_not_exists_hash_name`
+	// len(pathElements) will be 1, and golang will panic `runtime error: index out of range`
+	if len(pathElements) < 2 {
+		return r.URL.Path
+	}
 	id := pathElements[len(pathElements)-2]
 	return id
 }


### PR DESCRIPTION
prevent maliciously constructed parameters like `/api/public/dl/XZzCDnK2_not_exists_hash_name` cause panic

 this bug was introduced in https://github.com/filebrowser/filebrowser/pull/727
