### PR TITLE
make theme_color of Manifest can be set

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -41,7 +41,7 @@ func addConfigFlags(flags *pflag.FlagSet) {
 	flags.String("recaptcha.secret", "", "ReCaptcha secret")
 
 	flags.String("branding.name", "", "replace 'File Browser' by this name")
-	flags.String("branding.color", "", "set theme_color of Manifest")
+	flags.String("branding.color", "", "set the theme color")
 	flags.String("branding.files", "", "path to directory with images and custom styles")
 	flags.Bool("branding.disableExternal", false, "disable external links such as GitHub links")
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -41,6 +41,7 @@ func addConfigFlags(flags *pflag.FlagSet) {
 	flags.String("recaptcha.secret", "", "ReCaptcha secret")
 
 	flags.String("branding.name", "", "replace 'File Browser' by this name")
+	flags.String("branding.color", "", "set theme_color of Manifest")
 	flags.String("branding.files", "", "path to directory with images and custom styles")
 	flags.Bool("branding.disableExternal", false, "disable external links such as GitHub links")
 }
@@ -131,6 +132,7 @@ func printSettings(ser *settings.Server, set *settings.Settings, auther auth.Aut
 	fmt.Fprintf(w, "\tName:\t%s\n", set.Branding.Name)
 	fmt.Fprintf(w, "\tFiles override:\t%s\n", set.Branding.Files)
 	fmt.Fprintf(w, "\tDisable external links:\t%t\n", set.Branding.DisableExternal)
+	fmt.Fprintf(w, "\tColor:\t%s\n", set.Branding.Color)
 	fmt.Fprintln(w, "\nServer:")
 	fmt.Fprintf(w, "\tLog:\t%s\n", ser.Log)
 	fmt.Fprintf(w, "\tPort:\t%s\n", ser.Port)

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -51,6 +51,8 @@ you want to change. Other options will remain unchanged.`,
 				set.Shell = convertCmdStrToCmdArray(mustGetString(flags, flag.Name))
 			case "branding.name":
 				set.Branding.Name = mustGetString(flags, flag.Name)
+			case "branding.color":
+				set.Branding.Color = mustGetString(flags, flag.Name)
 			case "branding.disableExternal":
 				set.Branding.DisableExternal = mustGetBool(flags, flag.Name)
 			case "branding.files":

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -16,7 +16,7 @@
 
   <!-- Add to home screen for Android and modern mobile browsers -->
   <link rel="manifest" id="manifestPlaceholder" crossorigin="use-credentials">
-  <meta name="theme-color" content="#2979ff">
+  <meta name="theme-color" content="[{[ if .Color -]}][{[ .Color ]}][{[ else ]}]#2979ff[{[ end ]}]">
 
   <!-- Add to home screen for Safari on iOS/iPadOS -->
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -26,7 +26,7 @@
 
   <!-- Add to home screen for Windows -->
   <meta name="msapplication-TileImage" content="[{[ .StaticURL ]}]/img/icons/mstile-144x144.png">
-  <meta name="msapplication-TileColor" content="#2979ff">
+  <meta name="msapplication-TileColor" content="[{[ if .Color -]}][{[ .Color ]}][{[ else ]}]#2979ff[{[ end ]}]">
 
   <!-- Inject Some Variables and generate the manifest json -->
   <script>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -51,7 +51,7 @@
       "start_url": window.location.origin + window.FileBrowser.BaseURL,
       "display": "standalone",
       "background_color": "#ffffff",
-      "theme_color": "#455a64"
+      "theme_color": window.FileBrowser.Color || "#455a64"
     }
 
     const stringManifest = JSON.stringify(dynamicManifest);

--- a/http/static.go
+++ b/http/static.go
@@ -29,6 +29,7 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, fSys 
 	data := map[string]interface{}{
 		"Name":            d.settings.Branding.Name,
 		"DisableExternal": d.settings.Branding.DisableExternal,
+		"Color":           d.settings.Branding.Color,
 		"BaseURL":         d.server.BaseURL,
 		"Version":         version.Version,
 		"StaticURL":       path.Join(d.server.BaseURL, "/static"),

--- a/settings/branding.go
+++ b/settings/branding.go
@@ -6,4 +6,5 @@ type Branding struct {
 	DisableExternal bool   `json:"disableExternal"`
 	Files           string `json:"files"`
 	Theme           string `json:"theme"`
+	Color           string `json:"color"`
 }


### PR DESCRIPTION
The 'theme_color' of Manifest affects the color of status bar
of mobile view, however it's static before. Make it can be set
via `filebrowser config set --branding.color "<hex-color-code>"`.

Signed-off-by: bekcpear <i@bitbili.net>