### PR TITLE
fix search by type with empty file name

### DIFF
--- a/search/conditions.go
+++ b/search/conditions.go
@@ -75,7 +75,7 @@ func parseSearch(value string) *searchOptions {
 		value = typeRegexp.ReplaceAllString(value, "")
 	}
 
-	// If it's canse insensitive, put everything in lowercase.
+	// If it's case insensitive, put everything in lowercase.
 	if !opts.CaseSensitive {
 		value = strings.ToLower(value)
 	}

--- a/search/search.go
+++ b/search/search.go
@@ -29,6 +29,8 @@ func Search(fs afero.Fs, scope, query string, checker rules.Checker, found func(
 		originalPath = strings.TrimPrefix(originalPath, "/")
 		originalPath = "/" + originalPath
 		path := originalPath
+		originalPath = strings.TrimPrefix(originalPath, scope)
+		originalPath = strings.TrimPrefix(originalPath, "/")
 
 		if path == scope {
 			return nil
@@ -43,25 +45,18 @@ func Search(fs afero.Fs, scope, query string, checker rules.Checker, found func(
 		}
 
 		if len(search.Conditions) > 0 {
-			match := false
-
 			for _, t := range search.Conditions {
 				if t(path) {
-					match = true
-					break
+					return found(originalPath, f)
 				}
 			}
 
-			if !match {
-				return nil
-			}
+			return nil
 		}
 
 		if len(search.Terms) > 0 {
 			for _, term := range search.Terms {
 				if strings.Contains(path, term) {
-					originalPath = strings.TrimPrefix(originalPath, scope)
-					originalPath = strings.TrimPrefix(originalPath, "/")
 					return found(originalPath, f)
 				}
 			}

--- a/search/search.go
+++ b/search/search.go
@@ -29,8 +29,6 @@ func Search(fs afero.Fs, scope, query string, checker rules.Checker, found func(
 		originalPath = strings.TrimPrefix(originalPath, "/")
 		originalPath = "/" + originalPath
 		path := originalPath
-		originalPath = strings.TrimPrefix(originalPath, scope)
-		originalPath = strings.TrimPrefix(originalPath, "/")
 
 		if path == scope {
 			return nil
@@ -45,21 +43,32 @@ func Search(fs afero.Fs, scope, query string, checker rules.Checker, found func(
 		}
 
 		if len(search.Conditions) > 0 {
+			match := false
+
 			for _, t := range search.Conditions {
 				if t(path) {
-					return found(originalPath, f)
+					match = true
+					break
 				}
 			}
 
-			return nil
+			if !match {
+				return nil
+			}
 		}
 
 		if len(search.Terms) > 0 {
 			for _, term := range search.Terms {
 				if strings.Contains(path, term) {
+					originalPath = strings.TrimPrefix(originalPath, scope)
+					originalPath = strings.TrimPrefix(originalPath, "/")
 					return found(originalPath, f)
 				}
 			}
+		} else {
+			originalPath = strings.TrimPrefix(originalPath, scope)
+			originalPath = strings.TrimPrefix(originalPath, "/")
+			return found(originalPath, f)
 		}
 
 		return nil


### PR DESCRIPTION
**Description**
Currently, when searching by type and not giving any filename, filebrowser shows up nothing. Because there is only a return nil on that execution path.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [ ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [ ] AVOID breaking the continuous integration build.

**Further comments**
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
