### PR TITLE
Small fixes

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -132,7 +132,7 @@ export default {
         return
       }
 
-      if (event.shiftKey) {
+      if (event.shiftKey && this.selected.length > 0) {
         let fi = 0
         let la = 0
 
@@ -145,7 +145,9 @@ export default {
         }
 
         for (; fi <= la; fi++) {
-          this.addSelected(fi)
+          if (this.$store.state.selected.indexOf(fi) == -1) {
+            this.addSelected(fi)
+          }
         }
 
         return

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -12,10 +12,6 @@ export function parseToken (token) {
 
   const data = JSON.parse(Base64.decode(parts[1]))
 
-  if (Math.round(new Date().getTime() / 1000) > data.exp) {
-    throw new Error('token expired')
-  }
-
   localStorage.setItem('jwt', token)
   store.commit('setJWT', token)
   store.commit('setUser', data.user)

--- a/http/resource.go
+++ b/http/resource.go
@@ -93,6 +93,11 @@ var resourcePostPutHandler = withUser(func(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	action := "upload"
+	if r.Method == http.MethodPut {
+		action = "save"
+	}
+
 	err := d.RunHook(func() error {
 		dir, _ := filepath.Split(r.URL.Path)
 		err := d.user.Fs.MkdirAll(dir, 0775)
@@ -120,7 +125,7 @@ var resourcePostPutHandler = withUser(func(w http.ResponseWriter, r *http.Reques
 		etag := fmt.Sprintf(`"%x%x"`, info.ModTime().UnixNano(), info.Size())
 		w.Header().Set("ETag", etag)
 		return nil
-	}, "upload", r.URL.Path, "", d.user)
+	}, action, r.URL.Path, "", d.user)
 
 	return errToStatus(err), err
 })


### PR DESCRIPTION
### Shift multiple selection count
- When using multiple file selection with shift selection the counter will re add already selected items, making counter show wrong values. Only no selected files should be added to the counter.
- The logic of shift key selection is being executed even with no file selected. Logic should runs only when there is a selection.

### Frontend token validation #638
- A valid token can be considerated invalid if theres a current time disparity between the server and the client. Since the token is validated in all requests by backend there is no need of frontend validation.

### Save event hook #696
- A hook for save event is missing on backend. Backend resource handler should trigger save hook when receiving requests with PUT method used by editor on frontend.