### PR TITLE
Proposal for public folders

### DIFF
--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -1,6 +1,13 @@
 <template>
-  <div class="share" v-if="loaded">
-    <a target="_blank" :href="link" v-if="!file.isDir">
+  <div
+    class="share"
+    v-if="loaded"
+  >
+    <a
+      target="_blank"
+      :href="link"
+      v-if="!file.isDir"
+    >
       <div class="share__box">
         <div class="share__box__download">{{ $t('download.downloadFile') }}</div>
         <div class="share__box__info">
@@ -11,21 +18,27 @@
             width="150"
             xmlns="http://www.w3.org/2000/svg"
           >
+            <path d="M6 2c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6H6zm7 7V3.5L18.5 9H13z" />
             <path
-              d="M6 2c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6H6zm7 7V3.5L18.5 9H13z"
+              d="M0 0h24v24H0z"
+              fill="none"
             />
-            <path d="M0 0h24v24H0z" fill="none" />
           </svg>
           <h1 class="share__box__title">{{ file.name }}</h1>
-          <qrcode-vue :value="fullLink" size="200" level="M"></qrcode-vue>
+          <qrcode-vue
+            :value="fullLink"
+            size="200"
+            level="M"
+          ></qrcode-vue>
         </div>
       </div>
     </a>
-    <listing></listing>
+    <listing :class="{ multiple }"></listing>
   </div>
 </template>
 
 <script>
+import { mapState, mapMutations } from 'vuex'
 import Listing from '@/components/files/Listing'
 
 import { share as api } from '@/api'
@@ -51,6 +64,17 @@ export default {
     this.fetchData()
   },
   computed: {
+    ...mapState([
+      'isEditor',
+      'isFiles',
+      'isListing',
+      'loading',
+      'multiple',
+      'reload',
+      'req',
+      'selectedCount',
+      'user'
+    ]),
     hash: function () {
       return this.$route.params.pathMatch
     },
@@ -84,7 +108,22 @@ export default {
             return file.items
           });
 
+          this.$store.commit('setReload', false)
+          this.$store.commit('resetSelected')
+          this.$store.commit('multiple', false)
+          this.$store.commit('closeHovers')
+
           this.dirContent = items;
+          const req = {
+            items,
+            sorting: {
+              isDir: true,
+              asc: false,
+              by: "name",
+              path: relativePath,
+            }
+          };
+          this.$store.commit('updateRequest', req)
         }
 
         this.loaded = true

--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -83,7 +83,6 @@ export default {
           }).then((file) => {
             return file.items
           });
-          console.log(items);
 
           this.dirContent = items;
         }

--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -1,27 +1,33 @@
 <template>
   <div class="share" v-if="loaded">
-    <a target="_blank" :href="link">
+    <a target="_blank" :href="link" v-if="!file.isDir">
       <div class="share__box">
-        <div class="share__box__download" v-if="file.isDir">{{ $t('download.downloadFolder') }}</div>
-        <div class="share__box__download" v-else>{{ $t('download.downloadFile') }}</div>
+        <div class="share__box__download">{{ $t('download.downloadFile') }}</div>
         <div class="share__box__info">
-          <svg v-if="file.isDir" fill="#40c4ff" height="150" viewBox="0 0 24 24" width="150" xmlns="http://www.w3.org/2000/svg">
-            <path d="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/>
-            <path d="M0 0h24v24H0z" fill="none"/>
-          </svg>
-          <svg v-else fill="#40c4ff" height="150" viewBox="0 0 24 24" width="150" xmlns="http://www.w3.org/2000/svg">
-            <path d="M6 2c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6H6zm7 7V3.5L18.5 9H13z"/>
-            <path d="M0 0h24v24H0z" fill="none"/>
+          <svg
+            fill="#40c4ff"
+            height="150"
+            viewBox="0 0 24 24"
+            width="150"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6 2c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6H6zm7 7V3.5L18.5 9H13z"
+            />
+            <path d="M0 0h24v24H0z" fill="none" />
           </svg>
           <h1 class="share__box__title">{{ file.name }}</h1>
           <qrcode-vue :value="fullLink" size="200" level="M"></qrcode-vue>
         </div>
       </div>
     </a>
+    <listing></listing>
   </div>
 </template>
 
 <script>
