### PR TITLE
Automatically jumps to the next photo when deleting while previewing

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -135,7 +135,7 @@ export default {
           to: this.url + this.req.items[i].name,
           name: this.req.items[i].name
         })
-      }      
+      }
 
       let base = el.querySelector('.name').innerHTML + '/'
       let path = this.$route.path + base

--- a/frontend/src/components/files/Preview.vue
+++ b/frontend/src/components/files/Preview.vue
@@ -147,6 +147,7 @@ export default {
   methods: {
     back () {
       this.$store.commit('setPreviewMode', false)
+      this.$store.commit('postDeleteLink', null)
       let uri = url.removeLastDir(this.$route.path) + '/'
       this.$router.push({ path: uri })
     },
@@ -205,6 +206,7 @@ export default {
         for (let j = i + 1; j < this.listing.length; j++) {
           if (mediaTypes.includes(this.listing[j].type)) {
             this.nextLink = this.listing[j].url
+            this.$store.commit('postDeleteLink', this.nextLink);
             break
           }
         }

--- a/frontend/src/components/prompts/Delete.vue
+++ b/frontend/src/components/prompts/Delete.vue
@@ -39,7 +39,14 @@ export default {
         if (!this.isListing) {
           await api.remove(this.$route.path)
           buttons.success('delete')
-          this.$router.push({ path: url.removeLastDir(this.$route.path) + '/' })
+          let path = url.removeLastDir(this.$route.path) + '/'
+
+          if (this.$store.state.postDeleteLink != null) {
+            path = this.$store.state.postDeleteLink;
+            this.$store.commit('postDeleteLink', null);
+          }
+
+          this.$router.push({ path: path })
           return
         }
 

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -24,7 +24,8 @@ const state = {
   showShell: false,
   showMessage: null,
   showConfirm: null,
-  previewMode: false
+  previewMode: false,
+  postDeleteLink: null
 }
 
 export default new Vuex.Store({

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -86,6 +86,9 @@ const mutations = {
   },
   setPreviewMode(state, value) {
     state.previewMode = value
+  },
+  postDeleteLink: (state, value) => {
+    state.postDeleteLink = value
   }
 }
 


### PR DESCRIPTION
**Description**
Introduces a new `postDeleteLink` property to the store, and uses it to jump to the next photo when deleting while previewing, rather than returning to the files list every time.

Closes issue #1091 