### PR TITLE
delete keyup only if no active prompt #895

### DIFF
--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -176,7 +176,8 @@ export default {
           !this.isFiles ||
           this.loading ||
           !this.user.perm.delete ||
-          (this.isListing && this.selectedCount === 0)) return
+          (this.isListing && this.selectedCount === 0) ||
+          this.$store.state.show != null) return
 
         this.$store.commit('showHover', 'delete')
       }


### PR DESCRIPTION
**Description**
Fixes #895. When there are active prompts, and someone pushes `DELETE` key it should not remove file (closing existing prompt and opening new one). Especially when people are renaming file and they press delete.