### PR TITLE
Some fixes

### DIFF
--- a/files/file.go
+++ b/files/file.go
@@ -148,12 +148,15 @@ func (i *FileInfo) detectType(modify, saveContent, readHeader bool) error {
 	// of files couldn't be opened: we'd have immediately
 	// a 500 even though it doesn't matter. So we just log it.
 
-	var buffer []byte
-
 	mimetype := mime.TypeByExtension(i.Extension)
-	if mimetype == "" && readHeader {
+
+	var buffer []byte
+	if readHeader {
 		buffer = i.readFirstBytes()
-		mimetype = http.DetectContentType(buffer)
+
+		if mimetype == "" {
+			mimetype = http.DetectContentType(buffer)
+		}
 	}
 
 	switch {

--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -31,7 +31,7 @@
               <a target="_blank" :href="link" class="button button--flat">{{ $t('buttons.download') }}</a>
             </div>
             <div class="share__box__element share__box__center">
-              <qrcode-vue :value="link" size="200" level="M"></qrcode-vue>
+              <qrcode-vue :value="fullLink" size="200" level="M"></qrcode-vue>
             </div>
         </div>
         <div v-if="req.isDir && req.items.length > 0" class="share__box share__box__items">
@@ -160,6 +160,9 @@ export default {
 
       const path = this.$route.path.split('/').splice(2).join('/')
       return `${baseURL}/api/public/dl/${path}${queryArg}`
+    },
+    fullLink: function () {
+      return window.location.origin + this.link
     },
     humanSize: function () {
       if (this.req.isDir) {

--- a/http/data.go
+++ b/http/data.go
@@ -73,5 +73,5 @@ func handle(fn handleFunc, prefix string, store *storage.Storage, server *settin
 		}
 	})
 
-	return http.StripPrefix(prefix, handler)
+	return stripPrefix(prefix, handler)
 }

--- a/http/utils.go
+++ b/http/utils.go
@@ -56,11 +56,13 @@ func stripPrefix(prefix string, h http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p := strings.TrimPrefix(r.URL.Path, prefix)
+		rp := strings.TrimPrefix(r.URL.RawPath, prefix)
 		r2 := new(http.Request)
 		*r2 = *r
 		r2.URL = new(url.URL)
 		*r2.URL = *r.URL
 		r2.URL.Path = p
+		r2.URL.RawPath = rp
 		h.ServeHTTP(w, r2)
 	})
 }

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -22,7 +22,7 @@ type Rule struct {
 // MatchHidden matches paths with a basename
 // that begins with a dot.
 func MatchHidden(path string) bool {
-	return strings.HasPrefix(filepath.Base(path), ".")
+	return path != "" && strings.HasPrefix(filepath.Base(path), ".")
 }
 
 // Matches matches a path against a rule.


### PR DESCRIPTION
### fix: prefix handling on http router
An inconsistency was introduced with `http.StripPrefix()` and `stripPrefix()` on the migration to go 1.16, causing errors when baseUrl is set.  fix #1332, fix #1336

### fix: text file detection on editor
The method `readFirstBytes()` was not being called, making detection of text files not possible.

### fix: qr code url on share
The qrcode was missing the host on the url. fix #1342

### fix: hide dotfile on share
The `filepath.Base` method used by hide dotfile check returns a dot when the provided path is empty, causing the `MatchHidden` rule to be triggered. fix #1335, fix #1338