### PR TITLE
Fix bug with inlineLink not creating url properly.

### DIFF
--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -240,7 +240,7 @@ export default {
       return `${baseURL}/api/public/dl/${path}${queryArg}`;
     },
     inlineLink: function () {
-      let url = new URL(this.link);
+      let url = new URL(this.fullLink);
       url.searchParams.set("inline", "true");
       return url.href;
     },


### PR DESCRIPTION
**Description**
I am fixing a bug in the creation of an inline share view link that previously only used a partial url. This was a bug in my previous attempt to fix the broken inline view for password shares, should be fixed now.
