### PR TITLE
Upload progress

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8802,6 +8802,11 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
     "lodash.transform": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "clipboard": "^2.0.4",
     "js-base64": "^2.5.1",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.throttle": "^4.1.1",
     "material-design-icons": "^3.0.1",
     "moment": "^2.24.0",
     "normalize.css": "^8.0.1",


### PR DESCRIPTION
This new upload progress calculation fixes the following issues:
### Non linear progress
- On a batch of multiples files, the progress bar increases faster when is uploading a small file. The progress should increase linearly, based on size of all files being updated.

### Inconsistently progress #990
- Every time user uploads a file, a new calculation is made based on the current batch of files, ignoring files that was being uploaded before. Calculation should be done with information of all files being upload.

### Performance
- Events from files being uploaded can be heavily expensive, every upload will trigger multiple events every second. Using throttle is possible to limit the execution of some functions.