### PR TITLE
Some fixes

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,7 @@ var (
 
 func init() {
 	cobra.OnInitialize(initConfig)
+	cobra.MousetrapHelpText = ""
 
 	rootCmd.SetVersionTemplate("File Browser version {{printf \"%s\" .Version}}\n")
 

--- a/frontend/src/api/search.js
+++ b/frontend/src/api/search.js
@@ -16,6 +16,11 @@ export default async function search (base, query) {
 
     data = data.map((item) => {
       item.url = `/files${base}` + url.encodePath(item.path)
+
+      if (item.dir) {
+        item.url += '/'
+      }
+
       return item
     })
 

--- a/frontend/src/components/files/Listing.vue
+++ b/frontend/src/components/files/Listing.vue
@@ -368,7 +368,7 @@ export default {
       }
 
       let files = await upload.scanFiles(dt)
-      let path = this.$route.path + base
+      let path = this.$route.path.endsWith('/') ? this.$route.path + base : this.$route.path + '/' + base
       let items = this.req.items
 
       if (base !== '') {
@@ -409,7 +409,7 @@ export default {
         }
       }
 
-      let path = this.$route.path
+      let path = this.$route.path.endsWith('/') ? this.$route.path : this.$route.path + '/'
       let conflict = upload.checkConflict(files, this.req.items)
 
       if (conflict) {

--- a/frontend/src/components/files/Preview.vue
+++ b/frontend/src/components/files/Preview.vue
@@ -52,7 +52,7 @@
           but don't worry, you can <a :href="download">download it</a>
           and watch it with your favorite video player!
         </video>
-        <object v-else-if="req.extension == '.pdf'" class="pdf" :data="raw"></object>
+        <object v-else-if="req.extension.toLowerCase() == '.pdf'" class="pdf" :data="raw"></object>
         <a v-else-if="req.type == 'blob'" :href="download">
           <h2 class="message">{{ $t('buttons.download') }} <i class="material-icons">file_download</i></h2>
         </a>


### PR DESCRIPTION
### File upload missing path slash
Ensures that the current path contain a slash at the end.

### Search missing path slash #1119
Adds a trailing slash to the end of the results url.

### Preview case sensitive extension #1120
Compares the file extension in lower case.

### Allow start from Windows explorer #1110
Disables the Mousetrap hook for Windows from Cobra cli library.