### PR TITLE
Fix multiple selection

### DIFF
--- a/files/listing.go
+++ b/files/listing.go
@@ -62,11 +62,11 @@ func (l byName) Swap(i, j int) {
 // Treat upper and lower case equally
 func (l byName) Less(i, j int) bool {
 	if l.Items[i].IsDir && !l.Items[j].IsDir {
-		return true
+		return l.Sorting.Asc
 	}
 
 	if !l.Items[i].IsDir && l.Items[j].IsDir {
-		return false
+		return !l.Sorting.Asc
 	}
 
 	return natural.Less(strings.ToLower(l.Items[j].Name), strings.ToLower(l.Items[i].Name))

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -129,7 +129,7 @@ export default {
         return
       }
 
-      if (event.shiftKey && this.selected.length === 1) {
+      if (event.shiftKey) {
         let fi = 0
         let la = 0
 


### PR DESCRIPTION
**Description**
Fixes multiple selection when pressing shift and selections between folders and files.

**Further comments**
- Removed clause of shift selection only when one file is selected, allowing to make shift key selections with multiple files selected.
- Make sorting aways list folders first, making the shift selection between folders and files behave properly with descending order.