### PR TITLE
Disable the logout method for authentication methods other than 'json' (currently 'proxy' and 'none'.) Resolves #870.

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -24,7 +24,7 @@
           <span>{{ $t('sidebar.settings') }}</span>
         </router-link>
 
-        <button v-if="!noAuth" @click="logout" class="action" id="logout" :aria-label="$t('sidebar.logout')" :title="$t('sidebar.logout')">
+        <button v-if="authMethod == 'json'" @click="logout" class="action" id="logout" :aria-label="$t('sidebar.logout')" :title="$t('sidebar.logout')">
           <i class="material-icons">exit_to_app</i>
           <span>{{ $t('sidebar.logout') }}</span>
         </button>
@@ -56,7 +56,7 @@
 <script>
 import { mapState, mapGetters } from 'vuex'
 import * as auth from '@/utils/auth'
-import { version, signup, disableExternal, noAuth } from '@/utils/constants'
+import { version, signup, disableExternal, noAuth, authMethod } from '@/utils/constants'
 
 export default {
   name: 'sidebar',
@@ -69,7 +69,8 @@ export default {
     signup: () => signup,
     version: () => version,
     disableExternal: () => disableExternal,
-    noAuth: () => noAuth
+    noAuth: () => noAuth,
+    authMethod: () => authMethod
   },
   methods: {
     help () {

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -8,6 +8,7 @@ const signup = window.FileBrowser.Signup
 const version = window.FileBrowser.Version
 const logoURL = `/${staticURL}/img/logo.svg`
 const noAuth = window.FileBrowser.NoAuth
+const authMethod = window.FileBrowser.AuthMethod
 const loginPage = window.FileBrowser.LoginPage
 
 export {
@@ -20,5 +21,6 @@ export {
   signup,
   version,
   noAuth,
+  authMethod,
   loginPage
 }

--- a/http/static.go
+++ b/http/static.go
@@ -34,6 +34,7 @@ func handleWithStaticData(w http.ResponseWriter, r *http.Request, d *data, box *
 		"StaticURL":       staticURL,
 		"Signup":          d.settings.Signup,
 		"NoAuth":          d.settings.AuthMethod == auth.MethodNoAuth,
+		"AuthMethod":      d.settings.AuthMethod,
 		"LoginPage":       auther.LoginPage(),
 		"CSS":             false,
 		"ReCaptcha":       false,


### PR DESCRIPTION
**Description**

When the authentication method is set to proxy or none, the Logout button is not needed, and only confuses users.

Resolves #870.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [ ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [ ] AVOID breaking the continuous integration build.

**Further comments**
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
