### PR TITLE
Wait for async command exit

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -102,6 +102,14 @@ func (r *Runner) exec(raw, evt, path, dst string, user *users.User) error {
 
 	if !blocking {
 		log.Printf("[INFO] Nonblocking Command: \"%s\"", strings.Join(command, " "))
+		defer func() {
+			go func() {
+				err := cmd.Wait()
+				if err != nil {
+					log.Printf("[INFO] Nonblocking Command \"%s\" failed: %s", strings.Join(command, " "), err)
+				}
+			}()
+		}()
 		return cmd.Start()
 	}
 


### PR DESCRIPTION
This prevents the accumulation of zombie processes when using
async (&) event commands. Also log async command failures.

For example when using

```shell
filebrowser cmds add before_copy 'true&'
```

the following zombie processes remain after 3 copies:

```shell
 232983 pts/3    Z+     0:00 [true] <defunct>
 232989 pts/3    Z+     0:00 [true] <defunct>
 233001 pts/3    Z+     0:00 [true] <defunct>

```


:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

This commit also logs failures of async commands:
```shell
[INFO] Nonblocking Command "false" failed: exit status 1
```