### PR TITLE
Use database dir for docker image

### DIFF
--- a/.docker.json
+++ b/.docker.json
@@ -3,6 +3,6 @@
   "baseURL": "",
   "address": "",
   "log": "stdout",
-  "database": "/database.db",
+  "database": "/var/lib/filebrowser/database.db",
   "root": "/srv"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ HEALTHCHECK --start-period=2s --interval=5s --timeout=3s \
 VOLUME /srv
 EXPOSE 80
 
+RUN mkdir /var/lib/filebrowser && chmod a+w /var/lib/filebrowser
 COPY .docker.json /.filebrowser.json
 COPY filebrowser /filebrowser
 


### PR DESCRIPTION
For now, it's impossible to start the docker image with another user than `root` without a previously created database file mouted as a volume.

With this PR, it'll be possible to use a custom user and docker volumes (directories), or no volume at all.

The doc must be updated with the followed command:
```
mkdir /path/filebrowserdb && chmod a+w /path/filebrowserdb

docker run \
    -v /path/to/root:/srv \
    -v /path/filebrowserdb:/var/lib/database.db \
    -v /path/.filebrowser.json:/.filebrowser.json \
    --user $(id -u):$(id -g)
    -p 80:80 \
    filebrowser/filebrowser
```