### PR TITLE
Feature/disable exec

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -140,6 +140,7 @@ func printSettings(ser *settings.Server, set *settings.Settings, auther auth.Aut
 	fmt.Fprintf(w, "\tAddress:\t%s\n", ser.Address)
 	fmt.Fprintf(w, "\tTLS Cert:\t%s\n", ser.TLSCert)
 	fmt.Fprintf(w, "\tTLS Key:\t%s\n", ser.TLSKey)
+	fmt.Fprintf(w, "\tExec Enabled:\t%t\n", ser.EnableExec)
 	fmt.Fprintln(w, "\nDefaults:")
 	fmt.Fprintf(w, "\tScope:\t%s\n", set.Defaults.Scope)
 	fmt.Fprintf(w, "\tLocale:\t%s\n", set.Defaults.Locale)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,6 +64,7 @@ func addServerFlags(flags *pflag.FlagSet) {
 	flags.Int("img-processors", 4, "image processors count")
 	flags.Bool("disable-thumbnails", false, "disable image thumbnails")
 	flags.Bool("disable-preview-resize", false, "disable resize of image previews")
+	flags.Bool("disable-exec", false, "disables Command Runner feature")
 }
 
 var rootCmd = &cobra.Command{
@@ -240,6 +241,9 @@ func getRunParams(flags *pflag.FlagSet, st *storage.Storage) *settings.Server {
 
 	_, disablePreviewResize := getParamB(flags, "disable-preview-resize")
 	server.ResizePreview = !disablePreviewResize
+
+	_, disableExec := getParamB(flags, "disable-exec")
+	server.EnableExec = !disableExec
 
 	return server
 }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -13,7 +13,7 @@
 
   <link rel="icon" type="image/png" sizes="32x32" href="[{[ .StaticURL ]}]/img/icons/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="[{[ .StaticURL ]}]/img/icons/favicon-16x16.png">
-  
+
   <!-- Add to home screen for Android and modern mobile browsers -->
   <link rel="manifest" id="manifestPlaceholder" crossorigin="use-credentials">
   <meta name="theme-color" content="#2979ff">
@@ -31,7 +31,7 @@
   <!-- Inject Some Variables and generate the manifest json -->
   <script>
     window.FileBrowser = JSON.parse(`[{[ .Json ]}]`);
-    
+
     var fullStaticURL = window.location.origin + window.FileBrowser.StaticURL;
     var dynamicManifest = {
       "name": window.FileBrowser.Name || 'File Browser',

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -37,7 +37,7 @@
             <delete-button v-show="showDeleteButton"></delete-button>
           </div>
 
-          <shell-button v-show="user.perm.execute" />
+          <shell-button v-if="isExecEnabled && user.perm.execute" />
           <switch-button v-show="isListing"></switch-button>
           <download-button v-show="showDownloadButton"></download-button>
           <upload-button v-show="showUpload"></upload-button>
@@ -68,7 +68,7 @@ import CopyButton from './buttons/Copy'
 import ShareButton from './buttons/Share'
 import ShellButton from './buttons/Shell'
 import {mapGetters, mapState} from 'vuex'
-import { logoURL } from '@/utils/constants'
+import { logoURL, enableExec } from '@/utils/constants'
 import * as api from '@/api'
 import buttons from '@/utils/buttons'
 
@@ -120,6 +120,7 @@ export default {
       'multiple'
     ]),
     logoURL: () => logoURL,
+    isExecEnabled: () => enableExec,
     isMobile () {
       return this.width <= 736
     },

--- a/frontend/src/components/settings/Permissions.vue
+++ b/frontend/src/components/settings/Permissions.vue
@@ -9,13 +9,14 @@
     <p><input type="checkbox" :disabled="admin" v-model="perm.delete"> {{ $t('settings.perm.delete') }}</p>
     <p><input type="checkbox" :disabled="admin" v-model="perm.download"> {{ $t('settings.perm.download') }}</p>
     <p><input type="checkbox" :disabled="admin" v-model="perm.modify"> {{ $t('settings.perm.modify') }}</p>
-    <p><input type="checkbox" :disabled="admin" v-model="perm.execute"> {{ $t('settings.perm.execute') }}</p>
+    <p v-if="isExecEnabled"><input type="checkbox" :disabled="admin" v-model="perm.execute"> {{ $t('settings.perm.execute') }}</p>
     <p><input type="checkbox" :disabled="admin" v-model="perm.rename"> {{ $t('settings.perm.rename') }}</p>
     <p><input type="checkbox" :disabled="admin" v-model="perm.share"> {{ $t('settings.perm.share') }}</p>
   </div>
 </template>
 
 <script>
+import { enableExec } from '@/utils/constants'
 export default {
   name: 'permissions',
   props: ['perm'],
@@ -33,7 +34,8 @@ export default {
 
         this.perm.admin = value
       }
-    }
+    },
+    isExecEnabled: () => enableExec
   }
 }
 </script>

