### PR TITLE
Some fixes

### DIFF
--- a/frontend/src/api/pub.js
+++ b/frontend/src/api/pub.js
@@ -1,23 +1,47 @@
-import { fetchJSON, removePrefix } from './utils'
+import { fetchURL, removePrefix } from './utils'
 import { baseURL } from '@/utils/constants'
 
-export async function fetch(hash, password = "") {
-  return fetchJSON(`/api/public/share/${hash}`, {
+export async function fetch (url, password = "") {
+  url = removePrefix(url)
+
+  const res = await fetchURL(`/api/public/share${url}`, {
     headers: {'X-SHARE-PASSWORD': password},
   })
+
+  if (res.status === 200) {
+    let data = await res.json()
+    data.url = `/share${url}`
+
+    if (data.isDir) {
+      if (!data.url.endsWith('/')) data.url += '/'
+      data.items = data.items.map((item, index) => {
+        item.index = index
+        item.url = `${data.url}${encodeURIComponent(item.name)}`
+
+        if (item.isDir) {
+          item.url += '/'
+        }
+
+        return item
+      })
+    }
+
+    return data
+  } else {
+    throw new Error(res.status)
+  }
 }
 
 export function download(format, hash, token, ...files) {
   let url = `${baseURL}/api/public/dl/${hash}`
 
-  const prefix = `/share/${hash}`
   if (files.length === 1) {
-    url += removePrefix(files[0], prefix) + '?'
+    url += encodeURIComponent(files[0]) + '?'
   } else {
     let arg = ''
 
     for (let file of files) {
-      arg += removePrefix(file, prefix) + ','
+      arg += encodeURIComponent(file)  + ','
     }
 
     arg = arg.substring(0, arg.length - 1)

--- a/frontend/src/api/utils.js
+++ b/frontend/src/api/utils.js
@@ -33,12 +33,8 @@ export async function fetchJSON (url, opts) {
   }
 }
 
-export function removePrefix (url, prefix) {
-  if (url.startsWith('/files')) {
-    url = url.slice(6)
-  } else if (prefix) {
-    url = url.replace(prefix, '')
-  }
+export function removePrefix (url) {
+  url = url.split('/').splice(2).join('/')
 
   if (url === '') url = '/'
   if (url[0] !== '/') url = '/' + url

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -78,7 +78,11 @@ export default {
     },
     thumbnailUrl () {
       const path = this.url.replace(/^\/files\//, '')
-      return `${baseURL}/api/preview/thumb/${path}?auth=${this.jwt}&inline=true`
+
+      // reload the image when the file is replaced
+      const key = Date.parse(this.modified)
+
+      return `${baseURL}/api/preview/thumb/${path}?auth=${this.jwt}&inline=true&k=${key}`
     },
     isThumbsEnabled () {
       return enableThumbs

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -66,7 +66,7 @@ export default {
       return this.readOnly == undefined && this.user.perm.rename
     },
     canDrop () {
-      if (!this.isDir || this.readOnly == undefined) return false
+      if (!this.isDir || this.readOnly !== undefined) return false
 
       for (let i of this.selected) {
         if (this.req.items[i].url === this.url) {

--- a/frontend/src/components/prompts/Info.vue
+++ b/frontend/src/components/prompts/Info.vue
@@ -63,7 +63,7 @@ export default {
         return moment(this.req.modified).fromNow()
       }
 
-      return moment(this.req.items[this.selected[0]]).fromNow()
+      return moment(this.req.items[this.selected[0]].modified).fromNow()
     },
     name: function () {
       return this.selectedCount === 0 ? this.req.name : this.req.items[this.selected[0]].name

--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -123,15 +123,21 @@
   color: #fff;
 }
 
-#previewer .action i {
+#previewer header > .action i {
   color: #fff;
 }
 
-#previewer .action:hover {
+@media (min-width: 738px) {
+  #previewer header #dropdown .action i {
+    color: #fff;
+  }
+}
+
+#previewer header .action:hover {
   background-color: rgba(255, 255, 255, 0.3)
 }
 
-#previewer .action span {
+#previewer header .action span {
   display: none;
 }
 

--- a/frontend/src/utils/buttons.js
+++ b/frontend/src/utils/buttons.js
@@ -6,6 +6,10 @@ function loading (button) {
     return
   }
 
+  if (el.innerHTML == 'autorenew' || el.innerHTML == 'done') {
+    return
+  }
+
   el.dataset.icon = el.innerHTML
   el.style.opacity = 0
 

--- a/frontend/src/views/files/Listing.vue
+++ b/frontend/src/views/files/Listing.vue
@@ -588,8 +588,12 @@ export default {
 
           let files = []
 
-          for (let i of this.selected) {
-            files.push(this.req.items[i].url)
+          if (this.selectedCount > 0) {
+            for (let i of this.selected) {
+              files.push(this.req.items[i].url)
+            }
+          } else {
+            files.push(this.$route.path)
           }
 
           api.download(format, ...files)

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -102,10 +102,13 @@ export default {
       return `${baseURL}/api/raw${url.encodePath(this.req.path)}?auth=${this.jwt}`
     },
     previewUrl () {
+      // reload the image when the file is replaced
+      const key = Date.parse(this.req.modified)
+
       if (this.req.type === 'image' && !this.fullSize) {
-        return `${baseURL}/api/preview/big${url.encodePath(this.req.path)}?auth=${this.jwt}`
+        return `${baseURL}/api/preview/big${url.encodePath(this.req.path)}?auth=${this.jwt}&k=${key}`
       }
-      return `${baseURL}/api/raw${url.encodePath(this.req.path)}?auth=${this.jwt}`
+      return `${baseURL}/api/raw${url.encodePath(this.req.path)}?auth=${this.jwt}&k=${key}`
     },
     raw () {
       return `${this.previewUrl}&inline=true`

--- a/http/http.go
+++ b/http/http.go
@@ -54,8 +54,8 @@ func NewHandler(
 
 	api.PathPrefix("/resources").Handler(monkey(resourceGetHandler, "/api/resources")).Methods("GET")
 	api.PathPrefix("/resources").Handler(monkey(resourceDeleteHandler(fileCache), "/api/resources")).Methods("DELETE")
-	api.PathPrefix("/resources").Handler(monkey(resourcePostPutHandler, "/api/resources")).Methods("POST")
-	api.PathPrefix("/resources").Handler(monkey(resourcePostPutHandler, "/api/resources")).Methods("PUT")
+	api.PathPrefix("/resources").Handler(monkey(resourcePostHandler, "/api/resources")).Methods("POST")
+	api.PathPrefix("/resources").Handler(monkey(resourcePutHandler, "/api/resources")).Methods("PUT")
 	api.PathPrefix("/resources").Handler(monkey(resourcePatchHandler, "/api/resources")).Methods("PATCH")
 
 	api.Path("/shares").Handler(monkey(shareListHandler, "/api/shares")).Methods("GET")

--- a/http/http.go
+++ b/http/http.go
@@ -54,7 +54,7 @@ func NewHandler(
 
 	api.PathPrefix("/resources").Handler(monkey(resourceGetHandler, "/api/resources")).Methods("GET")
 	api.PathPrefix("/resources").Handler(monkey(resourceDeleteHandler(fileCache), "/api/resources")).Methods("DELETE")
-	api.PathPrefix("/resources").Handler(monkey(resourcePostHandler, "/api/resources")).Methods("POST")
+	api.PathPrefix("/resources").Handler(monkey(resourcePostHandler(fileCache), "/api/resources")).Methods("POST")
 	api.PathPrefix("/resources").Handler(monkey(resourcePutHandler, "/api/resources")).Methods("PUT")
 	api.PathPrefix("/resources").Handler(monkey(resourcePatchHandler, "/api/resources")).Methods("PATCH")
 

--- a/http/preview.go
+++ b/http/preview.go
@@ -79,7 +79,7 @@ func handleImagePreview(w http.ResponseWriter, r *http.Request, imgSvc ImgServic
 		return errToStatus(err), err
 	}
 
-	cacheKey := previewCacheKey(file.Path, previewSize)
+	cacheKey := previewCacheKey(file.Path, file.ModTime.Unix(), previewSize)
 	cachedFile, ok, err := fileCache.Load(r.Context(), cacheKey)
 	if err != nil {
 		return errToStatus(err), err
@@ -133,6 +133,6 @@ func handleImagePreview(w http.ResponseWriter, r *http.Request, imgSvc ImgServic
 	return 0, nil
 }
 
-func previewCacheKey(fPath string, previewSize PreviewSize) string {
-	return fPath + previewSize.String()
+func previewCacheKey(fPath string, fTime int64, previewSize PreviewSize) string {
+	return fmt.Sprintf("%x%x%x", fPath, fTime, previewSize)
 }

--- a/http/raw.go
+++ b/http/raw.go
@@ -173,13 +173,6 @@ func rawDirHandler(w http.ResponseWriter, r *http.Request, d *data, file *files.
 		return http.StatusInternalServerError, err
 	}
 
-	name := file.Name
-	if name == "." || name == "" {
-		name = "archive"
-	}
-	name += extension
-	w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.PathEscape(name))
-
 	err = ar.Create(w)
 	if err != nil {
 		return http.StatusInternalServerError, err
@@ -187,6 +180,18 @@ func rawDirHandler(w http.ResponseWriter, r *http.Request, d *data, file *files.
 	defer ar.Close()
 
 	commonDir := fileutils.CommonPrefix(filepath.Separator, filenames...)
+
+	var name string
+	if len(filenames) > 1 {
+		name = "_" + filepath.Base(commonDir)
+	} else {
+		name = file.Name
+	}
+	if name == "." || name == "" {
+		name = "archive"
+	}
+	name += extension
+	w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.PathEscape(name))
 
 	for _, fname := range filenames {
 		err = addFile(ar, d, fname, commonDir)

--- a/http/raw.go
+++ b/http/raw.go
@@ -108,8 +108,6 @@ var rawHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) 
 })
 
 func addFile(ar archiver.Writer, d *data, path, commonPath string) error {
-	// Checks are always done with paths with "/" as path separator.
-	path = strings.Replace(path, "\\", "/", -1)
 	if !d.Check(path) {
 		return nil
 	}
@@ -134,7 +132,7 @@ func addFile(ar archiver.Writer, d *data, path, commonPath string) error {
 
 	if path != commonPath {
 		filename := strings.TrimPrefix(path, commonPath)
-		filename = strings.TrimPrefix(filename, "/")
+		filename = strings.TrimPrefix(filename, string(filepath.Separator))
 		err = ar.Write(archiver.File{
 			FileInfo: archiver.FileInfo{
 				FileInfo:   info,
@@ -188,7 +186,7 @@ func rawDirHandler(w http.ResponseWriter, r *http.Request, d *data, file *files.
 	}
 	defer ar.Close()
 
-	commonDir := fileutils.CommonPrefix('/', filenames...)
+	commonDir := fileutils.CommonPrefix(filepath.Separator, filenames...)
 
 	for _, fname := range filenames {
 		err = addFile(ar, d, fname, commonDir)

--- a/http/resource.go
+++ b/http/resource.go
@@ -91,7 +91,7 @@ func resourceDeleteHandler(fileCache FileCache) handleFunc {
 
 func resourcePostHandler(fileCache FileCache) handleFunc {
 	return withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
-		if !d.user.Perm.Create {
+		if !d.user.Perm.Create || !d.Check(r.URL.Path) {
 			return http.StatusForbidden, nil
 		}
 
@@ -141,7 +141,7 @@ func resourcePostHandler(fileCache FileCache) handleFunc {
 }
 
 var resourcePutHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
-	if !d.user.Perm.Modify {
+	if !d.user.Perm.Modify || !d.Check(r.URL.Path) {
 		return http.StatusForbidden, nil
 	}
 
@@ -174,6 +174,9 @@ var resourcePatchHandler = withUser(func(w http.ResponseWriter, r *http.Request,
 	dst := r.URL.Query().Get("destination")
 	action := r.URL.Query().Get("action")
 	dst, err := url.QueryUnescape(dst)
+	if !d.Check(src) || !d.Check(dst) {
+		return http.StatusForbidden, nil
+	}
 	if err != nil {
 		return errToStatus(err), err
 	}


### PR DESCRIPTION
### fix: archive contains parent path on Windows
The compressed file of a directory has additional folder structure, having root of the application as root for the generated archive, when running on a Windows system.

### chore: split POST method on resource http handler
The handlers for the save and upload methods are becoming complex, which can trigger golang linting.

### fix: update image cache when replacing
The generated image preview for an image is not updated when the file was replaced. Adding the file time for the cache key will help to prevent mismatch previews.

### fix: stuck icon on header button
Making multiple presses on a header button in a short period can cause the icon to become stuck.

### fix: check rules on http resource handlers
The resource handlers are still processing requests when the user was deny rules.

### fix: item dragging on file listing
Typo on the listing item component was preventing dropping list items.

### fix: modified time on info prompt
The info prompt was displayed invalid data for the time field.

### fix: header dropdown icon color on previewer
The header buttons icons on previewer has color similar to the dropdown, making it not visible when the dropdown is showed on mobile.

### fix: full file path on share
The api is providing the path information relative to the application root.

### fix: encoded file path on share
The path is not being encoded on the share view, causing issues with special characters.

### fix: download current dir on file listing
The header download button is downloading the root folder instead of the current.

### fix: root path name on archive
Downloading a selection of files generate a archive having the root of the application as the name.