+import Listing from '@/components/files/Listing'
+
 import { share as api } from '@/api'
 import { baseURL } from '@/utils/constants'
 import QrcodeVue from 'qrcode.vue'
@@ -29,12 +35,14 @@ import QrcodeVue from 'qrcode.vue'
 export default {
   name: 'share',
   components: {
-    QrcodeVue
+    QrcodeVue,
+    Listing
   },
   data: () => ({
     loaded: false,
     notFound: false,
-    file: null
+    file: null,
+    dirContent: null
   }),
   watch: {
     '$route': 'fetchData'
@@ -57,6 +65,29 @@ export default {
     fetchData: async function () {
       try {
         this.file = await api.getHash(this.hash)
+
+        if (this.file.isDir) {
+          const tmpPath = this.hash.split('/')
+          const hash = tmpPath.shift();
+          const relativePath = tmpPath.join('/');
+
+          const items = await fetch('/api/public/resources/' + hash, {
+            headers: {
+              'Content-Type': 'application/json',
+              'Relative-Path': relativePath
+            }
+          }).then((ret) => {
+            if (ret.status === 200) {
+              return ret.json();
+            }
+          }).then((file) => {
+            return file.items
+          });
+          console.log(items);
+
+          this.dirContent = items;
+        }
+
         this.loaded = true
       } catch (e) {
         this.notFound = true

--- a/http/http.go
+++ b/http/http.go
@@ -64,6 +64,7 @@ func NewHandler(storage *storage.Storage, server *settings.Server) (http.Handler
 	public := api.PathPrefix("/public").Subrouter()
 	public.PathPrefix("/dl").Handler(monkey(publicDlHandler, "/api/public/dl/")).Methods("GET")
 	public.PathPrefix("/share").Handler(monkey(publicShareHandler, "/api/public/share/")).Methods("GET")
+	public.PathPrefix("/resources").Handler(monkey(publicShareFolderHandler, "/api/public/resources/")).Methods("GET")
 
 	return stripPrefix(server.BaseURL, r), nil
 }

--- a/http/public.go
+++ b/http/public.go
@@ -62,9 +62,14 @@ var publicDlHandler = withHashFile(func(w http.ResponseWriter, r *http.Request, 
 var publicShareFolderHandler = withHashFile(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
 	baseFolder := d.raw.(*files.FileInfo)
 
+	path := baseFolder.Path
+	if relativeHeaderString := r.Header.Get("Relative-Path"); relativeHeaderString != "" {
+		path = path + "/" + relativeHeaderString
+	}
+
 	file, err := files.NewFileInfo(files.FileOptions{
 		Fs:      d.user.Fs,
-		Path:    baseFolder.Path + "/" + r.Header.Get("Relative-Path"),
+		Path:    path,
 		Modify:  d.user.Perm.Modify,
 		Expand:  true,
 		Checker: d,

--- a/http/public.go
+++ b/http/public.go
@@ -58,3 +58,22 @@ var publicDlHandler = withHashFile(func(w http.ResponseWriter, r *http.Request, 
 
 	return rawDirHandler(w, r, d, file)
 })
+
+var publicShareFolderHandler = withHashFile(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	baseFolder := d.raw.(*files.FileInfo)
+
+	file, err := files.NewFileInfo(files.FileOptions{
+		Fs:      d.user.Fs,
+		Path:    baseFolder.Path + "/" + r.Header.Get("Relative-Path"),
+		Modify:  d.user.Perm.Modify,
+		Expand:  true,
+		Checker: d,
+	})
+	if err != nil {
+		return errToStatus(err), err
+	}
+
+	file.Listing.Sorting = d.user.Sorting
+	file.Listing.ApplySort()
+	return renderJSON(w, r, file)
+})


### PR DESCRIPTION
**Description**
I try to make it easy to share folders.
I think folder should be taken as is and not as a big **zip**.
My goal is to use the **Listing** component which I feed with a **GET** request to `/api/public/resources/`.

I don't see how you fill-up the **Listing** component.
So at this point this is not a working solution.
I have the folder content from the server but I'm not able to show it. 

I would be happy to have some help from you on the **Vue** side.
To fill-up the component and be able to explore it from the public area using the hash.

What do you think?