### PR TITLE
Some development tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _old
 rice-box.go
 .idea/
 filebrowser
+filebrowser.exe
 
 .DS_Store
 node_modules

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ build-frontend: | ; $(info $(M) building frontend…)
 ## build-backend: Build backend
 .PHONY: build-backend
 build-backend: | ; $(info $(M) building backend…)
-	$Q $(GO) build -ldflags '$(LDFLAGS)' -o filebrowser
+	$Q $(GO) build -ldflags '$(LDFLAGS)' -o .
 
 ## test: Run all tests
 .PHONY: test
@@ -61,7 +61,7 @@ test-frontend: | ; $(info $(M) running frontend tests…)
 
 ## test-backend: Run backend tests
 .PHONY: test-backend
-test-backend: | $(RICE) ; $(info $(M) running backend tests…)
+test-backend: | ; $(info $(M) running backend tests…)
 	$Q $(GO) test -v ./...
 
 ## lint: Lint

--- a/frontend/assets.go
+++ b/frontend/assets.go
@@ -1,3 +1,5 @@
+// +build !dev
+
 package frontend
 
 import "embed"

--- a/frontend/assets_dev.go
+++ b/frontend/assets_dev.go
@@ -1,0 +1,14 @@
+// +build dev
+
+package frontend
+
+import (
+	"io/fs"
+	"os"
+)
+
+var assets fs.FS = os.DirFS("frontend")
+
+func Assets() fs.FS {
+	return assets
+}


### PR DESCRIPTION
### chore: automatic output name on build
Allows the command to choose which name and extension will be used for the build output, useful when building for Windows.

### chore: frontend DirFS for development
Adds a build constraint that makes the backend use the os filesystem for frontend assets, making easier to view code changes by allowing live-reload.