### PR TITLE
Fixed share delete confirmation

### DIFF
--- a/frontend/src/components/prompts/ShareDelete.vue
+++ b/frontend/src/components/prompts/ShareDelete.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="card floating">
     <div class="card-content">
-      <p>{{ $t("prompts.deleteMessageShare", { path: "" }) }}</p>
+      <p>{{ $t("prompts.deleteMessageShare") }}</p>
     </div>
     <div class="card-action">
       <button

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -118,7 +118,7 @@
     "currentlyNavigating": "Currently navigating on:",
     "deleteMessageMultiple": "Are you sure you want to delete {count} file(s)?",
     "deleteMessageSingle": "Are you sure you want to delete this file/folder?",
-    "deleteMessageShare": "Are you sure you want to delete this share({path})?",
+    "deleteMessageShare": "Are you sure you want to delete this share?",
     "deleteTitle": "Delete files",
     "displayName": "Display Name:",
     "download": "Download files",


### PR DESCRIPTION
**Description**
As of the latest release, when you go to Settings>Share Management, you have the ability to Delete a share link. When I go to delete a share link, however, I am met with an empty set of parenthesis at the end of the prompt. This patch should fix that issue.

Image of issue in production:
![filebrowser](https://user-images.githubusercontent.com/35144594/120119484-e0a99580-c165-11eb-92b6-8a7ce8f061aa.jpg)


Related Issues and Merges:
- #1210 
- #1212 [(more specifically)](https://github.com/filebrowser/filebrowser/commit/b600b11415fd1fb90ff2f5136be95a9c737ae1cb#diff-d1381e1a98366c9308bbc66f3a31add276a3211bbb86e024ca65afc957aae968)
- #1307 [(more specifically)](https://github.com/filebrowser/filebrowser/commit/2a1f759e9e734868076f6454631d925744830c45#diff-d1381e1a98366c9308bbc66f3a31add276a3211bbb86e024ca65afc957aae968)

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also, you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins, or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

**Further comments**
In previous builds, it looks as though there was once an actual path outputted, however that has been removed. I couldn't find any specifics detailing why that was removed, but I stuck with that and finished removing it entirely. If we wish to add it back I am 100% on board with that as well. Open to discussion about this issue.