### PR TITLE
[Frontend] Fix invalid start_url in manifest file.

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -13,7 +13,7 @@
       "type": "image/png"
     }
   ],
-  "start_url": "./",
+  "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#455a64"


### PR DESCRIPTION
As far as I know the invalid start_url format breaks only the "Add to Home Screen" functionality, so it's a really minor change, fixing a nice functionality.

