### PR TITLE
Some fixes

### DIFF
--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -205,6 +205,34 @@ main .spinner .bounce2 {
   height: 100%;
 }
 
+#previewer .preview .info {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1.5em;
+  color: #fff;
+}
+#previewer .preview .info .title {
+  margin-bottom: 1em;
+}
+#previewer .preview .info .title i {
+  display: block;
+  margin-bottom: .1em;
+  font-size: 4em;
+}
+#previewer .preview .info .button {
+  display: inline-block;
+}
+#previewer .preview .info .button:hover {
+  background-color: rgba(255, 255, 255, 0.2)
+}
+#previewer .preview .info .button i {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 1.3em;
+}
+
 #previewer .pdf {
   width: 100%;
   height: 100%;

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -63,7 +63,8 @@
     "size": "Size",
     "sortByLastModified": "Sort by last modified",
     "sortByName": "Sort by name",
-    "sortBySize": "Sort by size"
+    "sortBySize": "Sort by size",
+    "noPreview": "Preview is not available for this file."
   },
   "help": {
     "click": "select file or directory",

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -89,12 +89,31 @@
           class="pdf"
           :data="raw"
         ></object>
-        <a v-else-if="req.type == 'blob'" :href="downloadUrl">
-          <h2 class="message">
-            {{ $t("buttons.download") }}
-            <i class="material-icons">file_download</i>
-          </h2>
-        </a>
+        <div v-else-if="req.type == 'blob'" class="info">
+          <div class="title">
+            <i class="material-icons">feedback</i>
+            {{ $t("files.noPreview") }}
+          </div>
+          <div>
+            <a target="_blank" :href="downloadUrl" class="button button--flat">
+              <div>
+                <i class="material-icons">file_download</i
+                >{{ $t("buttons.download") }}
+              </div>
+            </a>
+            <a
+              target="_blank"
+              :href="downloadUrl + '&inline=true'"
+              class="button button--flat"
+              v-if="!req.isDir"
+            >
+              <div>
+                <i class="material-icons">open_in_new</i
+                >{{ $t("buttons.openFile") }}
+              </div>
+            </a>
+          </div>
+        </div>
       </div>
     </template>
 

--- a/http/raw.go
+++ b/http/raw.go
@@ -200,11 +200,6 @@ func rawDirHandler(w http.ResponseWriter, r *http.Request, d *data, file *files.
 }
 
 func rawFileHandler(w http.ResponseWriter, r *http.Request, file *files.FileInfo) (int, error) {
-	isFresh := checkEtag(w, r, file.ModTime.Unix(), file.Size)
-	if isFresh {
-		return http.StatusNotModified, nil
-	}
-
 	fd, err := file.Fs.Open(file.Path)
 	if err != nil {
 		return http.StatusInternalServerError, err
@@ -213,6 +208,7 @@ func rawFileHandler(w http.ResponseWriter, r *http.Request, file *files.FileInfo
 
 	setContentDisposition(w, r, file)
 
+	w.Header().Set("Cache-Control", "private")
 	http.ServeContent(w, r, file.Name, file.ModTime, fd)
 	return 0, nil
 }

--- a/http/static.go
+++ b/http/static.go
@@ -77,7 +77,7 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, fSys 
 		return http.StatusInternalServerError, err
 	}
 
-	data["Json"] = string(b)
+	data["Json"] = strings.ReplaceAll(string(b), `'`, `\'`)
 
 	fileContents, err := fs.ReadFile(fSys, file)
 	if err != nil {

--- a/http/utils.go
+++ b/http/utils.go
@@ -3,7 +3,6 @@ package http
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -66,12 +65,4 @@ func stripPrefix(prefix string, h http.Handler) http.Handler {
 		r2.URL.RawPath = rp
 		h.ServeHTTP(w, r2)
 	})
-}
-
-func checkEtag(w http.ResponseWriter, r *http.Request, fTime, fSize int64) bool {
-	etag := fmt.Sprintf("%x%x", fTime, fSize)
-	w.Header().Set("Cache-Control", "private")
-	w.Header().Set("Etag", etag)
-
-	return r.Header.Get("If-None-Match") == etag
 }


### PR DESCRIPTION
### fix: file caching directive
Using etag header with `http.ServeContent` causes unexpected behavior. The etag was removed in favor of the `http.ServeContent` implementation. fixes #1497

### feat: open file option on preview
Allows users to open the file when the preview is not available.