### PR TITLE
Add folder upload

### DIFF
--- a/http/resource.go
+++ b/http/resource.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"path/filepath"
 
 	"github.com/filebrowser/filebrowser/v2/files"
 
@@ -94,6 +95,12 @@ var resourcePostPutHandler = withUser(func(w http.ResponseWriter, r *http.Reques
 	}
 
 	err := d.RunHook(func() error {
+		dir, _ := filepath.Split(r.URL.Path)
+		err := d.user.Fs.MkdirAll(dir, 0775)
+		if err != nil {
+			return err
+		}
+
 		file, err := d.user.Fs.OpenFile(r.URL.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0775)
 		if err != nil {
 			return err


### PR DESCRIPTION
**Description**
Implements ability to upload folders via drag and drop.

**Further comments**
Uses DataTransferItem.webkitGetAsEntry() to recursively retrieve data from directories, allows multiple selection with files and directories. Works with modern browsers, fallback to old DataTransfer API when not compatible.