### PR TITLE
Add single click mode

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -145,6 +145,7 @@ func printSettings(ser *settings.Server, set *settings.Settings, auther auth.Aut
 	fmt.Fprintf(w, "\tScope:\t%s\n", set.Defaults.Scope)
 	fmt.Fprintf(w, "\tLocale:\t%s\n", set.Defaults.Locale)
 	fmt.Fprintf(w, "\tView mode:\t%s\n", set.Defaults.ViewMode)
+	fmt.Fprintf(w, "\tSingle Click:\t%t\n", set.Defaults.SingleClick)
 	fmt.Fprintf(w, "\tCommands:\t%s\n", strings.Join(set.Defaults.Commands, " "))
 	fmt.Fprintf(w, "\tSorting:\n")
 	fmt.Fprintf(w, "\t\tBy:\t%s\n", set.Defaults.Sorting.By)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -302,8 +302,9 @@ func quickSetup(flags *pflag.FlagSet, d pythonData) {
 		Signup:        false,
 		CreateUserDir: false,
 		Defaults: settings.UserDefaults{
-			Scope:  ".",
-			Locale: "en",
+			Scope:       ".",
+			Locale:      "en",
+			SingleClick: false,
 			Perm: users.Permissions{
 				Admin:    false,
 				Execute:  true,

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -27,7 +27,7 @@ var usersCmd = &cobra.Command{
 
 func printUsers(usrs []*users.User) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tUsername\tScope\tLocale\tV. Mode\tAdmin\tExecute\tCreate\tRename\tModify\tDelete\tShare\tDownload\tPwd Lock")
+	fmt.Fprintln(w, "ID\tUsername\tScope\tLocale\tV. Mode\tS.Click\tAdmin\tExecute\tCreate\tRename\tModify\tDelete\tShare\tDownload\tPwd Lock")
 
 	for _, u := range usrs {
 		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%t\t%t\t%t\t%t\t%t\t%t\t%t\t%t\t%t\t%t\t\n",

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -30,12 +30,13 @@ func printUsers(usrs []*users.User) {
 	fmt.Fprintln(w, "ID\tUsername\tScope\tLocale\tV. Mode\tAdmin\tExecute\tCreate\tRename\tModify\tDelete\tShare\tDownload\tPwd Lock")
 
 	for _, u := range usrs {
-		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%t\t%t\t%t\t%t\t%t\t%t\t%t\t%t\t%t\t\n",
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%t\t%t\t%t\t%t\t%t\t%t\t%t\t%t\t%t\t%t\t\n",
 			u.ID,
 			u.Username,
 			u.Scope,
 			u.Locale,
 			u.ViewMode,
+			u.SingleClick,
 			u.Perm.Admin,
 			u.Perm.Execute,
 			u.Perm.Create,
@@ -75,6 +76,7 @@ func addUserFlags(flags *pflag.FlagSet) {
 	flags.String("scope", ".", "scope for users")
 	flags.String("locale", "en", "locale for users")
 	flags.String("viewMode", string(users.ListViewMode), "view mode for users")
+	flags.Bool("singleClick", false, "use single clicks only")
 }
 
 func getViewMode(flags *pflag.FlagSet) users.ViewMode {
@@ -95,6 +97,8 @@ func getUserDefaults(flags *pflag.FlagSet, defaults *settings.UserDefaults, all 
 			defaults.Locale = mustGetString(flags, flag.Name)
 		case "viewMode":
 			defaults.ViewMode = getViewMode(flags)
+		case "singleClick":
+			defaults.SingleClick = mustGetBool(flags, flag.Name)
 		case "perm.admin":
 			defaults.Perm.Admin = mustGetBool(flags, flag.Name)
 		case "perm.execute":

--- a/cmd/users_update.go
+++ b/cmd/users_update.go
@@ -41,17 +41,19 @@ options you want to change.`,
 		checkErr(err)
 
 		defaults := settings.UserDefaults{
-			Scope:    user.Scope,
-			Locale:   user.Locale,
-			ViewMode: user.ViewMode,
-			Perm:     user.Perm,
-			Sorting:  user.Sorting,
-			Commands: user.Commands,
+			Scope:       user.Scope,
+			Locale:      user.Locale,
+			ViewMode:    user.ViewMode,
+			SingleClick: user.SingleClick,
+			Perm:        user.Perm,
+			Sorting:     user.Sorting,
+			Commands:    user.Commands,
 		}
 		getUserDefaults(flags, &defaults, false)
 		user.Scope = defaults.Scope
 		user.Locale = defaults.Locale
 		user.ViewMode = defaults.ViewMode
+		user.SingleClick = defaults.SingleClick
 		user.Perm = defaults.Perm
 		user.Commands = defaults.Commands
 		user.Sorting = defaults.Sorting

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -26,9 +26,6 @@
       <p class="modified">
         <time :datetime="modified">{{ humanTime() }}</time>
       </p>
-
-      <input v-if="user.singleClick" v-bind:checked="isSelected"
-             class="selection" type="checkbox" @click.stop="click">
     </div>
   </div>
 </template>
@@ -174,7 +171,7 @@ export default {
       action(overwrite, rename)
     },
     itemClick: function(event) {
-      if (this.user.singleClick) this.open()
+      if (this.user.singleClick && !this.$store.state.multiple) this.open()
       else this.click(event)
     },
     click: function (event) {

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -6,8 +6,8 @@
   @dragstart="dragStart"
   @dragover="dragOver"
   @drop="drop"
-  @click="click"
-  @dblclick="open"
+  @click="itemClick"
+  @dblclick="dblclick"
   @touchstart="touchstart"
   :data-dir="isDir"
   :aria-label="name"
@@ -26,6 +26,9 @@
       <p class="modified">
         <time :datetime="modified">{{ humanTime() }}</time>
       </p>
+
+      <input v-if="user.singleClick" v-bind:checked="isSelected"
+             class="selection" type="checkbox" @click.stop="click">
     </div>
   </div>
 </template>
@@ -47,7 +50,7 @@ export default {
   },
   props: ['name', 'isDir', 'url', 'type', 'size', 'modified', 'index'],
   computed: {
-    ...mapState(['selected', 'req', 'user', 'jwt']),
+    ...mapState(['user', 'selected', 'req', 'user', 'jwt']),
     ...mapGetters(['selectedCount']),
     isSelected () {
       return (this.selected.indexOf(this.index) !== -1)
@@ -170,8 +173,12 @@ export default {
 
       action(overwrite, rename)
     },
+    itemClick: function(event) {
+      if (this.user.singleClick) this.open()
+      else this.click(event)
+    },
     click: function (event) {
-      if (this.selectedCount !== 0) event.preventDefault()
+      if (!this.user.singleClick && this.selectedCount !== 0) event.preventDefault()
       if (this.$store.state.selected.indexOf(this.index) !== -1) {
         this.removeSelected(this.index)
         return
@@ -198,8 +205,11 @@ export default {
         return
       }
 
-      if (!event.ctrlKey && !this.$store.state.multiple) this.resetSelected()
+      if (!this.user.singleClick && !event.ctrlKey && !this.$store.state.multiple) this.resetSelected()
       this.addSelected(this.index)
+    },
+    dblclick: function () {
+      if (!this.user.singleClick) this.open()
     },
     touchstart () {
       setTimeout(() => {

--- a/frontend/src/components/settings/UserForm.vue
+++ b/frontend/src/components/settings/UserForm.vue
@@ -24,6 +24,10 @@
       <input type="checkbox" :disabled="user.perm.admin" v-model="user.lockPassword"> {{ $t('settings.lockPassword') }}
     </p>
 
+    <p>
+      <input type="checkbox" v-model="user.singleClick"> {{ $t('settings.singleClick') }}
+    </p>
+
     <permissions :perm.sync="user.perm" />
     <commands v-if="isExecEnabled" :commands.sync="user.commands" />
 

--- a/frontend/src/css/listing.css
+++ b/frontend/src/css/listing.css
@@ -104,12 +104,6 @@
   width: calc(100% - 5vw);
 }
 
-#listing.mosaic .item .selection {
-  position: absolute;
-  top: 16px;
-  right: 16px;
-}
-
 #listing.list {
   flex-direction: column;
   width: 100%;
@@ -221,11 +215,6 @@
 
 #listing.list .item.header .active {
   font-weight: bold;
-}
-
-#listing.list .item .selection {
-  position: absolute;
-  right: 24px;
 }
 
 #listing #multiple-selection {

--- a/frontend/src/css/listing.css
+++ b/frontend/src/css/listing.css
@@ -104,6 +104,12 @@
   width: calc(100% - 5vw);
 }
 
+#listing.mosaic .item .selection {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+}
+
 #listing.list {
   flex-direction: column;
   width: 100%;
@@ -215,6 +221,11 @@
 
 #listing.list .item.header .active {
   font-weight: bold;
+}
+
+#listing.list .item .selection {
+  position: absolute;
+  right: 24px;
 }
 
 #listing #multiple-selection {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -173,7 +173,7 @@
     "globalRules": "This is a global set of allow and disallow rules. They apply to every user. You can define specific rules on each user's settings to override this ones.",
     "allowSignup": "Allow users to signup",
     "createUserDir": "Auto create user home dir while adding new user",
-    "singleClick": "Use only single click gestures on the interface",
+    "singleClick": "Use single clicks to open folders",
     "insertRegex": "Insert regex expression",
     "insertPath": "Insert the path",
     "userUpdated": "User updated!",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -173,6 +173,7 @@
     "globalRules": "This is a global set of allow and disallow rules. They apply to every user. You can define specific rules on each user's settings to override this ones.",
     "allowSignup": "Allow users to signup",
     "createUserDir": "Auto create user home dir while adding new user",
+    "singleClick": "Use only single click gestures on the interface",
     "insertRegex": "Insert regex expression",
     "insertPath": "Insert the path",
     "userUpdated": "User updated!",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -173,7 +173,7 @@
     "globalRules": "This is a global set of allow and disallow rules. They apply to every user. You can define specific rules on each user's settings to override this ones.",
     "allowSignup": "Allow users to signup",
     "createUserDir": "Auto create user home dir while adding new user",
-    "singleClick": "Use single clicks to open folders",
+    "singleClick": "Use single clicks to open files and directories",
     "insertRegex": "Insert regex expression",
     "insertPath": "Insert the path",
     "userUpdated": "User updated!",

--- a/http/auth.go
+++ b/http/auth.go
@@ -23,6 +23,7 @@ type userInfo struct {
 	ID           uint              `json:"id"`
 	Locale       string            `json:"locale"`
 	ViewMode     users.ViewMode    `json:"viewMode"`
+	SingleClick  bool              `json:"singleClick"`
 	Perm         users.Permissions `json:"perm"`
 	Commands     []string          `json:"commands"`
 	LockPassword bool              `json:"lockPassword"`
@@ -172,6 +173,7 @@ func printToken(w http.ResponseWriter, _ *http.Request, d *data, user *users.Use
 			ID:           user.ID,
 			Locale:       user.Locale,
 			ViewMode:     user.ViewMode,
+			SingleClick:  user.SingleClick,
 			Perm:         user.Perm,
 			LockPassword: user.LockPassword,
 			Commands:     user.Commands,

--- a/settings/defaults.go
+++ b/settings/defaults.go
@@ -8,12 +8,13 @@ import (
 // UserDefaults is a type that holds the default values
 // for some fields on User.
 type UserDefaults struct {
-	Scope    string            `json:"scope"`
-	Locale   string            `json:"locale"`
-	ViewMode users.ViewMode    `json:"viewMode"`
-	Sorting  files.Sorting     `json:"sorting"`
-	Perm     users.Permissions `json:"perm"`
-	Commands []string          `json:"commands"`
+	Scope       string            `json:"scope"`
+	Locale      string            `json:"locale"`
+	ViewMode    users.ViewMode    `json:"viewMode"`
+	SingleClick bool              `json:"singleClick"`
+	Sorting     files.Sorting     `json:"sorting"`
+	Perm        users.Permissions `json:"perm"`
+	Commands    []string          `json:"commands"`
 }
 
 // Apply applies the default options to a user.
@@ -21,6 +22,7 @@ func (d *UserDefaults) Apply(u *users.User) {
 	u.Scope = d.Scope
 	u.Locale = d.Locale
 	u.ViewMode = d.ViewMode
+	u.SingleClick = d.SingleClick
 	u.Perm = d.Perm
 	u.Sorting = d.Sorting
 	u.Commands = d.Commands

--- a/settings/defaults.go
+++ b/settings/defaults.go
@@ -11,7 +11,7 @@ type UserDefaults struct {
 	Scope        string            `json:"scope"`
 	Locale       string            `json:"locale"`
 	ViewMode     users.ViewMode    `json:"viewMode"`
-  SingleClick  bool              `json:"singleClick"`
+	SingleClick  bool              `json:"singleClick"`
 	Sorting      files.Sorting     `json:"sorting"`
 	Perm         users.Permissions `json:"perm"`
 	Commands     []string          `json:"commands"`

--- a/users/users.go
+++ b/users/users.go
@@ -28,6 +28,7 @@ type User struct {
 	Locale       string        `json:"locale"`
 	LockPassword bool          `json:"lockPassword"`
 	ViewMode     ViewMode      `json:"viewMode"`
+	SingleClick  bool          `json:"singleClick"`
 	Perm         Permissions   `json:"perm"`
 	Commands     []string      `json:"commands"`
 	Sorting      files.Sorting `json:"sorting"`


### PR DESCRIPTION
This PR adds the ability to navigate through the files only using single clicks, using checkboxes to select one or multiple elements. As it directly relates to the user experience, this is configurable per user instead of globally. In my opinion, this improves the user experience on mobile, and that's the main reason I propose those changes. 🙂 

Though, some questions might need to be addressed:
* Would it be a better idea to enable it on mobile and disable it on desktop, instead of manually configuring it?
* I used raw checkboxes, do you want to replace them with Material looking ones instead? I didn't want to alter the package dependencies before asking.