--- a/frontend/src/components/settings/UserForm.vue
+++ b/frontend/src/components/settings/UserForm.vue
@@ -25,7 +25,7 @@
     </p>
 
     <permissions :perm.sync="user.perm" />
-    <commands :commands.sync="user.commands" />
+    <commands v-if="isExecEnabled" :commands.sync="user.commands" />
 
     <div v-if="!isDefault">
       <h3>{{ $t('settings.rules') }}</h3>
@@ -40,6 +40,7 @@ import Languages from './Languages'
 import Rules from './Rules'
 import Permissions from './Permissions'
 import Commands from './Commands'
+import { enableExec } from '@/utils/constants'
 
 export default {
   name: 'user',
@@ -53,7 +54,8 @@ export default {
   computed: {
     passwordPlaceholder () {
       return this.isNew ? '' : this.$t('settings.avoidChanges')
-    }
+    },
+    isExecEnabled: () => enableExec
   },
   watch: {
     'user.perm.admin': function () {

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -13,6 +13,7 @@ const loginPage = window.FileBrowser.LoginPage
 const theme = window.FileBrowser.Theme
 const enableThumbs = window.FileBrowser.EnableThumbs
 const resizePreview = window.FileBrowser.ResizePreview
+const enableExec = window.FileBrowser.EnableExec
 
 export {
   name,
@@ -28,5 +29,6 @@ export {
   loginPage,
   theme,
   enableThumbs,
-  resizePreview
+  resizePreview,
+  enableExec
 }

--- a/frontend/src/views/Layout.vue
+++ b/frontend/src/views/Layout.vue
@@ -7,7 +7,7 @@
     <sidebar></sidebar>
     <main>
       <router-view></router-view>
-      <shell v-if="isLogged && user.perm.execute" />
+      <shell v-if="isExecEnabled && isLogged && user.perm.execute" />
     </main>
     <prompts></prompts>
   </div>
@@ -19,6 +19,7 @@ import Sidebar from '@/components/Sidebar'
 import Prompts from '@/components/prompts/Prompts'
 import SiteHeader from '@/components/Header'
 import Shell from '@/components/Shell'
+import { enableExec } from '@/utils/constants'
 
 export default {
   name: 'layout',
@@ -30,7 +31,8 @@ export default {
   },
   computed: {
     ...mapGetters([ 'isLogged', 'progress' ]),
-    ...mapState([ 'user' ])
+    ...mapState([ 'user' ]),
+    isExecEnabled: () => enableExec
   },
   watch: {
     '$route': function () {

--- a/frontend/src/views/settings/Global.vue
+++ b/frontend/src/views/settings/Global.vue
@@ -14,9 +14,11 @@
         <p class="small">{{ $t('settings.globalRules') }}</p>
         <rules :rules.sync="settings.rules" />
 
-        <h3>{{ $t('settings.executeOnShell') }}</h3>
-        <p class="small">{{ $t('settings.executeOnShellDescription') }}</p>
-        <input class="input input--block" type="text" placeholder="bash -c, cmd /c, ..." v-model="settings.shell" />
+        <div v-if="isExecEnabled">
+          <h3>{{ $t('settings.executeOnShell') }}</h3>
+          <p class="small">{{ $t('settings.executeOnShellDescription') }}</p>
+          <input class="input input--block" type="text" placeholder="bash -c, cmd /c, ..." v-model="settings.shell" />
+        </div>
 
         <h3>{{ $t('settings.branding') }}</h3>
 
@@ -67,7 +69,7 @@
       </div>
     </form>
 
-    <form class="card" @submit.prevent="save">
+    <form v-if="isExecEnabled" class="card" @submit.prevent="save">
       <div class="card-title">
         <h2>{{ $t('settings.commandRunner') }}</h2>
       </div>
@@ -104,6 +106,7 @@ import { settings as api } from '@/api'
 import UserForm from '@/components/settings/UserForm'
 import Rules from '@/components/settings/Rules'
 import Themes from '@/components/settings/Themes'
+import { enableExec } from '@/utils/constants'
 
 export default {
   name: 'settings',
@@ -119,7 +122,8 @@ export default {
     }
   },
   computed: {
-    ...mapState([ 'user' ])
+    ...mapState([ 'user' ]),
+    isExecEnabled: () => enableExec
   },
   async created () {
     try {

--- a/http/commands.go
+++ b/http/commands.go
@@ -37,74 +37,76 @@ func wsErr(ws *websocket.Conn, r *http.Request, status int, err error) { //nolin
 	}
 }
 
-var commandsHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
-	conn, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		return http.StatusInternalServerError, err
-	}
-	defer conn.Close()
+func commandsHandler (enableExec bool) handleFunc {
+	return withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return http.StatusInternalServerError, err
+		}
+		defer conn.Close()
 
-	var raw string
+		var raw string
 
-	for {
-		_, msg, err := conn.ReadMessage() //nolint:shadow
+		for {
+			_, msg, err := conn.ReadMessage() //nolint:shadow
+			if err != nil {
+				wsErr(conn, r, http.StatusInternalServerError, err)
+				return 0, nil
+			}
+
+			raw = strings.TrimSpace(string(msg))
+			if raw != "" {
+				break
+			}
+		}
+
+		if !enableExec || !d.user.CanExecute(strings.Split(raw, " ")[0]) {
+			if err := conn.WriteMessage(websocket.TextMessage, cmdNotAllowed); err != nil { //nolint:shadow
+				wsErr(conn, r, http.StatusInternalServerError, err)
+			}
+
+			return 0, nil
+		}
+
+		command, err := runner.ParseCommand(d.settings, raw)
+		if err != nil {
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(err.Error())); err != nil { //nolint:shadow
+				wsErr(conn, r, http.StatusInternalServerError, err)
+			}
+			return 0, nil
+		}
+
+		cmd := exec.Command(command[0], command[1:]...) //nolint:gosec
+		cmd.Dir = d.user.FullPath(r.URL.Path)
+
+		stdout, err := cmd.StdoutPipe()
 		if err != nil {
 			wsErr(conn, r, http.StatusInternalServerError, err)
 			return 0, nil
 		}
 
-		raw = strings.TrimSpace(string(msg))
-		if raw != "" {
-			break
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			wsErr(conn, r, http.StatusInternalServerError, err)
+			return 0, nil
 		}
-	}
 
-	if !d.user.CanExecute(strings.Split(raw, " ")[0]) {
-		if err := conn.WriteMessage(websocket.TextMessage, cmdNotAllowed); err != nil { //nolint:shadow
+		if err := cmd.Start(); err != nil {
+			wsErr(conn, r, http.StatusInternalServerError, err)
+			return 0, nil
+		}
+
+		s := bufio.NewScanner(io.MultiReader(stdout, stderr))
+		for s.Scan() {
+			if err := conn.WriteMessage(websocket.TextMessage, s.Bytes()); err != nil {
+				log.Print(err)
+			}
+		}
+
+		if err := cmd.Wait(); err != nil {
 			wsErr(conn, r, http.StatusInternalServerError, err)
 		}
 
 		return 0, nil
-	}
-
-	command, err := runner.ParseCommand(d.settings, raw)
-	if err != nil {
-		if err := conn.WriteMessage(websocket.TextMessage, []byte(err.Error())); err != nil { //nolint:shadow
-			wsErr(conn, r, http.StatusInternalServerError, err)
-		}
-		return 0, nil
-	}
-
-	cmd := exec.Command(command[0], command[1:]...) //nolint:gosec
-	cmd.Dir = d.user.FullPath(r.URL.Path)
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		wsErr(conn, r, http.StatusInternalServerError, err)
-		return 0, nil
-	}
-
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		wsErr(conn, r, http.StatusInternalServerError, err)
-		return 0, nil
-	}
-
-	if err := cmd.Start(); err != nil {
-		wsErr(conn, r, http.StatusInternalServerError, err)
-		return 0, nil
-	}
-
-	s := bufio.NewScanner(io.MultiReader(stdout, stderr))
-	for s.Scan() {
-		if err := conn.WriteMessage(websocket.TextMessage, s.Bytes()); err != nil {
-			log.Print(err)
-		}
-	}
-
-	if err := cmd.Wait(); err != nil {
-		wsErr(conn, r, http.StatusInternalServerError, err)
-	}
-
-	return 0, nil
-})
+	})
+}

