### PR TITLE
Fix 401 error in share view open file button

### DIFF
--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -93,7 +93,7 @@
             </a>
             <a
               target="_blank"
-              :href="link + '&inline=true'"
+              :href="inlineLink"
               class="button button--flat"
               v-if="!req.isDir"
             >
@@ -239,6 +239,10 @@ export default {
       const path = this.$route.path.split("/").splice(2).join("/");
       return `${baseURL}/api/public/dl/${path}${queryArg}`;
     },
+    inlineLink: function () {
+      url = new URL(this.link);
+      url.searchParams.set('inline', 'true');
+      return url.href;
     fullLink: function () {
       return window.location.origin + this.link;
     },

--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -243,6 +243,7 @@ export default {
       url = new URL(this.link);
       url.searchParams.set('inline', 'true');
       return url.href;
+    },
     fullLink: function () {
       return window.location.origin + this.link;
     },

--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -240,8 +240,8 @@ export default {
       return `${baseURL}/api/public/dl/${path}${queryArg}`;
     },
     inlineLink: function () {
-      url = new URL(this.link);
-      url.searchParams.set('inline', 'true');
+      let url = new URL(this.link);
+      url.searchParams.set("inline", "true");
       return url.href;
     },
     fullLink: function () {

--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -93,7 +93,7 @@
             </a>
             <a
               target="_blank"
-              :href="link + '?inline=true'"
+              :href="link + '&inline=true'"
               class="button button--flat"
               v-if="!req.isDir"
             >


### PR DESCRIPTION
This link would be generated with a `?token=<hash>?inline=true` when it should be `?token=<hash>&inline=true`. This was causing 401 Unauthorized errors because `URL.Query().Get("token")` would return the empty string and so [authenticateShareRequest](https://github.com/filebrowser/filebrowser/blob/dee465ab865ba5bf96fbfbe5888f4e95731d3701/http/public.go#L126) would try to verify the password in the header, which doesn't exist for these requests.