### PR TITLE
Automatically jumps to the next photo when deleting while previewing.

### DIFF
--- a/frontend/src/components/prompts/Delete.vue
+++ b/frontend/src/components/prompts/Delete.vue
@@ -30,7 +30,11 @@ export default {
     ...mapState(['req', 'selected'])
   },
   methods: {
-    ...mapMutations(['closeHovers']),
+    ...mapMutations([
+      'closeHovers',
+      'setPostDeletionLink',
+      'setDeletionOccurred'
+    ]),
     submit: async function () {
       this.closeHovers()
       buttons.loading('delete')
@@ -39,7 +43,18 @@ export default {
         if (!this.isListing) {
           await api.remove(this.$route.path)
           buttons.success('delete')
-          this.$router.push({ path: url.removeLastDir(this.$route.path) + '/' })
+          let path = url.removeLastDir(this.$route.path) + '/'
+
+          // Indicate a deletion occurred to ensure the current index gets
+          // spliced out in Preview.vue.
+          this.setDeletionOccurred(true)
+
+          // Jump to the next listing item, if there is one.
+          if (this.$store.state.postDeletionLink != null) {
+            path = this.$store.state.postDeletionLink;
+          }
+
+          this.$router.push({ path: path })
           return
         }
 

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -24,7 +24,10 @@ const state = {
   showShell: false,
   showMessage: null,
   showConfirm: null,
-  previewMode: false
+  previewMode: false,
+  postDeletionLink: null,
+  currentListingIndex: -1,
+  deletionOccurred: false
 }
 
 export default new Vuex.Store({

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -86,6 +86,15 @@ const mutations = {
   },
   setPreviewMode(state, value) {
     state.previewMode = value
+  },
+  setPostDeletionLink: (state, value) => {
+    state.postDeletionLink = value
+  },
+  setCurrentListingIndex: (state, value) => {
+    state.currentListingIndex = value
+  },
+  setDeletionOccurred: (state, value) => {
+    state.deletionOccurred = value
   }
 }
 


### PR DESCRIPTION
**Description**
Deletions made while previewing now immediately load the preview of the next file in the list. When the last file is deleted, previewing ends and returns to the file list, as before.

Closes #1091 