### PR TITLE
Automatically jumps to the next photo when deleting while previewing.

### DIFF
--- a/frontend/src/components/files/Preview.vue
+++ b/frontend/src/components/files/Preview.vue
@@ -133,14 +133,14 @@ export default {
     }
   },
   async mounted () {
-    window.addEventListener('keyup', this.key)
+    window.addEventListener('keydown', this.key)
     this.$store.commit('setPreviewMode', true)
     this.listing = this.oldReq.items
-    this.$root.$on('preview_deleted', this.deleted)
+    this.$root.$on('preview-deleted', this.deleted)
     this.updatePreview()
   },
   beforeDestroy () {
-    window.removeEventListener('keyup', this.key)
+    window.removeEventListener('keydown', this.key)
     this.$store.commit('setPreviewMode', false)
   },
   methods: {
@@ -153,8 +153,10 @@ export default {
 
       if (this.hasNext) {
         this.next()
-      } else {
+      } else if (!this.hasPrevious && !this.hasNext == true) {
         this.back()
+      } else {
+        this.prev()
       }
     },
     back () {
@@ -169,7 +171,6 @@ export default {
       this.$router.push({ path: this.nextLink })
     },
     key (event) {
-      event.preventDefault()
 
       if (this.show !== null) {
         return

--- a/frontend/src/components/files/Preview.vue
+++ b/frontend/src/components/files/Preview.vue
@@ -142,18 +142,15 @@ export default {
   beforeDestroy () {
     window.removeEventListener('keydown', this.key)
     this.$store.commit('setPreviewMode', false)
+    this.$root.$off('preview-deleted', this.deleted)
   },
   methods: {
-    deleted (path) {
-
-      let pieces = path.split('/')
-      let deletedName = decodeURIComponent(pieces[pieces.length - 1])
-
-      this.listing = this.listing.filter(item => item.name !== deletedName)
+    deleted () {
+      this.listing = this.listing.filter(item => item.name !== this.name)
 
       if (this.hasNext) {
         this.next()
-      } else if (!this.hasPrevious && !this.hasNext == true) {
+      } else if (!this.hasPrevious && !this.hasNext) {
         this.back()
       } else {
         this.prev()

--- a/frontend/src/components/files/Preview.vue
+++ b/frontend/src/components/files/Preview.vue
@@ -136,6 +136,7 @@ export default {
     window.addEventListener('keyup', this.key)
     this.$store.commit('setPreviewMode', true)
     this.listing = this.oldReq.items
+    this.$root.$on('preview_deleted', this.deleted)
     this.updatePreview()
   },
   beforeDestroy () {
@@ -143,6 +144,19 @@ export default {
     this.$store.commit('setPreviewMode', false)
   },
   methods: {
+    deleted (path) {
+
+      let pieces = path.split('/')
+      let deletedName = decodeURIComponent(pieces[pieces.length - 1])
+
+      this.listing = this.listing.filter(item => item.name !== deletedName)
+
+      if (this.hasNext) {
+        this.next()
+      } else {
+        this.back()
+      }
+    },
     back () {
       this.$store.commit('setPreviewMode', false)
       let uri = url.removeLastDir(this.$route.path) + '/'

--- a/frontend/src/components/prompts/Delete.vue
+++ b/frontend/src/components/prompts/Delete.vue
@@ -31,7 +31,6 @@ export default {
   methods: {
     ...mapMutations(['closeHovers']),
     submit: async function () {
-      this.closeHovers()
       buttons.loading('delete')
 
       try {
@@ -39,9 +38,12 @@ export default {
           await api.remove(this.$route.path)
           buttons.success('delete')
 
-          this.$root.$emit('preview_deleted', this.$route.path)
+          this.$root.$emit('preview-deleted', this.$route.path)
+          this.closeHovers()
           return
         }
+
+        this.closeHovers()
 
         if (this.selectedCount === 0) {
           return

--- a/frontend/src/components/prompts/Delete.vue
+++ b/frontend/src/components/prompts/Delete.vue
@@ -38,7 +38,7 @@ export default {
           await api.remove(this.$route.path)
           buttons.success('delete')
 
-          this.$root.$emit('preview-deleted', this.$route.path)
+          this.$root.$emit('preview-deleted')
           this.closeHovers()
           return
         }

--- a/frontend/src/components/prompts/Delete.vue
+++ b/frontend/src/components/prompts/Delete.vue
@@ -20,7 +20,6 @@
 <script>
 import {mapGetters, mapMutations, mapState} from 'vuex'
 import { files as api } from '@/api'
-import url from '@/utils/url'
 import buttons from '@/utils/buttons'
 
 export default {
@@ -39,7 +38,8 @@ export default {
         if (!this.isListing) {
           await api.remove(this.$route.path)
           buttons.success('delete')
-          this.$router.push({ path: url.removeLastDir(this.$route.path) + '/' })
+
+          this.$root.$emit('preview_deleted', this.$route.path)
           return
         }
 


### PR DESCRIPTION
**Description**
Deletions made while previewing now immediately load the preview of the next file in the list. When the last file is deleted, previewing ends and returns to the file list, as before.

Closes #1091