### PR TITLE
feat: implemented hideDotfiles feature in the backend

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -32,7 +32,8 @@
     "toggleSidebar": "Toggle sidebar",
     "update": "Update",
     "upload": "Upload",
-    "permalink": "Get Permanent Link"
+    "permalink": "Get Permanent Link",
+    "hideDotfiles": "Hide dotfiles"
   },
   "success": {
     "linkCopied": "Link copied!"
@@ -188,7 +189,8 @@
       "execute": "Execute commands",
       "rename": "Rename or move files and directories",
       "share": "Share files"
-    }
+    },
+    "hideDotfiles": "Hide dotfiles"
   },
   "sidebar": {
     "help": "Help",

--- a/frontend/src/views/settings/Profile.vue
+++ b/frontend/src/views/settings/Profile.vue
@@ -6,6 +6,7 @@
       </div>
 
       <div class="card-content">
+        <p><input type="checkbox" v-model="hideDotfiles"> {{ $t('settings.hideDotfiles') }}</p>
         <h3>{{ $t('settings.language') }}</h3>
         <languages class="input input--block" :locale.sync="locale"></languages>
       </div>
@@ -67,6 +68,7 @@ export default {
   },
   created () {
     this.locale = this.user.locale
+    this.hideDotfiles = this.user.hideDotfiles
   },
   methods: {
     ...mapMutations([ 'updateUser' ]),
@@ -90,8 +92,8 @@ export default {
       event.preventDefault()
 
       try {
-        const data = { id: this.user.id, locale: this.locale }
-        await api.update(data, ['locale'])
+        const data = { id: this.user.id, locale: this.locale, hideDotfiles: this.hideDotfiles }
+        await api.update(data, ['locale', 'hideDotfiles'])
         this.updateUser(data)
         this.$showSuccess(this.$t('settings.settingsUpdated'))
       } catch (e) {

--- a/http/auth.go
+++ b/http/auth.go
@@ -26,6 +26,7 @@ type userInfo struct {
 	Perm         users.Permissions `json:"perm"`
 	Commands     []string          `json:"commands"`
 	LockPassword bool              `json:"lockPassword"`
+	HideDotfiles bool              `json:"hideDotfiles"`
 }
 
 type authToken struct {
@@ -175,6 +176,7 @@ func printToken(w http.ResponseWriter, _ *http.Request, d *data, user *users.Use
 			Perm:         user.Perm,
 			LockPassword: user.LockPassword,
 			Commands:     user.Commands,
+			HideDotfiles: user.HideDotfiles,
 		},
 		StandardClaims: jwt.StandardClaims{
 			IssuedAt:  time.Now().Unix(),

--- a/http/data.go
+++ b/http/data.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tomasen/realip"
 
+	"github.com/filebrowser/filebrowser/v2/rules"
 	"github.com/filebrowser/filebrowser/v2/runner"
 	"github.com/filebrowser/filebrowser/v2/settings"
 	"github.com/filebrowser/filebrowser/v2/storage"
@@ -26,6 +27,10 @@ type data struct {
 
 // Check implements rules.Checker.
 func (d *data) Check(path string) bool {
+	if d.user.HideDotfiles && rules.MatchHidden.Matches(path) {
+		return false
+	}
+
 	allow := true
 	for _, rule := range d.settings.Rules {
 		if rule.Matches(path) {

--- a/http/data.go
+++ b/http/data.go
@@ -27,7 +27,7 @@ type data struct {
 
 // Check implements rules.Checker.
 func (d *data) Check(path string) bool {
-	if d.user.HideDotfiles && rules.MatchHidden.Matches(path) {
+	if d.user.HideDotfiles && rules.MatchHidden(path) {
 		return false
 	}
 

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -22,7 +22,7 @@ type Rule struct {
 // MatchHidden matches paths with a basename
 // that begins with a dot.
 func MatchHidden(path string) bool {
-	return filepath.Base(path)[0] == '.'
+	return strings.HasPrefix(filepath.Base(path), ".")
 }
 
 // Matches matches a path against a rule.

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -18,9 +19,10 @@ type Rule struct {
 	Regexp *Regexp `json:"regexp"`
 }
 
-var MatchHidden = Rule{
-	Regex:  true,
-	Regexp: &Regexp{Raw: `\/\..*$`},
+// MatchHidden matches paths with a basename
+// that begins with a dot.
+func MatchHidden(path string) bool {
+	return filepath.Base(path)[0] == '.'
 }
 
 // Matches matches a path against a rule.

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -18,6 +18,11 @@ type Rule struct {
 	Regexp *Regexp `json:"regexp"`
 }
 
+var MatchHidden = Rule{
+	Regex:  true,
+	Regexp: &Regexp{Raw: `\/\..*$`},
+}
+
 // Matches matches a path against a rule.
 func (r *Rule) Matches(path string) bool {
 	if r.Regex {

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -16,8 +16,8 @@ func TestMatchHidden(t *testing.T) {
 
 	for path, want := range cases {
 		got := MatchHidden(path)
-		if got != truth {
-			t.Errorf("MatchHidden(%s)=%v; want %v", path, got, truth)
+		if got != want {
+			t.Errorf("MatchHidden(%s)=%v; want %v", path, got, want)
 		}
 	}
 }

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -14,7 +14,7 @@ func TestMatchHidden(t *testing.T) {
 		"/Dockerfile":         false,
 	}
 
-	for path, truth := range cases {
+	for path, want := range cases {
 		got := MatchHidden(path)
 		if got != truth {
 			t.Errorf("MatchHidden(%s)=%v; want %v", path, got, truth)

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -1,0 +1,23 @@
+package rules
+
+import "testing"
+
+func TestMatchHidden(t *testing.T) {
+	cases := map[string]bool{
+		"/":                   false,
+		"/src":                false,
+		"/src/":               false,
+		"/.circleci":          true,
+		"/a/b/c/.docker.json": true,
+		".docker.json":        true,
+		"Dockerfile":          false,
+		"/Dockerfile":         false,
+	}
+
+	for path, truth := range cases {
+		got := MatchHidden(path)
+		if got != truth {
+			t.Errorf("MatchHidden(%s)=%v; want %v", path, got, truth)
+		}
+	}
+}

--- a/settings/defaults.go
+++ b/settings/defaults.go
@@ -8,12 +8,13 @@ import (
 // UserDefaults is a type that holds the default values
 // for some fields on User.
 type UserDefaults struct {
-	Scope    string            `json:"scope"`
-	Locale   string            `json:"locale"`
-	ViewMode users.ViewMode    `json:"viewMode"`
-	Sorting  files.Sorting     `json:"sorting"`
-	Perm     users.Permissions `json:"perm"`
-	Commands []string          `json:"commands"`
+	Scope        string            `json:"scope"`
+	Locale       string            `json:"locale"`
+	ViewMode     users.ViewMode    `json:"viewMode"`
+	Sorting      files.Sorting     `json:"sorting"`
+	Perm         users.Permissions `json:"perm"`
+	Commands     []string          `json:"commands"`
+	HideDotfiles bool              `json:"hideDotfiles"`
 }
 
 // Apply applies the default options to a user.
@@ -24,4 +25,5 @@ func (d *UserDefaults) Apply(u *users.User) {
 	u.Perm = d.Perm
 	u.Sorting = d.Sorting
 	u.Commands = d.Commands
+	u.HideDotfiles = d.HideDotfiles
 }

--- a/users/users.go
+++ b/users/users.go
@@ -33,6 +33,7 @@ type User struct {
 	Sorting      files.Sorting `json:"sorting"`
 	Fs           afero.Fs      `json:"-" yaml:"-"`
 	Rules        []rules.Rule  `json:"rules"`
+	HideDotfiles bool          `json:"hideDotfiles"`
 }
 
 // GetRules implements rules.Provider.


### PR DESCRIPTION
This PR addresses https://github.com/filebrowser/filebrowser/issues/1084.

Per @o1egl, I've rewritten my previous PR (https://github.com/filebrowser/filebrowser/pull/1085) to move the filtering logic to the backend. 

By default the `hideDotfiles` options is turned off, and it can be turned on in profile settings.