### PR TITLE
Determine the real IP address of the client for logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.5.0
+	github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	go.etcd.io/bbolt v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce h1:fb190+cK2Xz/dvi9Hv8eCYJYvIGUTN2/KLq1pT6CjEc=
+github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ulikunitz/xz v0.5.6 h1:jGHAfXawEGZQ3blwU5wnWKQJvAraT7Ftq9EXjnXYgt8=

--- a/http/data.go
+++ b/http/data.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/tomasen/realip"
+
 	"github.com/filebrowser/filebrowser/v2/runner"
 	"github.com/filebrowser/filebrowser/v2/settings"
 	"github.com/filebrowser/filebrowser/v2/storage"
@@ -60,7 +62,8 @@ func handle(fn handleFunc, prefix string, storage *storage.Storage, server *sett
 		}
 
 		if status >= 400 || err != nil {
-			log.Printf("%s: %v %s %v", r.URL.Path, status, r.RemoteAddr, err)
+			clientIP := realip.FromRequest(r)
+			log.Printf("%s: %v %s %v", r.URL.Path, status, clientIP, err)
 		}
 	})
 


### PR DESCRIPTION
When running behind a reverse proxy such as nginx, the remote IP as
logged is always that of the proxy. Figuring out the correct address
in this context is a little tricky, hence the following module is
used:

https://github.com/tomasen/realip

Because of the use of a simple module with no further dependencies, only a minor change is needed in `http/data.go`. I'm new to Go, so maybe I'm not doing the canonical thing to handle errors from the new function.

I can't find any issues that this closes, I didn't create an issue because it was easy to fix. I'm currently running this version and it works fine for me.

One side-effect is that the port of the client is not logged now, even when a reverse proxy is not in use. I don't think that information is very useful though - most network services I've seen don't log it.