### PR TITLE
Preview mobile dropdown and image size button

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <header v-if="!isEditor">
+  <header v-if="!isEditor && !isPreview">
     <div>
       <button @click="openSidebar" :aria-label="$t('buttons.toggleSidebar')" :title="$t('buttons.toggleSidebar')" class="action">
         <i class="material-icons">menu</i>
@@ -108,6 +108,7 @@ export default {
       'selectedCount',
       'isFiles',
       'isEditor',
+      'isPreview',
       'isListing',
       'isLogged'
     ]),

--- a/frontend/src/components/buttons/PreviewSize.vue
+++ b/frontend/src/components/buttons/PreviewSize.vue
@@ -1,0 +1,22 @@
+<template>
+  <button :title="$t('buttons.info')" :aria-label="$t('buttons.info')" class="action" @click="$emit('change-size')">
+    <i class="material-icons">{{ this.icon }}</i>
+    <span>{{ $t('buttons.info') }}</span>
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'preview-size-button',
+  props: [ 'size' ],
+  computed: {
+    icon () {
+      if (this.size) {
+        return 'photo_size_select_large'
+      }
+
+      return 'hd'
+    }
+  }
+}
+</script>

--- a/frontend/src/components/files/ExtendedImage.vue
+++ b/frontend/src/components/files/ExtendedImage.vue
@@ -77,6 +77,13 @@ export default {
     window.removeEventListener('resize', this.onResize)
     document.removeEventListener('mouseup', this.onMouseUp)
   },
+  watch: {
+    src: function () {
+      this.scale = 1
+      this.setZoom()
+      this.setCenter()
+    }
+  },
   methods: {
     onLoad() {
       let img = this.$refs.imgex

--- a/frontend/src/components/files/Preview.vue
+++ b/frontend/src/components/files/Preview.vue
@@ -9,6 +9,7 @@
         <span>{{ this.name }}</span>
       </div>
 
+      <preview-size-button v-if="isResizeEnabled && this.req.type === 'image'" @change-size="toggleSize" v-bind:size="fullSize" :disabled="loading"></preview-size-button>
       <button @click="openMore" id="more" :aria-label="$t('buttons.more')" :title="$t('buttons.more')" class="action">
         <i class="material-icons">more_vert</i>
       </button>
@@ -65,8 +66,9 @@
 <script>
 import { mapState } from 'vuex'
 import url from '@/utils/url'
-import { baseURL } from '@/utils/constants'
+import { baseURL, resizePreview } from '@/utils/constants'
 import { files as api } from '@/api'
+import PreviewSizeButton from '@/components/buttons/PreviewSize'
 import InfoButton from '@/components/buttons/Info'
 import DeleteButton from '@/components/buttons/Delete'
 import RenameButton from '@/components/buttons/Rename'
@@ -83,6 +85,7 @@ const mediaTypes = [
 export default {
   name: 'preview',
   components: {
+    PreviewSizeButton,
     InfoButton,
     DeleteButton,
     RenameButton,
@@ -95,7 +98,8 @@ export default {
       nextLink: '',
       listing: null,
       name: '',
-      subtitles: []
+      subtitles: [],
+      fullSize: false
     }
   },
   computed: {
@@ -110,7 +114,7 @@ export default {
       return `${baseURL}/api/raw${url.encodePath(this.req.path)}?auth=${this.jwt}`
     },
     previewUrl () {
-      if (this.req.type === 'image') {
+      if (this.req.type === 'image' && !this.fullSize) {
         return `${baseURL}/api/preview/big${url.encodePath(this.req.path)}?auth=${this.jwt}`
       }
       return `${baseURL}/api/raw${url.encodePath(this.req.path)}?auth=${this.jwt}`
@@ -120,6 +124,9 @@ export default {
     },
     showMore () {
       return this.$store.state.show === 'more'
+    },
+    isResizeEnabled () {
+      return resizePreview
     }
   },
   watch: {
@@ -206,6 +213,9 @@ export default {
     },
     resetPrompts () {
       this.$store.commit('closeHovers')
+    },
+    toggleSize () {
+      this.fullSize = !this.fullSize
     }
   }
 }

--- a/frontend/src/components/files/Preview.vue
+++ b/frontend/src/components/files/Preview.vue
@@ -9,10 +9,16 @@
         <span>{{ this.name }}</span>
       </div>
 
-      <rename-button :disabled="loading" v-if="user.perm.rename"></rename-button>
-      <delete-button :disabled="loading" v-if="user.perm.delete"></delete-button>
-      <download-button :disabled="loading" v-if="user.perm.download"></download-button>
-      <info-button :disabled="loading"></info-button>
+      <button @click="openMore" id="more" :aria-label="$t('buttons.more')" :title="$t('buttons.more')" class="action">
+        <i class="material-icons">more_vert</i>
+      </button>
+
+      <div id="dropdown" :class="{ active : showMore }">
+        <rename-button :disabled="loading" v-if="user.perm.rename"></rename-button>
+        <delete-button :disabled="loading" v-if="user.perm.delete"></delete-button>
+        <download-button :disabled="loading" v-if="user.perm.download"></download-button>
+        <info-button :disabled="loading"></info-button>
+      </div>
     </div>
 
     <div class="loading" v-if="loading">
@@ -51,6 +57,8 @@
         </a>
       </div>
     </template>
+
+    <div v-show="showMore" @click="resetPrompts" class="overlay"></div>
   </div>
 </template>
 
@@ -109,6 +117,9 @@ export default {
     },
     raw () {
       return `${this.previewUrl}&inline=true`
+    },
+    showMore () {
+      return this.$store.state.show === 'more'
     }
   },
   watch: {
@@ -189,6 +200,12 @@ export default {
 
         return
       }
+    },
+    openMore () {
+      this.$store.commit('showHover', 'more')
+    },
+    resetPrompts () {
+      this.$store.commit('closeHovers')
     }
   }
 }

--- a/frontend/src/store/getters.js
+++ b/frontend/src/store/getters.js
@@ -3,6 +3,7 @@ const getters = {
   isFiles: state => !state.loading && state.route.name === 'Files',
   isListing: (state, getters) => getters.isFiles && state.req.isDir,
   isEditor: (state, getters) => getters.isFiles && (state.req.type === 'text' || state.req.type === 'textImmutable'),
+  isPreview: state => state.previewMode,
   selectedCount: state => state.selected.length,
   progress : state => {
     if (state.upload.progress.length == 0) {

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -12,6 +12,7 @@ const authMethod = window.FileBrowser.AuthMethod
 const loginPage = window.FileBrowser.LoginPage
 const theme = window.FileBrowser.Theme
 const enableThumbs = window.FileBrowser.EnableThumbs
+const resizePreview = window.FileBrowser.ResizePreview
 
 export {
   name,
@@ -26,5 +27,6 @@ export {
   authMethod,
   loginPage,
   theme,
-  enableThumbs
+  enableThumbs,
+  resizePreview
 }

--- a/http/static.go
+++ b/http/static.go
@@ -40,6 +40,7 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, box *
 		"ReCaptcha":       false,
 		"Theme":           d.settings.Branding.Theme,
 		"EnableThumbs":    d.server.EnableThumbnails,
+		"ResizePreview":   d.server.ResizePreview,
 	}
 
 	if d.settings.Branding.Files != "" {


### PR DESCRIPTION
### Preview mobile dropdown
The preview header do not have dropdown for mobile devices, which can cause issues with small screens. It should behave like the file listing header, with its own dropdown.

### Preview image size button
Images in the preview have a fixed size of 1080px, causing bigger images to have a fraction of its size. Having a button for toggling the image size allows users to view the original image.