### PR TITLE
Generate manifest.json dynamically

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -14,7 +14,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/[{[ .StaticURL ]}]/img/icons/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/[{[ .StaticURL ]}]/img/icons/favicon-16x16.png">
   <!-- Add to home screen for Android and modern mobile browsers -->
-  <link rel="manifest" href="/[{[ .StaticURL ]}]/manifest.json">
+  <link rel="manifest" id="manifestPlaceholder">
   <meta name="theme-color" content="#2979ff">
 
   <!-- Add to home screen for Safari on iOS -->
@@ -27,8 +27,38 @@
   <meta name="msapplication-TileImage" content="/[{[ .StaticURL ]}]/img/icons/msapplication-icon-144x144.png">
   <meta name="msapplication-TileColor" content="#2979ff">
 
-  <!-- Inject Some Variables -->
-  <script>window.FileBrowser = JSON.parse(`[{[ .Json ]}]`)</script>
+  <!-- Inject Some Variables and generate the manifest json -->
+  <script>
+    window.FileBrowser = JSON.parse(`[{[ .Json ]}]`);
+    
+    var baseFullURL = window.location.protocol + "//" + window.location.hostname + ":" + window.location.port + window.FileBrowser.BaseURL;
+
+    var dynamicManifest = {
+      "name": window.FileBrowser.Name || 'File Browser',
+      "short_name": window.FileBrowser.Name || 'File Browser',
+      "icons": [
+        {
+          "src": baseFullURL + "/static/img/icons/android-chrome-192x192.png",
+          "sizes": "192x192",
+          "type": "image/png"
+        },
+        {
+          "src": baseFullURL + "/static/img/icons/android-chrome-512x512.png",
+          "sizes": "512x512",
+          "type": "image/png"
+        }
+      ],
+      "start_url": baseFullURL,
+      "display": "standalone",
+      "background_color": "#ffffff",
+      "theme_color": "#455a64"
+    }
+
+    const stringManifest = JSON.stringify(dynamicManifest);
+    const blob = new Blob([stringManifest], {type: 'application/json'});
+    const manifestURL = URL.createObjectURL(blob);
+    document.querySelector('#manifestPlaceholder').setAttribute('href', manifestURL);
+  </script>
 
   <style>
   #loading {

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -31,24 +31,23 @@
   <script>
     window.FileBrowser = JSON.parse(`[{[ .Json ]}]`);
     
-    var baseFullURL = window.location.protocol + "//" + window.location.hostname + ":" + window.location.port + window.FileBrowser.BaseURL;
-
+    var fullStaticURL = window.location.origin + "/" + window.FileBrowser.StaticURL; 
     var dynamicManifest = {
       "name": window.FileBrowser.Name || 'File Browser',
       "short_name": window.FileBrowser.Name || 'File Browser',
       "icons": [
         {
-          "src": baseFullURL + "/static/img/icons/android-chrome-192x192.png",
+          "src": fullStaticURL + "/img/icons/android-chrome-192x192.png",
           "sizes": "192x192",
           "type": "image/png"
         },
         {
-          "src": baseFullURL + "/static/img/icons/android-chrome-512x512.png",
+          "src": fullStaticURL + "/img/icons/android-chrome-512x512.png",
           "sizes": "512x512",
           "type": "image/png"
         }
       ],
-      "start_url": baseFullURL,
+      "start_url": window.location.origin + window.FileBrowser.BaseURL,
       "display": "standalone",
       "background_color": "#ffffff",
       "theme_color": "#455a64"


### PR DESCRIPTION
Generate manifest.json dynamically in index.html so that we can take advantage of the program variables like custom name, base url and static url.

Using this the Add to Home screen functionality should work in standalone display mode in Chrome and Android phones even if a custom base url is set and a reverse proxy server is used.
