### PR TITLE
Add ablity to disable file detection in listing

### DIFF
--- a/files/file.go
+++ b/files/file.go
@@ -163,10 +163,7 @@ func (i *FileInfo) detectType(modify, saveContent bool) error {
 	case strings.HasPrefix(mimetype, "image"):
 		i.Type = "image"
 		return nil
-	case (len(buffer) > 0 && isBinary(buffer)) || i.Size > 10*1024*1024: // 10 MB
-		i.Type = "blob"
-		return nil
-	default:
+	case strings.HasPrefix(mimetype, "text"):
 		i.Type = "text"
 
 		if !modify {
@@ -182,6 +179,9 @@ func (i *FileInfo) detectType(modify, saveContent bool) error {
 
 			i.Content = string(content)
 		}
+	default:
+		i.Type = "blob"
+		return nil
 	}
 
 	return nil

--- a/files/utils.go
+++ b/files/utils.go
@@ -2,53 +2,7 @@ package files
 
 import (
 	"os"
-	"unicode/utf8"
 )
-
-func isBinary(content []byte) bool {
-	maybeStr := string(content)
-	runeCnt := utf8.RuneCount(content)
-	runeIndex := 0
-	gotRuneErrCnt := 0
-	firstRuneErrIndex := -1
-
-	const (
-		// 8 and below are control chars (e.g. backspace, null, eof, etc)
-		maxControlCharsCode = 8
-		// 0xFFFD(65533) is  the "error" Rune or "Unicode replacement character"
-		// see https://golang.org/pkg/unicode/utf8/#pkg-constants
-		unicodeReplacementChar = 0xFFFD
-	)
-
-	for _, b := range maybeStr {
-		if b <= maxControlCharsCode {
-			return true
-		}
-
-		if b == unicodeReplacementChar {
-			// if it is not the last (utf8.UTFMax - x) rune
-			if runeCnt > utf8.UTFMax && runeIndex < runeCnt-utf8.UTFMax {
-				return true
-			}
-			// else it is the last (utf8.UTFMax - x) rune
-			// there maybe Vxxx, VVxx, VVVx, thus, we may got max 3 0xFFFD rune (assume V is the byte we got)
-			// for Chinese, it can only be Vxx, VVx, we may got max 2 0xFFFD rune
-			gotRuneErrCnt++
-
-			// mark the first time
-			if firstRuneErrIndex == -1 {
-				firstRuneErrIndex = runeIndex
-			}
-		}
-		runeIndex++
-	}
-
-	// if last (utf8.UTFMax - x ) rune has the "error" Rune, but not all
-	if firstRuneErrIndex != -1 && gotRuneErrCnt != runeCnt-firstRuneErrIndex {
-		return true
-	}
-	return false
-}
 
 func IsNamedPipe(mode os.FileMode) bool {
 	return mode&os.ModeNamedPipe != 0

--- a/files/utils.go
+++ b/files/utils.go
@@ -5,7 +5,7 @@ import (
 	"unicode/utf8"
 )
 
-func isBinary(content []byte, _ int) bool {
+func isBinary(content []byte) bool {
 	maybeStr := string(content)
 	runeCnt := utf8.RuneCount(content)
 	runeIndex := 0


### PR DESCRIPTION
Let's start from the beginning: there might be a better solution to the issue I solve with this PR.

In my situation, I'm accessing folders that contains lots of files (for instance, more than 1000 images). With the current version of filebrowser, it takes ages to display the content of this kind of folder, and I found out after some tests that it was due to the file type detection: after commenting the related lines, the folder appears as soon as I clicked on it.

This PR adds an option to disable this file detection on the listing, making the tool usable in this kind of situation. 🙂 However, I haven't digged that much into the guilty code: if you're not fine with those changes, I can take more time to understand exactly what's going one to find a better way!

Note that the configuration entry is only used for the listing, I believe it makes sense to keep it everywhere else (except for the deletion endpoint).