### PR TITLE
Some Fixes

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -16,4 +16,5 @@ var (
 	ErrInvalidAuthMethod    = errors.New("invalid auth method")
 	ErrPermissionDenied     = errors.New("permission denied")
 	ErrInvalidRequestParams = errors.New("invalid request params")
+	ErrSourceIsParent       = errors.New("source is parent")
 )

--- a/frontend/src/api/files.js
+++ b/frontend/src/api/files.js
@@ -43,7 +43,7 @@ async function resourceAction (url, method, content) {
   const res = await fetchURL(`/api/resources${url}`, opts)
 
   if (res.status !== 200) {
-    throw new Error(res.responseText)
+    throw new Error(await res.text())
   } else {
     return res
   }

--- a/frontend/src/components/files/Listing.vue
+++ b/frontend/src/components/files/Listing.vue
@@ -418,12 +418,13 @@ export default {
           confirm: (event) => {
             event.preventDefault()
             this.$store.commit('closeHovers')
-            this.handleFiles(files, path, true)
+            upload.handleFiles(files, path, true)
           }
         })
 
         return
       }
+
       upload.handleFiles(files, path)
     },
     resetOpacity () {

--- a/frontend/src/components/files/Listing.vue
+++ b/frontend/src/components/files/Listing.vue
@@ -8,9 +8,7 @@
     <input style="display:none" type="file" id="upload-folder-input" @change="uploadInput($event)" webkitdirectory multiple>
   </div>
   <div v-else id="listing"
-    :class="user.viewMode"
-    @dragenter="dragEnter"
-    @dragend="dragEnd">
+    :class="user.viewMode">
     <div>
       <div class="item header">
         <div></div>
@@ -99,7 +97,8 @@ export default {
   components: { Item },
   data: function () {
     return {
-      showLimit: 50
+      showLimit: 50,
+      dragCounter: 0
     }
   },
   computed: {
@@ -171,6 +170,8 @@ export default {
     window.addEventListener('resize', this.resizeEvent)
     window.addEventListener('scroll', this.scrollEvent)
     document.addEventListener('dragover', this.preventDefault)
+    document.addEventListener('dragenter', this.dragEnter)
+    document.addEventListener('dragleave', this.dragLeave)
     document.addEventListener('drop', this.drop)
   },
   beforeDestroy () {
@@ -179,6 +180,8 @@ export default {
     window.removeEventListener('resize', this.resizeEvent)
     window.removeEventListener('scroll', this.scrollEvent)
     document.removeEventListener('dragover', this.preventDefault)
+    document.removeEventListener('dragenter', this.dragEnter)
+    document.removeEventListener('dragleave', this.dragLeave)
     document.removeEventListener('drop', this.drop)
   },
   methods: {
@@ -326,6 +329,8 @@ export default {
       }
     },
     dragEnter () {
+      this.dragCounter++
+
       // When the user starts dragging an item, put every
       // file on the listing with 50% opacity.
       let items = document.getElementsByClassName('item')
@@ -334,11 +339,16 @@ export default {
         file.style.opacity = 0.5
       })
     },
-    dragEnd () {
-      this.resetOpacity()
+    dragLeave () {
+      this.dragCounter--
+
+      if (this.dragCounter == 0) {
+        this.resetOpacity()
+      }
     },
     drop: async function (event) {
       event.preventDefault()
+      this.dragCounter = 0
       this.resetOpacity()
 
       let dt = event.dataTransfer

--- a/frontend/src/components/prompts/Upload.vue
+++ b/frontend/src/components/prompts/Upload.vue
@@ -27,9 +27,11 @@ export default {
   name: 'upload',
   methods: {
     uploadFile: function () {
+      document.getElementById('upload-input').value = ''
       document.getElementById('upload-input').click()
     },
     uploadFolder: function () {
+      document.getElementById('upload-folder-input').value = ''
       document.getElementById('upload-folder-input').click()
     }
   }

--- a/http/resource.go
+++ b/http/resource.go
@@ -168,7 +168,7 @@ var resourcePatchHandler = withUser(func(w http.ResponseWriter, r *http.Request,
 				break
 			}
 			new := fmt.Sprintf("%s(%d)%s", base, counter, ext)
-			dst = filepath.Join(dir, new)
+			dst = filepath.ToSlash(dir) + new
 			counter++
 		}
 	}


### PR DESCRIPTION
### Renaming uses OS path separator
The renaming procedure invokes Split() and Join() methods, it uses path separator that can be different for each OS. Since filebrowser fileutils functions uses "/" for path separator, the renamed file path can have inconsistent path separator, which can cause issues. On windows systems the rename procedure causes error. The solution is to have paths with the "/" separator, achieved by using ToSlash() and using string concatenation instead of Join().

### Parent directory copy verification
Copying a directory when the source is parent of the destination one, causes a loop ended by multiple recursive copies of the source directory and a backend error. Verification is needed when copying, error should be returned when the source is parent from the destination.

### API Fetch not showing errors
Some frontend errors are showing an Object message, without any useful information. The fetch() function returns object with text(), instead of XMLHttpRequest responseText attribute. To get the error message, the text() method should be used on fetch() responses.

### Opacity not resetting on drag end
The dragEnd is not being called, which causes the opacity to not reset after a drag. The dragenter and dragleave is required for checking when the drag starts and when the drags ends. Since the event is triggered when dragging over the ListingItem, a counter is needed to know when the reset should be called.