### PR TITLE
delete extra remove prefix

### DIFF
--- a/frontend/src/api/files.js
+++ b/frontend/src/api/files.js
@@ -121,7 +121,7 @@ function moveCopy (items, copy = false, overwrite = false, rename = false) {
   let promises = []
 
   for (let item of items) {
-    const from = removePrefix(item.from)
+    const from = item.from
     const to = encodeURIComponent(removePrefix(item.to))
     const url = `${from}?action=${copy ? 'copy' : 'rename'}&destination=${to}&override=${overwrite}&rename=${rename}`
     promises.push(resourceAction(url, 'PATCH'))


### PR DESCRIPTION
**Description**
When there is a folder named files in the user root directory, copy, rename, move will [fail](https://github.com/filebrowser/filebrowser/issues/1185).

These operations call [moveCopy](https://github.com/filebrowser/filebrowser/blob/bc4a6462ced43a1f754b8ad4aae2d770a1750051/frontend/src/api/files.js#L124) function. Note the strip prefix. However, in turn this function calls [resourceAction](https://github.com/filebrowser/filebrowser/blob/bc4a6462ced43a1f754b8ad4aae2d770a1750051/frontend/src/api/files.js#L35) which strips prefix yet again. moveCopy's strip is unnecessary in this case.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [ ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [ ] AVOID breaking the continuous integration build.

**Further comments**
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
