### PR TITLE
Fixes HTTP server panics when trying to access static paths that don't exist and have .js extension

### DIFF
--- a/http/static.go
+++ b/http/static.go
@@ -82,9 +82,8 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, box *
 	if err != nil {
 		if err == os.ErrNotExist {
 			return http.StatusNotFound, err
-		} else {
-			return http.StatusInternalServerError, err
 		}
+		return http.StatusInternalServerError, err
 	}
 	index := template.Must(template.New("index").Delims("[{[", "]}]").Parse(fileContents))
 	err = index.Execute(w, data)

--- a/http/static.go
+++ b/http/static.go
@@ -78,7 +78,15 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, box *
 
 	data["Json"] = string(b)
 
-	index := template.Must(template.New("index").Delims("[{[", "]}]").Parse(box.MustString(file)))
+	fileContents, err := box.String(file)
+	if err != nil {
+		if err == os.ErrNotExist {
+			return http.StatusNotFound, err
+		} else {
+			return http.StatusInternalServerError, err
+		}
+	}
+	index := template.Must(template.New("index").Delims("[{[", "]}]").Parse(fileContents))
 	err = index.Execute(w, data)
 	if err != nil {
 		return http.StatusInternalServerError, err


### PR DESCRIPTION
**Description**
Fixes HTTP server panics when trying to access static paths that don't exist and have .js extension #1104 

When the box returns an error instead of creating a panic it returns an error.

It returns 404 when the error is os.ErrNotExist and 500 in other cases.

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.