### PR TITLE
Hiddenfiles

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -309,6 +309,7 @@ func quickSetup(flags *pflag.FlagSet, d pythonData) {
 				Share:    true,
 				Download: true,
 			},
+			ShowHidden: true,
 		},
 	}
 

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -58,7 +58,8 @@
     "size": "Size",
     "sortByName": "Sort by name",
     "sortBySize": "Sort by size",
-    "sortByLastModified": "Sort by last modified"
+    "sortByLastModified": "Sort by last modified",
+    "showHiddenFiles": "Show hidden files"
   },
   "help": {
     "click": "select file or directory",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -58,8 +58,7 @@
     "size": "Size",
     "sortByName": "Sort by name",
     "sortBySize": "Sort by size",
-    "sortByLastModified": "Sort by last modified",
-    "showHiddenFiles": "Show hidden files"
+    "sortByLastModified": "Sort by last modified"
   },
   "help": {
     "click": "select file or directory",
@@ -174,6 +173,7 @@
     "globalRules": "This is a global set of allow and disallow rules. They apply to every user. You can define specific rules on each user's settings to override this ones.",
     "allowSignup": "Allow users to signup",
     "createUserDir": "Auto create user home dir while adding new user",
+    "showHidden": "Show hidden files",
     "insertRegex": "Insert regex expression",
     "insertPath": "Insert the path",
     "userUpdated": "User updated!",

--- a/frontend/src/store/getters.js
+++ b/frontend/src/store/getters.js
@@ -13,7 +13,6 @@ const getters = {
     let sum = state.upload.progress.reduce((acc, val) => acc + val)
     return Math.ceil(sum / state.upload.size * 100);
   },
-  getShowHidden: state => state.showHidden
 }
 
 export default getters

