### PR TITLE
Add LDAP support

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -4,12 +4,13 @@ import (
 	"net/http"
 
 	"github.com/filebrowser/filebrowser/v2/users"
+	"github.com/filebrowser/filebrowser/v2/settings"
 )
 
 // Auther is the authentication interface.
 type Auther interface {
 	// Auth is called to authenticate a request.
-	Auth(r *http.Request, s *users.Storage, root string) (*users.User, error)
+	Auth(r *http.Request, s *users.Storage, set *settings.Storage, root string) (*users.User, error)
 	// LoginPage indicates if this auther needs a login page.
 	LoginPage() bool
 }

--- a/auth/json.go
+++ b/auth/json.go
@@ -26,7 +26,7 @@ type JSONAuth struct {
 }
 
 // Auth authenticates the user via a json in content body.
-func (a JSONAuth) Auth(r *http.Request, sto *users.Storage, root string) (*users.User, error) {
+func (a JSONAuth) Auth(r *http.Request, sto *users.Storage, set *settings.Storage, root string) (*users.User, error) {
 	var cred jsonCred
 
 	if r.Body == nil {

--- a/auth/ldap.go
+++ b/auth/ldap.go
@@ -1,0 +1,158 @@
+package auth
+
+import (
+    "net/http"
+    "encoding/json"
+    "crypto/tls"
+    "fmt"
+    "strings"
+
+    "github.com/filebrowser/filebrowser/v2/settings"
+    "github.com/filebrowser/filebrowser/v2/users"
+    "github.com/filebrowser/filebrowser/v2/errors"
+    "github.com/go-ldap/ldap/v3"
+)
+
+const MethodLDAPAuth settings.AuthMethod = "ldap"
+
+type LDAPAuth struct {
+    Server     string `json:"server"`
+    StartTLS   bool   `json:"starttls"`
+    SkipVerify bool   `json:"skipverify"`
+    BaseDN     string `json:"basedn"`
+    UserOU     string `json:"userou"`
+    GroupOU    string `json:"groupou"`
+    UserCN     string `json:"usercn"`
+    AdminCN    string `json:"admincn"`
+    UserHome   string `json:"userhome"`
+}
+
+func (a LDAPAuth) Auth(r *http.Request, sto *users.Storage, set *settings.Storage, root string) (user *users.User, err error) {
+    var cred jsonCred
+
+    if r.Body == nil {
+        return nil, errors.ErrEmptyRequest
+    }
+
+    err = json.NewDecoder(r.Body).Decode(&cred)
+    if err != nil {
+        return nil, err
+    }
+
+    p := strings.Split(a.Server, ":")
+    var l *ldap.Conn
+    if p[0] == "ldaps" {
+        l, err = ldap.DialURL(a.Server, ldap.DialWithTLSConfig(&tls.Config{InsecureSkipVerify: a.SkipVerify}))
+    } else {
+        l, err = ldap.DialURL(a.Server)
+        if err != nil {
+            return nil, err
+        }
+        if a.StartTLS {
+            err = l.StartTLS(&tls.Config{InsecureSkipVerify: a.SkipVerify})
+        }
+    }
+    if err != nil {
+        return nil, err
+    }
+    bind := fmt.Sprintf("uid=%s,ou=%s,%s", cred.Username, a.UserOU, a.BaseDN)
+    err = l.Bind(bind, cred.Password)
+    if err != nil {
+        return nil, err
+    }
+
+    var s *settings.Settings
+    s, err = set.Get()
+    if err != nil {
+        return nil, err
+    }
+
+    var isadmin bool
+    var hashome string = s.Defaults.Scope
+    if a.AdminCN != "" || a.UserCN != "" || a.UserHome != "" {
+        searchRequest := ldap.NewSearchRequest(
+            bind,
+            ldap.ScopeWholeSubtree,
+            ldap.NeverDerefAliases,
+            0,
+            0,
+            false,
+            "(&(objectClass=*))",
+            []string{"memberOf", a.UserHome},
+            nil,
+        )
+        searchResult, err := l.Search(searchRequest)
+        if err != nil {
+            return nil, err
+        }
+        l.Close()
+
+        var isuser bool
+        admingrp := fmt.Sprintf("cn=%s,ou=%s,%s", a.AdminCN, a.GroupOU, a.BaseDN)
+        usergrp := fmt.Sprintf("cn=%s,ou=%s,%s", a.UserCN, a.GroupOU, a.BaseDN)
+        for _, group := range searchResult.Entries[0].GetAttributeValues("memberOf") {
+            switch group {
+                case admingrp:
+                    isadmin = true
+                case usergrp:
+                    isuser = true 
+            }
+        }
+        if a.UserHome != "" {
+            hashome = searchResult.Entries[0].GetAttributeValue(a.UserHome)
+        }
+
+        // Deny entry to non-users if user group is enabled, admins always have access
+        if !isadmin && a.UserCN != "" && !isuser {
+            return nil, errors.ErrPermissionDenied
+        }
+    }
+
+    user, err = sto.Get(root, cred.Username)
+    if err != nil {
+        if err == errors.ErrNotExist {
+            user = &users.User{
+                Username: cred.Username,
+                Password: "much5af3v3rys3cur3", // No point hashing the password since we don't use it
+                LockPassword: true,             // Prevent user password change which would only lead to confusion
+            }
+            s.Defaults.Apply(user)
+            user.Perm.Admin = isadmin
+            if user.Scope != hashome {
+                user.Scope = hashome
+            } else {
+                home, err := s.MakeUserDir(cred.Username, user.Scope, root)
+                if err != nil {
+                    return nil, err
+                }
+                user.Scope = home
+            }
+            err = sto.Save(user)
+            if err != nil {
+                return nil, err
+            }
+        } else {
+            return nil, err
+        }
+    } else {
+        // Keep profile in sync with LDAP
+        var update bool
+        if user.Perm.Admin != isadmin {
+            user.Perm.Admin = isadmin
+            update = true
+        }
+        if user.Scope != hashome {
+            user.Scope = hashome
+            update = true
+        }
+        if update {
+            sto.Update(user)
+        }
+    }
+
+    return
+}
+
+func (a LDAPAuth) LoginPage() bool {
+    return true
+}

--- a/auth/none.go
+++ b/auth/none.go
@@ -14,7 +14,7 @@ const MethodNoAuth settings.AuthMethod = "noauth"
 type NoAuth struct{}
 
 // Auth uses authenticates user 1.
-func (a NoAuth) Auth(r *http.Request, sto *users.Storage, root string) (*users.User, error) {
+func (a NoAuth) Auth(r *http.Request, sto *users.Storage, set *settings.Storage, root string) (*users.User, error) {
 	return sto.Get(root, uint(1))
 }
 

--- a/auth/proxy.go
+++ b/auth/proxy.go
@@ -18,7 +18,7 @@ type ProxyAuth struct {
 }
 
 // Auth authenticates the user via an HTTP header.
-func (a ProxyAuth) Auth(r *http.Request, sto *users.Storage, root string) (*users.User, error) {
+func (a ProxyAuth) Auth(r *http.Request, sto *users.Storage, set *settings.Storage, root string) (*users.User, error) {
 	username := r.Header.Get(a.Header)
 	user, err := sto.Get(root, username)
 	if err == errors.ErrNotExist {

--- a/auth/storage.go
+++ b/auth/storage.go
@@ -13,13 +13,14 @@ type StorageBackend interface {
 
 // Storage is a auth storage.
 type Storage struct {
-	back  StorageBackend
-	users *users.Storage
+	back     StorageBackend
+	users    *users.Storage
+	settings *settings.Storage
 }
 
 // NewStorage creates a auth storage from a backend.
-func NewStorage(back StorageBackend, userStore *users.Storage) *Storage {
-	return &Storage{back: back, users: userStore}
+func NewStorage(back StorageBackend, userStore *users.Storage, settingsStore *settings.Storage) *Storage {
+	return &Storage{back: back, users: userStore, settings: settingsStore}
 }
 
 // Get wraps a StorageBackend.Get.

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -24,7 +24,7 @@
           <span>{{ $t('sidebar.settings') }}</span>
         </router-link>
 
-        <button v-if="authMethod == 'json'" @click="logout" class="action" id="logout" :aria-label="$t('sidebar.logout')" :title="$t('sidebar.logout')">
+        <button v-if="authMethod == 'json' || authMethod == 'ldap'" @click="logout" class="action" id="logout" :aria-label="$t('sidebar.logout')" :title="$t('sidebar.logout')">
           <i class="material-icons">exit_to_app</i>
           <span>{{ $t('sidebar.logout') }}</span>
         </button>

--- a/http/auth.go
+++ b/http/auth.go
@@ -99,7 +99,7 @@ var loginHandler = func(w http.ResponseWriter, r *http.Request, d *data) (int, e
 		return http.StatusInternalServerError, err
 	}
 
-	user, err := auther.Auth(r, d.store.Users, d.server.Root)
+	user, err := auther.Auth(r, d.store.Users, d.store.Settings, d.server.Root)
 	if err == os.ErrPermission {
 		return http.StatusForbidden, nil
 	} else if err != nil {

--- a/storage/bolt/auth.go
+++ b/storage/bolt/auth.go
@@ -22,6 +22,8 @@ func (s authBackend) Get(t settings.AuthMethod) (auth.Auther, error) {
 		auther = &auth.ProxyAuth{}
 	case auth.MethodNoAuth:
 		auther = &auth.NoAuth{}
+	case auth.MethodLDAPAuth:
+		auther = &auth.LDAPAuth{}
 	default:
 		return nil, errors.ErrInvalidAuthMethod
 	}

--- a/storage/bolt/bolt.go
+++ b/storage/bolt/bolt.go
@@ -15,7 +15,7 @@ func NewStorage(db *storm.DB) (*storage.Storage, error) {
 	userStore := users.NewStorage(usersBackend{db: db})
 	shareStore := share.NewStorage(shareBackend{db: db})
 	settingsStore := settings.NewStorage(settingsBackend{db: db})
-	authStore := auth.NewStorage(authBackend{db: db}, userStore)
+	authStore := auth.NewStorage(authBackend{db: db}, userStore, settingsStore)
 
 	err := save(db, "version", 2)
 	if err != nil {


### PR DESCRIPTION
Adds LDAP as an authentication/authorization backend using go-ldap/ldap
Profiles are still stored in bolt to keep things simple and avoid the need to alter the AD scheme.

This works by BINDING the user to the configured `ldap.userou` and, if successful, fetch the matching profile, if the profile doesn't exist it will be created using the configured DEFAULTS.

Access can be further restricted by setting the `ldap.usercn` which will limit access to members of this group.
Admin permission (in File Browser) is controlled by the `ldap.admincn` group which defaults to `file_browser_admins` you will have to create this group under `ldap.groupou` to use this feature.
Note that this only works if your AD server supports the `memberOf` attribute.

This is the most straight forward approach for people who simply want to authenticate File Browser against LDAP without the need to add custom objectClasses, attributesTypes and ACLs.

To get started simple set the `auth.method` to `ldap` and change the defaults as needed, see `config set --help` for all available `--ldap.*` options.

e.g. `config set --auth.method=ldap --ldap.starttls=false --ldap.basedn=dc=filebrowser,dc=org`

Which will connect to the LDAP server running on localhost skipping StartTLS.

Note that you will always need to pass all changed `--ldap.*` options to `config set --auth.method=ldap` or they will be reset to their respective defaults because of #715

There is a special option called `ldap.userhome` which, if set, will be used as the users scope.
By default this is set to the `homeDirectory` attribute, which in my case is pointing to a users config directory since my users don't have local accounts.

You can change this to anything you like as long as it is a TEXT attribute including adding a dedicated attributeType (e.g. fileBrowserScope) using a custom scheme.

Changes to admin permission and user scope are synchronized on every login whenever they change from LDAP to File Browser meaning you CANNOT change any LDAP attributes in File Browser for the sake of the Directory Managers sanity.
e.g. a user previously member of `ldap.admincn` will lose its admin permission on the next login if removed from the group and vice versa.
Same with `ldap.userhome`
The user password change in file browser is disabled by default during profile creation since the (File Browser) password isn't used.

This certainly needs testing, especially against different LDAP servers/version as i only tested it with DS389 (in development) and AD2012 (in production)

Closes #1164 (among other already closed LDAP feature requests)