--- a/http/commands.go
+++ b/http/commands.go
@@ -37,76 +37,74 @@ func wsErr(ws *websocket.Conn, r *http.Request, status int, err error) { //nolin
 	}
 }
 
-func commandsHandler (enableExec bool) handleFunc {
-	return withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return http.StatusInternalServerError, err
-		}
-		defer conn.Close()
+var commandsHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	defer conn.Close()
 
-		var raw string
+	var raw string
 
-		for {
-			_, msg, err := conn.ReadMessage() //nolint:shadow
-			if err != nil {
-				wsErr(conn, r, http.StatusInternalServerError, err)
-				return 0, nil
-			}
-
-			raw = strings.TrimSpace(string(msg))
-			if raw != "" {
-				break
-			}
-		}
-
-		if !enableExec || !d.user.CanExecute(strings.Split(raw, " ")[0]) {
-			if err := conn.WriteMessage(websocket.TextMessage, cmdNotAllowed); err != nil { //nolint:shadow
-				wsErr(conn, r, http.StatusInternalServerError, err)
-			}
-
-			return 0, nil
-		}
-
-		command, err := runner.ParseCommand(d.settings, raw)
-		if err != nil {
-			if err := conn.WriteMessage(websocket.TextMessage, []byte(err.Error())); err != nil { //nolint:shadow
-				wsErr(conn, r, http.StatusInternalServerError, err)
-			}
-			return 0, nil
-		}
-
-		cmd := exec.Command(command[0], command[1:]...) //nolint:gosec
-		cmd.Dir = d.user.FullPath(r.URL.Path)
-
-		stdout, err := cmd.StdoutPipe()
+	for {
+		_, msg, err := conn.ReadMessage() //nolint:shadow
 		if err != nil {
 			wsErr(conn, r, http.StatusInternalServerError, err)
 			return 0, nil
 		}
 
-		stderr, err := cmd.StderrPipe()
-		if err != nil {
-			wsErr(conn, r, http.StatusInternalServerError, err)
-			return 0, nil
+		raw = strings.TrimSpace(string(msg))
+		if raw != "" {
+			break
 		}
+	}
 
-		if err := cmd.Start(); err != nil {
-			wsErr(conn, r, http.StatusInternalServerError, err)
-			return 0, nil
-		}
-
-		s := bufio.NewScanner(io.MultiReader(stdout, stderr))
-		for s.Scan() {
-			if err := conn.WriteMessage(websocket.TextMessage, s.Bytes()); err != nil {
-				log.Print(err)
-			}
-		}
-
-		if err := cmd.Wait(); err != nil {
+	if !d.server.EnableExec || !d.user.CanExecute(strings.Split(raw, " ")[0]) {
+		if err := conn.WriteMessage(websocket.TextMessage, cmdNotAllowed); err != nil { //nolint:shadow
 			wsErr(conn, r, http.StatusInternalServerError, err)
 		}
 
 		return 0, nil
-	})
-}
+	}
+
+	command, err := runner.ParseCommand(d.settings, raw)
+	if err != nil {
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(err.Error())); err != nil { //nolint:shadow
+			wsErr(conn, r, http.StatusInternalServerError, err)
+		}
+		return 0, nil
+	}
+
+	cmd := exec.Command(command[0], command[1:]...) //nolint:gosec
+	cmd.Dir = d.user.FullPath(r.URL.Path)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		wsErr(conn, r, http.StatusInternalServerError, err)
+		return 0, nil
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		wsErr(conn, r, http.StatusInternalServerError, err)
+		return 0, nil
+	}
+
+	if err := cmd.Start(); err != nil {
+		wsErr(conn, r, http.StatusInternalServerError, err)
+		return 0, nil
+	}
+
+	s := bufio.NewScanner(io.MultiReader(stdout, stderr))
+	for s.Scan() {
+		if err := conn.WriteMessage(websocket.TextMessage, s.Bytes()); err != nil {
+			log.Print(err)
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		wsErr(conn, r, http.StatusInternalServerError, err)
+	}
+
+	return 0, nil
+})

