### PR TITLE
Use a valid Content-Type when extracting token 

### DIFF
--- a/http/auth.go
+++ b/http/auth.go
@@ -189,7 +189,7 @@ func printToken(w http.ResponseWriter, _ *http.Request, d *data, user *users.Use
 		return http.StatusInternalServerError, err
 	}
 
-	w.Header().Set("Content-Type", "cty")
+	w.Header().Set("Content-Type", "text/plain")
 	if _, err := w.Write([]byte(signed)); err != nil {
 		return http.StatusInternalServerError, err
 	}


### PR DESCRIPTION
I'm calling a POST request `/api/login` with JSON payload (username, password) to get a valid JWT.
When I try to parse the request I get an exception `Bad Content-Type header: cty`. I cannot manually replace this header due to engine limitation ([ktor](https://ktor.io/)), so this is the only solution to my issue.

CI build OK: [https://app.circleci.com/pipelines/github/DVDAndroid/filebrowser](https://app.circleci.com/pipelines/github/DVDAndroid/filebrowser?branch=DVDAndroid-patch-1)
Docker images: [https://hub.docker.com/repository/docker/dvdandroid/filebrowser](https://hub.docker.com/repository/docker/dvdandroid/filebrowser)
Content-Type header standard: [https://www.w3.org/Protocols/rfc1341/4_Content-Type.html](https://www.w3.org/Protocols/rfc1341/4_Content-Type.html)

Sincerely I don't know why content type is `cty` 