### PR TITLE
Added preview bypass for .gif files

### DIFF
--- a/http/preview.go
+++ b/http/preview.go
@@ -81,13 +81,13 @@ func handleImagePreview(w http.ResponseWriter, r *http.Request, file *files.File
 	defer fd.Close()
 
 	if format == imaging.GIF && size == sizeBig {
-		g, err := gif.DecodeAll(fd)
-		if err != nil {
-			return errToStatus(err), err
+		g, gerr := gif.DecodeAll(fd)
+		if gerr != nil {
+			return errToStatus(gerr), err
 		}
 
 		if gif.EncodeAll(w, g) != nil {
-			return errToStatus(err), err
+			return errToStatus(gerr), err
 		}
 		return 0, nil
 	}

--- a/http/preview.go
+++ b/http/preview.go
@@ -66,8 +66,7 @@ func handleImagePreview(w http.ResponseWriter, r *http.Request, file *files.File
 	defer fd.Close()
 
 	if format == imaging.GIF && size == sizeBig {
-		_, err := rawFileHandler(w, r, file)
-		if err != nil {
+		if _, err := rawFileHandler(w, r, file); err != nil { //nolint: govet
 			return errToStatus(err), err
 		}
 		return 0, nil

--- a/http/preview.go
+++ b/http/preview.go
@@ -3,6 +3,7 @@ package http
 import (
 	"fmt"
 	"image"
+	"image/gif"
 	"net/http"
 
 	"github.com/disintegration/imaging"
@@ -78,6 +79,18 @@ func handleImagePreview(w http.ResponseWriter, r *http.Request, file *files.File
 		return errToStatus(err), err
 	}
 	defer fd.Close()
+
+	if format == imaging.GIF && size == sizeBig {
+		g, err := gif.DecodeAll(fd)
+		if err != nil {
+			return errToStatus(err), err
+		}
+
+		if gif.EncodeAll(w, g) != nil {
+			return errToStatus(err), err
+		}
+		return 0, nil
+	}
 
 	img, err := imaging.Decode(fd, imaging.AutoOrientation(true))
 	if err != nil {


### PR DESCRIPTION
This PR adds a bypass for the preview generation of GIF files. I noticed gif files use the default gif.Encode function which only processes the first frame, making the whole GIF purpose useless. When previewing gif files right now, they're not animated. :frowning_face: 

The bypass is only activated for big previews since I thought a bunch of small gif files in a folder view looks silly and is probably not too keen on performance. Also the previews where streched to squares and I didn't want to go down that rabbit hole.

I literally learned Go for this within 2 hours but got it working. After all it's just a simple bypass using another function for gifs. Any feedback and suggestions are greatly appreciated.

I also thought about incorporating the process in the preexisting imgProcessor but it takes multiple seconds(!) to process all frames. I think just handing it out as is, is the better solution here. When you handle gif files you know they're not optimized for size.

Also, maybe this behavior can be hidden behind a settings toggle if desirable. I think previewing gifs in big mode should be animated by default.