--- a/http/data.go
+++ b/http/data.go
@@ -51,7 +51,7 @@ func handle(fn handleFunc, prefix string, store *storage.Storage, server *settin
 		}
 
 		status, err := fn(w, r, &data{
-			Runner:   &runner.Runner{Settings: settings},
+			Runner:   &runner.Runner{Enabled: server.EnableExec, Settings: settings},
 			store:    store,
 			settings: settings,
 			server:   server,

--- a/http/http.go
+++ b/http/http.go
@@ -61,7 +61,7 @@ func NewHandler(imgSvc ImgService, fileCache FileCache, store *storage.Storage, 
 	api.PathPrefix("/raw").Handler(monkey(rawHandler, "/api/raw")).Methods("GET")
 	api.PathPrefix("/preview/{size}/{path:.*}").
 		Handler(monkey(previewHandler(imgSvc, fileCache, server.EnableThumbnails, server.ResizePreview), "/api/preview")).Methods("GET")
-	api.PathPrefix("/command").Handler(monkey(commandsHandler(server.EnableExec), "/api/command")).Methods("GET")
+	api.PathPrefix("/command").Handler(monkey(commandsHandler, "/api/command")).Methods("GET")
 	api.PathPrefix("/search").Handler(monkey(searchHandler, "/api/search")).Methods("GET")
 
 	public := api.PathPrefix("/public").Subrouter()

--- a/http/http.go
+++ b/http/http.go
@@ -61,7 +61,7 @@ func NewHandler(imgSvc ImgService, fileCache FileCache, store *storage.Storage, 
 	api.PathPrefix("/raw").Handler(monkey(rawHandler, "/api/raw")).Methods("GET")
 	api.PathPrefix("/preview/{size}/{path:.*}").
 		Handler(monkey(previewHandler(imgSvc, fileCache, server.EnableThumbnails, server.ResizePreview), "/api/preview")).Methods("GET")
-	api.PathPrefix("/command").Handler(monkey(commandsHandler, "/api/command")).Methods("GET")
+	api.PathPrefix("/command").Handler(monkey(commandsHandler(server.EnableExec), "/api/command")).Methods("GET")
 	api.PathPrefix("/search").Handler(monkey(searchHandler, "/api/search")).Methods("GET")
 
 	public := api.PathPrefix("/public").Subrouter()

--- a/http/static.go
+++ b/http/static.go
@@ -41,6 +41,7 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, box *
 		"Theme":           d.settings.Branding.Theme,
 		"EnableThumbs":    d.server.EnableThumbnails,
 		"ResizePreview":   d.server.ResizePreview,
+		"EnableExec":      d.server.EnableExec,
 	}
 
 	if d.settings.Branding.Files != "" {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -19,17 +19,16 @@ type Runner struct {
 
 // RunHook runs the hooks for the before and after event.
 func (r *Runner) RunHook(fn func() error, evt, path, dst string, user *users.User) error {
-	if !r.Enabled {
-		return nil
-	}
 	path = user.FullPath(path)
 	dst = user.FullPath(dst)
 
-	if val, ok := r.Commands["before_"+evt]; ok {
-		for _, command := range val {
-			err := r.exec(command, "before_"+evt, path, dst, user)
-			if err != nil {
-				return err
+	if r.Enabled {
+		if val, ok := r.Commands["before_"+evt]; ok {
+			for _, command := range val {
+				err := r.exec(command, "before_"+evt, path, dst, user)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -39,11 +38,13 @@ func (r *Runner) RunHook(fn func() error, evt, path, dst string, user *users.Use
 		return err
 	}
 
-	if val, ok := r.Commands["after_"+evt]; ok {
-		for _, command := range val {
-			err := r.exec(command, "after_"+evt, path, dst, user)
-			if err != nil {
-				return err
+	if r.Enabled {
+		if val, ok := r.Commands["after_"+evt]; ok {
+			for _, command := range val {
+				err := r.exec(command, "after_"+evt, path, dst, user)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -13,11 +13,15 @@ import (
 
 // Runner is a commands runner.
 type Runner struct {
+	Enabled bool
 	*settings.Settings
 }
 
 // RunHook runs the hooks for the before and after event.
 func (r *Runner) RunHook(fn func() error, evt, path, dst string, user *users.User) error {
+	if !r.Enabled {
+		return nil
+	}
 	path = user.FullPath(path)
 	dst = user.FullPath(dst)
 

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -40,6 +40,7 @@ type Server struct {
 	Log              string `json:"log"`
 	EnableThumbnails bool   `json:"enableThumbnails"`
 	ResizePreview    bool   `json:"resizePreview"`
+	EnableExec       bool   `json:"enableExec"`
 }
 
 // Clean cleans any variables that might need cleaning.


### PR DESCRIPTION
This is an attempt to fix the comments in #1089 

This should implement the disabling of the command shell feature through constants as opposed to state.

shell functionality can be disabled by starting with `--disable-exec`

the style and approach of the change were guided heavily by this [suggested commit](https://github.com/filebrowser/filebrowser/commit/aa78e3ab1fcae6f618e811ba4e315a7a209f9df2#diff-6b93e5b09cd3ff47c452011d5839b1d3)