### PR TITLE
Commit sha to sidebar

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ build:
   env:
     - CGO_ENABLED=0
   ldflags:
-    - -s -w -X github.com/filebrowser/filebrowser/v2/version.Version={{ .Version }} -X github.com/filebrowser/filebrowser/v2/version.CommitSHA={{ .ShortCommit }}
+    - -s -w -X github.com/filebrowser/filebrowser/v2/version.Version={{ .Version }} -X github.com/filebrowser/filebrowser/v2/version.CommitSHA={{ .ShortCommit }} -X github.com/filebrowser/filebrowser/v2/version.GitURL={{ .GitURL }}
   main: main.go
   binary: filebrowser
   goos:

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -47,12 +47,12 @@
         <span v-if="disableExternal">File Browser</span>
         <a v-else rel="noopener noreferrer" target="_blank" href="https://github.com/filebrowser/filebrowser">File Browser</a>
         <span> {{ version }}</span>
-        <span>
-          Commit SHA: 
-          <a rel="noopener noreferrer" target="_blank" :href="'https://github.com/zoidy/filebrowser/commit/'+commitSHA">
-            <span style="width:3.7em;overflow:hidden;display:inline-block;white-space:nowrap;vertical-align:bottom;">{{ commitSHA }}</span>
-          </a>
-        </span>
+      </span>
+      <span>
+        Commit SHA: 
+        <a rel="noopener noreferrer" target="_blank" :href="gitURL+'/commit/'+commitSHA">
+          <span style="width:3.7em;overflow:hidden;display:inline-block;white-space:nowrap;vertical-align:bottom;">{{ commitSHA }}</span>
+        </a>
       </span>
       <span><a @click="help">{{ $t('sidebar.help') }}</a></span>
     </p>
@@ -62,7 +62,7 @@
 <script>
 import { mapState, mapGetters } from 'vuex'
 import * as auth from '@/utils/auth'
-import { version, signup, disableExternal, noAuth, authMethod, commitSHA } from '@/utils/constants'
+import { version, signup, disableExternal, noAuth, authMethod, commitSHA, gitURL } from '@/utils/constants'
 
 export default {
   name: 'sidebar',
@@ -77,7 +77,8 @@ export default {
     disableExternal: () => disableExternal,
     noAuth: () => noAuth,
     authMethod: () => authMethod,
-    commitSHA: () => commitSHA
+    commitSHA: () => commitSHA,
+    gitURL: () => gitURL
   },
   methods: {
     help () {

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -47,6 +47,12 @@
         <span v-if="disableExternal">File Browser</span>
         <a v-else rel="noopener noreferrer" target="_blank" href="https://github.com/filebrowser/filebrowser">File Browser</a>
         <span> {{ version }}</span>
+        <span>
+          Commit SHA: 
+          <a rel="noopener noreferrer" target="_blank" :href="'https://github.com/zoidy/filebrowser/commit/'+commitSHA">
+            <span style="width:3.7em;overflow:hidden;display:inline-block;white-space:nowrap;vertical-align:bottom;">{{ commitSHA }}</span>
+          </a>
+        </span>
       </span>
       <span><a @click="help">{{ $t('sidebar.help') }}</a></span>
     </p>
@@ -56,7 +62,7 @@
 <script>
 import { mapState, mapGetters } from 'vuex'
 import * as auth from '@/utils/auth'
-import { version, signup, disableExternal, noAuth, authMethod } from '@/utils/constants'
+import { version, signup, disableExternal, noAuth, authMethod, commitSHA } from '@/utils/constants'
 
 export default {
   name: 'sidebar',
@@ -70,7 +76,8 @@ export default {
     version: () => version,
     disableExternal: () => disableExternal,
     noAuth: () => noAuth,
-    authMethod: () => authMethod
+    authMethod: () => authMethod,
+    commitSHA: () => commitSHA
   },
   methods: {
     help () {

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -14,6 +14,7 @@ const theme = window.FileBrowser.Theme
 const enableThumbs = window.FileBrowser.EnableThumbs
 const resizePreview = window.FileBrowser.ResizePreview
 const enableExec = window.FileBrowser.EnableExec
+const commitSHA = window.FileBrowser.CommitSHA
 
 export {
   name,
@@ -30,5 +31,6 @@ export {
   theme,
   enableThumbs,
   resizePreview,
-  enableExec
+  enableExec,
+  commitSHA
 }

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -15,6 +15,7 @@ const enableThumbs = window.FileBrowser.EnableThumbs
 const resizePreview = window.FileBrowser.ResizePreview
 const enableExec = window.FileBrowser.EnableExec
 const commitSHA = window.FileBrowser.CommitSHA
+const gitURL = window.FileBrowser.GitURL
 
 export {
   name,
@@ -32,5 +33,6 @@ export {
   enableThumbs,
   resizePreview,
   enableExec,
-  commitSHA
+  commitSHA,
+  gitURL
 }

--- a/http/static.go
+++ b/http/static.go
@@ -42,6 +42,7 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, box *
 		"EnableThumbs":    d.server.EnableThumbnails,
 		"ResizePreview":   d.server.ResizePreview,
 		"EnableExec":      d.server.EnableExec,
+		"CommitSHA":       version.CommitSHA,
 	}
 
 	if d.settings.Branding.Files != "" {

--- a/http/static.go
+++ b/http/static.go
@@ -43,6 +43,7 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, box *
 		"ResizePreview":   d.server.ResizePreview,
 		"EnableExec":      d.server.EnableExec,
 		"CommitSHA":       version.CommitSHA,
+		"GitURL":          version.GitURL,
 	}
 
 	if d.settings.Branding.Files != "" {

--- a/version/version.go
+++ b/version/version.go
@@ -5,6 +5,6 @@ var (
 	Version = "(untracked)"
 	// CommitSHA is the commmit sha.
 	CommitSHA = "(unknown)"
-	//GitURL is the url of the remote
+	// GitURL is the url of the remote
 	GitURL = "(unavailable)"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -5,4 +5,6 @@ var (
 	Version = "(untracked)"
 	// CommitSHA is the commmit sha.
 	CommitSHA = "(unknown)"
+	//GitURL is the url of the remote
+	GitURL = "(unavailable)"
 )

--- a/wizard.sh
+++ b/wizard.sh
@@ -5,6 +5,7 @@ set -e
 untracked="(untracked)"
 REPO=$(cd $(dirname $0); pwd)
 COMMIT_SHA=$(git rev-parse --short HEAD)
+GIT_URL=$(git config --get remote.origin.url)
 ASSETS="false"
 BINARY="false"
 RELEASE=""
@@ -43,7 +44,7 @@ buildBinary () {
   rice embed-go
 
   cd $REPO
-  go build -a -o filebrowser -ldflags "-s -w -X github.com/filebrowser/filebrowser/v2/version.CommitSHA=$COMMIT_SHA"
+  go build -a -o filebrowser -ldflags "-s -w -X github.com/filebrowser/filebrowser/v2/version.CommitSHA=$COMMIT_SHA -X github.com/filebrowser/filebrowser/v2/version.GitURL=$GIT_URL"
 }
 
 release () {


### PR DESCRIPTION
Add the commit SHA to the sidebar right above the Help link. This makes it easier to track exactly which commit the binary corresponds to when building from source
