### PR TITLE
fix: run Commands when set by "cmds add" cli (#655)

### DIFF
--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -32,7 +31,7 @@ override the options.`,
 		s := &settings.Settings{
 			Key:        generateKey(),
 			Signup:     mustGetBool(flags, "signup"),
-			Shell:      strings.Split(strings.TrimSpace(mustGetString(flags, "shell")), " "),
+			Shell:      convertCmdStrToCmdArray(mustGetString(flags, "shell")),
 			AuthMethod: authMethod,
 			Defaults:   defaults,
 			Branding: settings.Branding{

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -50,7 +48,7 @@ you want to change. Other options will remain unchanged.`,
 			case "auth.method":
 				hasAuth = true
 			case "shell":
-				set.Shell = strings.Split(strings.TrimSpace(mustGetString(flags, flag.Name)), " ")
+				set.Shell = convertCmdStrToCmdArray(mustGetString(flags, flag.Name))
 			case "branding.name":
 				set.Branding.Name = mustGetString(flags, flag.Name)
 			case "branding.disableExternal":

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/asdine/storm"
 	"github.com/spf13/cobra"
@@ -177,4 +178,16 @@ func cleanUpMapValue(v interface{}) interface{} {
 	default:
 		return v
 	}
+}
+
+// convertCmdStrToCmdArray checks if cmd string is blank (whitespace included)
+// then returns empty string array, else returns the splitted word array of cmd.
+// This is to ensure the result will never be []string{""}
+func convertCmdStrToCmdArray(cmd string) []string {
+	var cmdArray []string
+	trimmedCmdStr := strings.TrimSpace(cmd)
+	if trimmedCmdStr != "" {
+		cmdArray = strings.Split(trimmedCmdStr, " ")
+	}
+	return cmdArray
 }


### PR DESCRIPTION
### Description
Hello, I came across the exact issue #[655](https://github.com/filebrowser/filebrowser/issues/655) in that when adding cmds via `filebrowser` cli instead of in web UI, filebrowser fails to run the command due to leading whitespace (eg. input command is "`echo hello`" but filebrowser will run "` echo hello`")

### To reproduce
```
rm -f filebrowser.db
filebrowser config init
filebrowser cmds add "before_upload" "echo hello world"
filebrowser -r .
```

Try to upload 1 file
- Expected: file is uploaded successfully, `hello world` is printed to stdout
- Actual: `no such file or directory` error due to running " echo hello world" instead of "echo hello world"
```
2020/10/03 15:00:59 [INFO] Blocking Command: " echo hello world"
2020/10/03 15:00:59 /service-runner: 404 127.0.0.1 fork/exec : no such file or directory
```
### Root cause
- [Settings.Shell](https://github.com/filebrowser/filebrowser/blob/master/cmd/config_init.go#L35) is initiated as `[]string{""}` instead of `[]string{}` due to [strings.Split() expected behavior](https://github.com/golang/go/issues/35130)
- that will result in [`len(Shell)` always >= 1](https://github.com/filebrowser/filebrowser/blob/master/runner/parser.go#L17)
- that leads to `command = append(s.Shell, raw)` which is ["", "echo hello world"] which leads to `cmd := exec.Command("", "echo", "hello", "world")` [here](https://github.com/filebrowser/filebrowser/blob/master/runner/runner.go#L68)
=> runs exec command `" echo hello world"` instead of "echo hello world"

### Testing
1. Try reproduce step
1. File is uploaded successfully and "hello world" is printed
```
2020/10/03 15:03:07 [INFO] Blocking Command: "echo hello world"
hello world
```

:rotating_light: I have followed all the below:
- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

:heart: Thank you!
