### PR TITLE
fix recaptcha race condition

### DIFF
--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -41,8 +41,10 @@ export default {
   mounted () {
     if (!recaptcha) return
 
-    window.grecaptcha.render('recaptcha', {
-      sitekey: recaptchaKey
+    window.grecaptcha.ready(function () {
+      window.grecaptcha.render('recaptcha', {
+        sitekey: recaptchaKey
+      })
     })
   },
   methods: {


### PR DESCRIPTION
**Description**
Currently when using recaptcha, there's a chance when vue mounted was called, render was not ready. Can be reproduced on macos big sur 11.01 and ipad OS 14.2 safari browser.

Using ready function to render the recaptcha. Fixes [1167](https://github.com/filebrowser/filebrowser/issues/1167);

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [ ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [ ] AVOID breaking the continuous integration build.

**Further comments**
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
