### PR TITLE
Fix URL to documentation in templates

### DIFF
--- a/frontend/src/views/settings/Global.vue
+++ b/frontend/src/views/settings/Global.vue
@@ -23,7 +23,7 @@
         <h3>{{ $t('settings.branding') }}</h3>
 
         <i18n path="settings.brandingHelp" tag="p" class="small">
-          <a class="link" target="_blank" href="https://filebrowser.xyz/configuration/custom-branding">{{ $t('settings.documentation') }}</a>
+          <a class="link" target="_blank" href="https://filebrowser.org/configuration/custom-branding">{{ $t('settings.documentation') }}</a>
         </i18n>
 
         <p>
@@ -78,7 +78,7 @@
         <i18n path="settings.commandRunnerHelp" tag="p" class="small">
           <code>FILE</code>
           <code>SCOPE</code>
-          <a class="link" target="_blank" href="https://filebrowser.xyz/configuration/command-runner">{{ $t('settings.documentation') }}</a>
+          <a class="link" target="_blank" href="https://filebrowser.org/configuration/command-runner">{{ $t('settings.documentation') }}</a>
         </i18n>
 
         <div v-for="command in settings.commands" :key="command.name" class="collapsible">


### PR DESCRIPTION
**Description**

https://filebrowser.xyz does not support HTTPS connection, so links is invalid:
```
$ LANG="en_US.UTF-8" curl https://filebrowser.xyz
curl: (7) Failed to connect to filebrowser.xyz port 443: Połączenie odrzucone
```

> If the feature changes current behaviour, explain why your solution is better.

It works and page load successfully.

- [X] Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [X] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [X] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [X] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [X] AVOID breaking the continuous integration build.

**Further comments**
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
