### PR TITLE
Update issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,19 +4,19 @@ about: Create a report to help us improve
 ---
 
 **Description**
-A clear and concise description of what the issue is about. What are you trying to do?
+<!-- A clear and concise description of what the issue is about. What are you trying to do? -->
 
 **Expected behaviour**
-What did you expect to happen?
+<!-- What did you expect to happen? -->
 
 **What is happening instead?**
-Please, give full error messages and/or log.
+<!-- Please, give full error messages and/or log. -->
 
 **Additional context**
-Add any other context about the problem here. If applicable, add screenshots to help explain your problem.
+<!-- Add any other context about the problem here. If applicable, add screenshots to help explain your problem. -->
 
 **How to reproduce?**
-Tell us how to reproduce this issue. How can someone who is starting from scratch reproduce this behaviour as minimally as possible?
+<!-- Tell us how to reproduce this issue. How can someone who is starting from scratch reproduce this behaviour as minimally as possible? -->
 
 **Files**
-A list of relevant files for this issue. Large files can be uploaded one-by-one or in a tarball/zipfile.
+<!-- A list of relevant files for this issue. Large files can be uploaded one-by-one or in a tarball/zipfile. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,13 +4,13 @@ about: Suggest an idea for this project
 ---
 
 **Is your feature request related to a problem? Please describe.**
-Add a clear and concise description of what the problem is. E.g. *I'm always frustrated when [...]*
+<!-- Add a clear and concise description of what the problem is. E.g. *I'm always frustrated when [...]* -->
 
 **Describe the solution you'd like**
-Add a clear and concise description of what you want to happen.
+<!-- Add a clear and concise description of what you want to happen.  -->
 
 **Describe alternatives you've considered**
-Add a clear and concise description of any alternative solutions or features you've considered.
+<!-- Add a clear and concise description of any alternative solutions or features you've considered.  -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 **Description**
+<!--
 Please explain the changes you made here.
 If the feature changes current behaviour, explain why your solution is better.
+-->
 
 :rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).
 
@@ -11,6 +13,8 @@ If the feature changes current behaviour, explain why your solution is better.
 - [ ] AVOID breaking the continuous integration build.
 
 **Further comments**
+<!--
 If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.
 
 :heart: Thank you!
+-->


### PR DESCRIPTION
**Description**
Update issues templates to hide help text from issues.

For example in #1354 (no offense), the user kept the placeholder and we see it in the issue.

