### PR TITLE
Fix: WKWebview Custom Protocol

### DIFF
--- a/frontend/src/api/files.js
+++ b/frontend/src/api/files.js
@@ -85,8 +85,9 @@ export function download (format, ...files) {
 export async function post (url, content = '', overwrite = false, onupload) {
   url = removePrefix(url)
 
+  let bufferContent
   if (content instanceof Blob && !['http:', 'https:'].includes(window.location.protocol)) {
-    content = await content.arrayBuffer()
+    bufferContent = await new Response(content).arrayBuffer()
   }
 
   return new Promise((resolve, reject) => {
@@ -112,7 +113,7 @@ export async function post (url, content = '', overwrite = false, onupload) {
       reject(error)
     }
 
-    request.send(content)
+    request.send(bufferContent || content)
   })
 }
 

--- a/frontend/src/api/files.js
+++ b/frontend/src/api/files.js
@@ -85,6 +85,10 @@ export function download (format, ...files) {
 export async function post (url, content = '', overwrite = false, onupload) {
   url = removePrefix(url)
 
+  if (content instanceof Blob && !['http:', 'https:'].includes(window.location.protocol)) {
+    content = await content.arrayBuffer()
+  }
+
   return new Promise((resolve, reject) => {
     let request = new XMLHttpRequest()
     request.open('POST', `${baseURL}/api/resources${url}?override=${overwrite}`, true)


### PR DESCRIPTION
**Description**
In WKWebview (the webview for iOS), the Blob data type is not supported for non-http protocols. This can cause issues for custom browsers for iOS that use WKURLSchemeHandler. This change detects if the page is being hosted on a non-http URL scheme and will convert the Blob to an ArrayBuffer if so.
