### PR TITLE
fix(docker): Add mime.types file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM alpine:latest as certs
+FROM alpine:latest as alpine
 RUN apk --update add ca-certificates
+RUN apk --update add mailcap
 
 FROM scratch
-COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=alpine /etc/mime.types /etc/mime.types
 
 VOLUME /srv
 EXPOSE 80


### PR DESCRIPTION
Uses the package `mailcap` from alpine as a source for `/etc/mime.types` which is required by golang.org/pkg/mime on Unix systems.

**Description**
filebrowser rely on https://golang.org/pkg/mime/#TypeByExtension to detect file types (and `http.DetectContentType()` is used as a fallback) but on docker we are missing the `/etc/mime.types` file in order for it to work.

This pull request adds the `mailcap` package to the alpine image
It adds 2 files
 - `/etc/mailcap`
 - `/etc/mime.types`

Only `/etc/mime.types` is useful.
