### PR TITLE
allow navigation information to be cached

### DIFF
--- a/frontend/src/store/getters.js
+++ b/frontend/src/store/getters.js
@@ -13,6 +13,15 @@ const getters = {
 
     let sum = state.upload.progress.reduce((acc, val) => acc + val)
     return Math.ceil(sum / state.upload.size * 100);
+  },
+  getLastViewedDetail: state => (path) => {
+    if (state.lastViewed.details.has(path)) {
+      let i = state.lastViewed.paths.indexOf(path)
+      state.lastViewed.paths.splice(i, 1)
+      state.lastViewed.paths.push(path)
+      return state.lastViewed.details.get(path)
+    }
+    return null
   }
 }
 

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -25,7 +25,12 @@ const state = {
   showMessage: null,
   showConfirm: null,
   previewMode: false,
-  hash: ''
+  hash: '',
+  lastViewed: {
+    path: '',
+    clicked: '',
+    pageOffset: 0
+  }
 }
 
 export default new Vuex.Store({

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -27,9 +27,8 @@ const state = {
   previewMode: false,
   hash: '',
   lastViewed: {
-    path: '',
-    clicked: '',
-    pageOffset: 0
+    paths: [],
+    details: new Map()
   }
 }
 

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -88,7 +88,14 @@ const mutations = {
     state.previewMode = value
   },
   setHash: (state, value) => (state.hash = value),
-  setLastViewed: (state, value) => (state.lastViewed = value)
+  addLastViewed: (state, value) => {
+    let paths = state.lastViewed.paths
+    if (!state.lastViewed.details.has(value.path)) paths.push(value.path)
+    state.lastViewed.details.set(value.path, value.detail)
+    if (paths.length > 10) {
+      state.lastViewed.details.delete(paths.shift())
+    }
+  }
 }
 
 export default mutations

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -88,6 +88,7 @@ const mutations = {
     state.previewMode = value
   },
   setHash: (state, value) => (state.hash = value),
+  setLastViewed: (state, value) => (state.lastViewed = value)
 }
 
 export default mutations

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -145,13 +145,13 @@ export default {
       await this.fetchData()
       let detail = this.getLastViewedDetail(clean(`/${this.$route.params.pathMatch}`))
       if (detail !== null) {
-        let offset = Math.min(1000, detail.pageOffset), oldPageOffset = 0, pageOffset = window.pageYOffset
-        let int = setInterval(function () {
-          window.scrollTo(0, offset)
+        let offsetTarget = Math.min(1000, detail.pageOffset), oldPageOffset = 0, pageOffset = window.pageYOffset
+        let interval = setInterval(function () {
+          window.scrollTo(0, offsetTarget)
+          if (offsetTarget >= detail.pageOffset || oldPageOffset === pageOffset) clearInterval(interval);
           oldPageOffset = pageOffset
           pageOffset = window.pageYOffset
-          if (offset >= detail.pageOffset || oldPageOffset === pageOffset) clearInterval(int);
-          offset += Math.min(1000, detail.pageOffset - offset)
+          offsetTarget += Math.min(1000, detail.pageOffset - offsetTarget)
         }, 20);
 
         for (let i = 0; i < this.req.items.length; i++) {


### PR DESCRIPTION
**Description**
Save navigation information.
Currently when navigating back from a preview, editor, the view will reset. This pr saves the last view navigation information.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [ ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [ ] AVOID breaking the continuous integration build.

**Further comments**
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