--- a/frontend/src/store/getters.js
+++ b/frontend/src/store/getters.js
@@ -12,7 +12,8 @@ const getters = {
 
     let sum = state.upload.progress.reduce((acc, val) => acc + val)
     return Math.ceil(sum / state.upload.size * 100);
-  }
+  },
+  getShowHidden: state => state.showHidden
 }
 
 export default getters

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -24,7 +24,8 @@ const state = {
   showShell: false,
   showMessage: null,
   showConfirm: null,
-  previewMode: false
+  previewMode: false,
+  showHidden: true
 }
 
 export default new Vuex.Store({

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -24,8 +24,7 @@ const state = {
   showShell: false,
   showMessage: null,
   showConfirm: null,
-  previewMode: false,
-  showHidden: true
+  previewMode: false
 }
 
 export default new Vuex.Store({

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -87,9 +87,6 @@ const mutations = {
   setPreviewMode(state, value) {
     state.previewMode = value
   },
-  setShowHidden: (state, value) => {
-    state.showHidden = value
-  }
 }
 
 export default mutations

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -86,6 +86,9 @@ const mutations = {
   },
   setPreviewMode(state, value) {
     state.previewMode = value
+  },
+  setShowHidden: (state, value) => {
+    state.showHidden = value
   }
 }
 

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -10,13 +10,6 @@
         <router-link :to="link.url">{{ link.name }}</router-link>
       </span>
 
-      <span style="margin-left:auto;">
-        <input 
-          type="checkbox" 
-          v-model="showHidden">
-        <span>{{ $t('files.showHiddenFiles') }}</span>
-      </span>
-
     </div>
 
     <div v-if="error">
@@ -189,7 +182,7 @@ export default {
           return
         }
 
-        if (res.isDir && !this.showHidden) {
+        if (res.isDir && !this.user.showHidden) {
           res = pruneHiddenFiles(res)
         }
 

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -9,6 +9,12 @@
         <span class="chevron"><i class="material-icons">keyboard_arrow_right</i></span>
         <router-link :to="link.url">{{ link.name }}</router-link>
       </span>
+
+      <span style="margin-left:auto;">
+        <input type="checkbox">
+        Show hidden files
+      </span>
+
     </div>
 
     <div v-if="error">
@@ -38,6 +44,27 @@ import { mapGetters, mapState, mapMutations } from 'vuex'
 
 function clean (path) {
   return path.endsWith('/') ? path.slice(0, -1) : path
+}
+
+// pruneHiddenFiles removes files that start
+// with a dot and update numDirs and numFiles
+function pruneHiddenFiles(data) {
+  let numDirs = 0
+  let numFiles = 0
+  data.items = data.items.filter((item) => {
+    if (item.name[0] == ".") {
+      return false
+    }
+    if (item.isDir) {
+      numDirs++
+    } else {
+      numFiles++
+    }
+    return true
+  })
+  data.numDirs = numDirs
+  data.numFiles = numFiles
+  return data
 }
 
 export default {
@@ -145,10 +172,15 @@ export default {
       if (url[0] !== '/') url = '/' + url
 
       try {
-        const res = await api.fetch(url)
+        let res = await api.fetch(url)
 
         if (clean(res.path) !== clean(`/${this.$route.params.pathMatch}`)) {
           return
+        }
+
+        let showHiddenFiles = false
+        if (!showHiddenFiles) {
+          res = pruneHiddenFiles(res)
         }
 
         this.$store.commit('updateRequest', res)

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -179,7 +179,7 @@ export default {
         }
 
         let showHiddenFiles = false
-        if (!showHiddenFiles) {
+        if (res.isDir && !showHiddenFiles) {
           res = pruneHiddenFiles(res)
         }
 

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -11,8 +11,10 @@
       </span>
 
       <span style="margin-left:auto;">
-        <input type="checkbox">
-        Show hidden files
+        <input 
+          type="checkbox" 
+          v-model="showHidden">
+        <span>{{ $t('files.showHiddenFiles') }}</span>
       </span>
 
     </div>
@@ -82,7 +84,7 @@ export default {
       'selectedCount',
       'isListing',
       'isEditor',
-      'isFiles'
+      'isFiles',
     ]),
     ...mapState([
       'req',
@@ -127,6 +129,15 @@ export default {
       }
 
       return breadcrumbs
+    },
+    showHidden: {
+      get: function () {
+        return this.$store.getters.getShowHidden
+      },
+      set: function (val) {
+        this.$store.commit('setShowHidden', val)
+        this.fetchData()
+      }
     }
   },
   data: function () {
@@ -178,8 +189,7 @@ export default {
           return
         }
 
-        let showHiddenFiles = false
-        if (res.isDir && !showHiddenFiles) {
+        if (res.isDir && !this.showHidden) {
           res = pruneHiddenFiles(res)
         }
 

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -9,7 +9,6 @@
         <span class="chevron"><i class="material-icons">keyboard_arrow_right</i></span>
         <router-link :to="link.url">{{ link.name }}</router-link>
       </span>
-
     </div>
 
     <div v-if="error">

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -123,15 +123,6 @@ export default {
 
       return breadcrumbs
     },
-    showHidden: {
-      get: function () {
-        return this.$store.getters.getShowHidden
-      },
-      set: function (val) {
-        this.$store.commit('setShowHidden', val)
-        this.fetchData()
-      }
-    }
   },
   data: function () {
     return {

--- a/frontend/src/views/settings/Profile.vue
+++ b/frontend/src/views/settings/Profile.vue
@@ -6,6 +6,9 @@
       </div>
 
       <div class="card-content">
+
+        <p><input type="checkbox" v-model="showHidden"> {{ $t('settings.showHidden') }}</p>
+
         <h3>{{ $t('settings.language') }}</h3>
         <languages class="input input--block" :locale.sync="locale"></languages>
       </div>
@@ -67,6 +70,7 @@ export default {
   },
   created () {
     this.locale = this.user.locale
+    this.showHidden = this.user.showHidden
   },
   methods: {
     ...mapMutations([ 'updateUser' ]),
@@ -90,8 +94,8 @@ export default {
       event.preventDefault()
 
       try {
-        const data = { id: this.user.id, locale: this.locale }
-        await api.update(data, ['locale'])
+        const data = { id: this.user.id, locale: this.locale, showHidden: this.showHidden }
+        await api.update(data, ['locale', 'showHidden'])
         this.updateUser(data)
         this.$showSuccess(this.$t('settings.settingsUpdated'))
       } catch (e) {

--- a/http/auth.go
+++ b/http/auth.go
@@ -26,6 +26,7 @@ type userInfo struct {
 	Perm         users.Permissions `json:"perm"`
 	Commands     []string          `json:"commands"`
 	LockPassword bool              `json:"lockPassword"`
+	ShowHidden   bool              `json:"showHidden"`
 }
 
 type authToken struct {
@@ -175,6 +176,7 @@ func printToken(w http.ResponseWriter, _ *http.Request, d *data, user *users.Use
 			Perm:         user.Perm,
 			LockPassword: user.LockPassword,
 			Commands:     user.Commands,
+			ShowHidden:   user.ShowHidden,
 		},
 		StandardClaims: jwt.StandardClaims{
 			IssuedAt:  time.Now().Unix(),

--- a/settings/defaults.go
+++ b/settings/defaults.go
@@ -8,12 +8,13 @@ import (
 // UserDefaults is a type that holds the default values
 // for some fields on User.
 type UserDefaults struct {
-	Scope    string            `json:"scope"`
-	Locale   string            `json:"locale"`
-	ViewMode users.ViewMode    `json:"viewMode"`
-	Sorting  files.Sorting     `json:"sorting"`
-	Perm     users.Permissions `json:"perm"`
-	Commands []string          `json:"commands"`
+	Scope      string            `json:"scope"`
+	Locale     string            `json:"locale"`
+	ViewMode   users.ViewMode    `json:"viewMode"`
+	Sorting    files.Sorting     `json:"sorting"`
+	Perm       users.Permissions `json:"perm"`
+	Commands   []string          `json:"commands"`
+	ShowHidden bool              `json:"showHidden"`
 }
 
 // Apply applies the default options to a user.
@@ -24,4 +25,5 @@ func (d *UserDefaults) Apply(u *users.User) {
 	u.Perm = d.Perm
 	u.Sorting = d.Sorting
 	u.Commands = d.Commands
+	u.ShowHidden = d.ShowHidden
 }

--- a/users/users.go
+++ b/users/users.go
@@ -33,6 +33,7 @@ type User struct {
 	Sorting      files.Sorting `json:"sorting"`
 	Fs           afero.Fs      `json:"-" yaml:"-"`
 	Rules        []rules.Rule  `json:"rules"`
+	ShowHidden   bool          `json:"showHidden"`
 }
 
 // GetRules implements rules.Provider.


### PR DESCRIPTION
This PR addresses https://github.com/filebrowser/filebrowser/issues/1084 through the following:

Frontend:
* Added a checkbox in Profile Settings to toggle show/hide dotfiles at the user level
* When the files api is called on a directory and `showHidden` is `true`, all directory entries that begin with a `.` are prune from the api results.

Backend:
* Added `showHidden` to the `userDefaults` and `userInfo`
* This attribute defaults to false (by default users do not see hidden files) and is sent along with other `userInfo` from the auth endpoint to the frontend. 

@o1egl please review :)