### PR TITLE
Use config port for docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM alpine:latest
 RUN apk --update add ca-certificates \
                      mailcap \
-                     curl
+                     curl \
+                     jq
 
 HEALTHCHECK --start-period=2s --interval=5s --timeout=3s \
-  CMD curl -f http://localhost/health || exit 1
+  CMD curl -f http://localhost:$(jq '.port' /.filebrowser.json)/health || curl -f http://localhost/health || exit 1
 
 VOLUME /srv
 EXPOSE 80


### PR DESCRIPTION
This PR allows to use the configured port in docker healthcheck.

There is a big issue with the default docker config, for now: if we want to use another user than `root` (`--user 1000:1000`), we obviously cannot use any reserved port (`0-1023`), so we must specify a port bigger than 1023.

The default healthcheck always targets the 80 port. The container will be unhealthy if we choose a custom port.

**The best way to fix this issue would be to always use a port > 1023 (as `8080` or `3000`), and to remove the `port` option, but this will be a bc break for all people using this image**