### PR TITLE
Some fixes

### DIFF
--- a/frontend/src/api/search.js
+++ b/frontend/src/api/search.js
@@ -1,8 +1,26 @@
-import { fetchJSON, removePrefix } from './utils'
+import { fetchURL, removePrefix } from './utils'
+import url from '../utils/url'
 
-export default async function search (url, query) {
-  url = removePrefix(url)
+export default async function search (base, query) {
+  base = removePrefix(base)
   query = encodeURIComponent(query)
 
-  return fetchJSON(`/api/search${url}?query=${query}`, {})
+  if (!base.endsWith('/')) {
+    base += '/'
+  }
+
+  let res = await fetchURL(`/api/search${base}?query=${query}`, {})
+
+  if (res.status === 200) {
+    let data = await res.json()
+
+    data = data.map((item) => {
+      item.url = `/files${base}` + url.encodePath(item.path)
+      return item
+    })
+
+    return data
+  } else {
+    throw Error(res.status)
+  }
 }

--- a/frontend/src/components/Search.vue
+++ b/frontend/src/components/Search.vue
@@ -49,7 +49,7 @@
         </template>
         <ul v-show="results.length > 0">
           <li v-for="(s,k) in filteredResults" :key="k">
-            <router-link @click.native="close" :to="'./' + s.path">
+            <router-link @click.native="close" :to="s.url">
               <i v-if="s.dir" class="material-icons">folder</i>
               <i v-else class="material-icons">insert_drive_file</i>
               <span>./{{ s.path }}</span>
@@ -183,8 +183,12 @@ export default {
 
       this.ongoing = true
 
+      try {
+        this.results = await search(path, this.value)
+      } catch (error) {
+        this.$showError(error)
+      }
 
-      this.results = await search(path, this.value)
       this.ongoing = false
     }
   }

--- a/frontend/src/components/files/Preview.vue
+++ b/frontend/src/components/files/Preview.vue
@@ -103,7 +103,7 @@ export default {
     }
   },
   computed: {
-    ...mapState(['req', 'user', 'oldReq', 'jwt', 'loading']),
+    ...mapState(['req', 'user', 'oldReq', 'jwt', 'loading', 'show']),
     hasPrevious () {
       return (this.previousLink !== '')
     },
@@ -158,6 +158,10 @@ export default {
     },
     key (event) {
       event.preventDefault()
+
+      if (this.show !== null) {
+        return
+      }
 
       if (event.which === 13 || event.which === 39) { // right arrow
         if (this.hasNext) this.next()

--- a/frontend/src/components/settings/Commands.vue
+++ b/frontend/src/components/settings/Commands.vue
@@ -16,7 +16,11 @@ export default {
         return this.commands.join(' ')
       },
       set (value) {
-        this.$emit('update:commands', value.split(' '))
+        if (value !== '') {
+          this.$emit('update:commands', value.split(' '))
+        } else {
+          this.$emit('update:commands', [])
+        }
       }
     }
   }

--- a/frontend/src/utils/upload.js
+++ b/frontend/src/utils/upload.js
@@ -96,31 +96,25 @@ export function scanFiles(dt) {
   })
 }
 
-export function handleFiles(files, path, overwrite = false) {
+export function handleFiles(files, base, overwrite = false) {
   for (let i = 0; i < files.length; i++) {
+    let id = store.state.upload.id
+    let path = base
     let file = files[i]
 
-    let filename = (file.fullPath !== undefined) ? file.fullPath : file.name
-    let filenameEncoded = url.encodeRFC5987ValueChars(filename)
-
-    let id = store.state.upload.id
-
-    let itemPath = path + filenameEncoded
+    if (file.fullPath !== undefined) {
+      path += url.encodePath(file.fullPath)
+    } else {
+      path += url.encodeRFC5987ValueChars(file.name)
+    }
 
     if (file.isDir) {
-      itemPath = path
-      let folders = file.fullPath.split("/")
-
-      for (let i = 0; i < folders.length; i++) {
-        let folder = folders[i]
-        let folderEncoded = encodeURIComponent(folder)
-        itemPath += folderEncoded + "/"
-      }
+      path += '/'
     }
 
     const item = {
       id,
-      path: itemPath,
+      path,
       file,
       overwrite
     }

--- a/search/search.go
+++ b/search/search.go
@@ -60,7 +60,9 @@ func Search(fs afero.Fs, scope, query string, checker rules.Checker, found func(
 		if len(search.Terms) > 0 {
 			for _, term := range search.Terms {
 				if strings.Contains(path, term) {
-					return found(strings.TrimPrefix(originalPath, scope), f)
+					originalPath = strings.TrimPrefix(originalPath, scope)
+					originalPath = strings.TrimPrefix(originalPath, "/")
+					return found(originalPath, f)
 				}
 			}
 		}


### PR DESCRIPTION
### File upload path encoding #1096
When uploading multiple files, the path is partially encoded. The path should have only folders and filename encoded, not including the slash separator.

### Search results absolute url #1094
The results displayed have relative urls, causing issues when a slash is missing on the end of the url of the current page, and there is some inconsistency on the backend, which sometimes provides a slash on start of the path. The results should have absolute urls, not requiring validation of the current page url, and the backend should omit the initial slash on the file path.

### Preview key shortcut conflict #1098 
The preview navigation keys can be triggered while a prompt is open. Preview keys should not be possible to trigger while a prompt is showed.

### Empty commands setting
When the commands input is cleared, the frontend still sends a array with empty string to the server, causing command verification to allow any command to be executed. Frontend should send a empty array to the server when the input is empty.