### PR TITLE
Hook authentication method

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -3,13 +3,14 @@ package auth
 import (
 	"net/http"
 
+	"github.com/filebrowser/filebrowser/v2/settings"
 	"github.com/filebrowser/filebrowser/v2/users"
 )
 
 // Auther is the authentication interface.
 type Auther interface {
 	// Auth is called to authenticate a request.
-	Auth(r *http.Request, s users.Store, root string) (*users.User, error)
+	Auth(r *http.Request, usr users.Store, stg *settings.Settings, srv *settings.Server) (*users.User, error)
 	// LoginPage indicates if this auther needs a login page.
 	LoginPage() bool
 }

--- a/auth/hook.go
+++ b/auth/hook.go
@@ -1,0 +1,302 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/filebrowser/filebrowser/v2/errors"
+	"github.com/filebrowser/filebrowser/v2/files"
+	"github.com/filebrowser/filebrowser/v2/settings"
+	"github.com/filebrowser/filebrowser/v2/users"
+)
+
+// MethodHookAuth is used to identify hook auth.
+const MethodHookAuth settings.AuthMethod = "hook"
+
+type hookCred struct {
+	Password string `json:"password"`
+	Username string `json:"username"`
+}
+
+// HookAuth is a hook implementation of an Auther.
+type HookAuth struct {
+	Users    users.Store        `json:"-"`
+	Settings *settings.Settings `json:"-"`
+	Server   *settings.Server   `json:"-"`
+	Cred     hookCred           `json:"-"`
+	Fields   hookFields         `json:"-"`
+	Command  string             `json:"command"`
+}
+
+// Auth authenticates the user via a json in content body.
+func (a *HookAuth) Auth(r *http.Request, usr users.Store, stg *settings.Settings, srv *settings.Server) (*users.User, error) {
+	var cred hookCred
+
+	if r.Body == nil {
+		return nil, os.ErrPermission
+	}
+
+	err := json.NewDecoder(r.Body).Decode(&cred)
+	if err != nil {
+		return nil, os.ErrPermission
+	}
+
+	a.Users = usr
+	a.Settings = stg
+	a.Server = srv
+	a.Cred = cred
+
+	action, err := a.RunCommand()
+	if err != nil {
+		return nil, err
+	}
+
+	switch action {
+	case "auth":
+		u, err := a.SaveUser()
+		if err != nil {
+			return nil, err
+		}
+		return u, nil
+	case "block":
+		return nil, os.ErrPermission
+	case "pass":
+		u, err := a.Users.Get(a.Server.Root, a.Cred.Username)
+		if err != nil || !users.CheckPwd(a.Cred.Password, u.Password) {
+			return nil, os.ErrPermission
+		}
+		return u, nil
+	default:
+		return nil, fmt.Errorf("invalid hook action: %s", action)
+	}
+}
+
+// LoginPage tells that hook auth requires a login page.
+func (a *HookAuth) LoginPage() bool {
+	return true
+}
+
+// RunCommand starts the hook command and returns the action
+func (a *HookAuth) RunCommand() (string, error) {
+	command := strings.Split(a.Command, " ")
+	envMapping := func(key string) string {
+		switch key {
+		case "USERNAME":
+			return a.Cred.Username
+		case "PASSWORD":
+			return a.Cred.Password
+		default:
+			return os.Getenv(key)
+		}
+	}
+	for i, arg := range command {
+		if i == 0 {
+			continue
+		}
+		command[i] = os.Expand(arg, envMapping)
+	}
+
+	cmd := exec.Command(command[0], command[1:]...) //nolint:gosec
+	cmd.Env = append(os.Environ(), fmt.Sprintf("USERNAME=%s", a.Cred.Username))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("PASSWORD=%s", a.Cred.Password))
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	a.GetValues(string(out))
+
+	return a.Fields.Values["hook.action"], nil
+}
+
+// GetValues creates a map with values from the key-value format string
+func (a *HookAuth) GetValues(s string) {
+	m := map[string]string{}
+
+	// make line breaks consistent on Windows platform
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+
+	// iterate input lines
+	for _, val := range strings.Split(s, "\n") {
+		v := strings.SplitN(val, "=", 2) //nolint: gomnd
+
+		// skips non key and value format
+		if len(v) != 2 { //nolint: gomnd
+			continue
+		}
+
+		fieldKey := strings.TrimSpace(v[0])
+		fieldValue := strings.TrimSpace(v[1])
+
+		if a.Fields.IsValid(fieldKey) {
+			m[fieldKey] = fieldValue
+		}
+	}
+
+	a.Fields.Values = m
+}
+
+// SaveUser updates the existing user or creates a new one when not found
+func (a *HookAuth) SaveUser() (*users.User, error) {
+	u, err := a.Users.Get(a.Server.Root, a.Cred.Username)
+	if err != nil && err != errors.ErrNotExist {
+		return nil, err
+	}
+
+	if u == nil {
+		pass, err := users.HashPwd(a.Cred.Password)
+		if err != nil {
+			return nil, err
+		}
+
+		// create user with the provided credentials
+		d := &users.User{
+			Username:     a.Cred.Username,
+			Password:     pass,
+			Scope:        a.Settings.Defaults.Scope,
+			Locale:       a.Settings.Defaults.Locale,
+			ViewMode:     a.Settings.Defaults.ViewMode,
+			SingleClick:  a.Settings.Defaults.SingleClick,
+			Sorting:      a.Settings.Defaults.Sorting,
+			Perm:         a.Settings.Defaults.Perm,
+			Commands:     a.Settings.Defaults.Commands,
+			HideDotfiles: a.Settings.Defaults.HideDotfiles,
+		}
+		u = a.GetUser(d)
+
+		userHome, err := a.Settings.MakeUserDir(u.Username, u.Scope, a.Server.Root)
+		if err != nil {
+			return nil, fmt.Errorf("user: failed to mkdir user home dir: [%s]", userHome)
+		}
+		u.Scope = userHome
+		log.Printf("user: %s, home dir: [%s].", u.Username, userHome)
+
+		err = a.Users.Save(u)
+		if err != nil {
+			return nil, err
+		}
+	} else if p := !users.CheckPwd(a.Cred.Password, u.Password); len(a.Fields.Values) > 1 || p {
+		u = a.GetUser(u)
+
+		// update the password when it doesn't match the current
+		if p {
+			pass, err := users.HashPwd(a.Cred.Password)
+			if err != nil {
+				return nil, err
+			}
+			u.Password = pass
+		}
+
+		// update user with provided fields
+		err := a.Users.Update(u)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return u, nil
+}
+
+// GetUser returns a User filled with hook values or provided defaults
+func (a *HookAuth) GetUser(d *users.User) *users.User {
+	// adds all permissions when user is admin
+	isAdmin := a.Fields.GetBoolean("user.perm.admin", d.Perm.Admin)
+	perms := users.Permissions{
+		Admin:    isAdmin,
+		Execute:  isAdmin || a.Fields.GetBoolean("user.perm.execute", d.Perm.Execute),
+		Create:   isAdmin || a.Fields.GetBoolean("user.perm.create", d.Perm.Create),
+		Rename:   isAdmin || a.Fields.GetBoolean("user.perm.rename", d.Perm.Rename),
+		Modify:   isAdmin || a.Fields.GetBoolean("user.perm.modify", d.Perm.Modify),
+		Delete:   isAdmin || a.Fields.GetBoolean("user.perm.delete", d.Perm.Delete),
+		Share:    isAdmin || a.Fields.GetBoolean("user.perm.share", d.Perm.Share),
+		Download: isAdmin || a.Fields.GetBoolean("user.perm.download", d.Perm.Download),
+	}
+	user := users.User{
+		ID:          d.ID,
+		Username:    d.Username,
+		Password:    d.Password,
+		Scope:       a.Fields.GetString("user.scope", d.Scope),
+		Locale:      a.Fields.GetString("user.locale", d.Locale),
+		ViewMode:    users.ViewMode(a.Fields.GetString("user.viewMode", string(d.ViewMode))),
+		SingleClick: a.Fields.GetBoolean("user.singleClick", d.SingleClick),
+		Sorting: files.Sorting{
+			Asc: a.Fields.GetBoolean("user.sorting.asc", d.Sorting.Asc),
+			By:  a.Fields.GetString("user.sorting.by", d.Sorting.By),
+		},
+		Commands:     a.Fields.GetArray("user.commands", d.Commands),
+		HideDotfiles: a.Fields.GetBoolean("user.hideDotfiles", d.HideDotfiles),
+		Perm:         perms,
+		LockPassword: true,
+	}
+
+	return &user
+}
+
+// hookFields is used to access fields from the hook
+type hookFields struct {
+	Values map[string]string
+}
+
+// validHookFields contains names of the fields that can be used
+var validHookFields = []string{
+	"hook.action",
+	"user.scope",
+	"user.locale",
+	"user.viewMode",
+	"user.singleClick",
+	"user.sorting.by",
+	"user.sorting.asc",
+	"user.commands",
+	"user.hideDotfiles",
+	"user.perm.admin",
+	"user.perm.execute",
+	"user.perm.create",
+	"user.perm.rename",
+	"user.perm.modify",
+	"user.perm.delete",
+	"user.perm.share",
+	"user.perm.download",
+}
+
+// IsValid checks if the provided field is on the valid fields list
+func (hf *hookFields) IsValid(field string) bool {
+	for _, val := range validHookFields {
+		if field == val {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetString returns the string value or provided default
+func (hf *hookFields) GetString(k, dv string) string {
+	val, ok := hf.Values[k]
+	if ok {
+		return val
+	}
+	return dv
+}
+
+// GetBoolean returns the bool value or provided default
+func (hf *hookFields) GetBoolean(k string, dv bool) bool {
+	val, ok := hf.Values[k]
+	if ok {
+		return val == "true"
+	}
+	return dv
+}
+
+// GetArray returns the array value or provided default
+func (hf *hookFields) GetArray(k string, dv []string) []string {
+	val, ok := hf.Values[k]
+	if ok && strings.TrimSpace(val) != "" {
+		return strings.Split(val, " ")
+	}
+	return dv
+}

--- a/auth/json.go
+++ b/auth/json.go
@@ -26,7 +26,7 @@ type JSONAuth struct {
 }
 
 // Auth authenticates the user via a json in content body.
-func (a JSONAuth) Auth(r *http.Request, sto users.Store, root string) (*users.User, error) {
+func (a JSONAuth) Auth(r *http.Request, usr users.Store, stg *settings.Settings, srv *settings.Server) (*users.User, error) {
 	var cred jsonCred
 
 	if r.Body == nil {
@@ -51,7 +51,7 @@ func (a JSONAuth) Auth(r *http.Request, sto users.Store, root string) (*users.Us
 		}
 	}
 
-	u, err := sto.Get(root, cred.Username)
+	u, err := usr.Get(srv.Root, cred.Username)
 	if err != nil || !users.CheckPwd(cred.Password, u.Password) {
 		return nil, os.ErrPermission
 	}

--- a/auth/none.go
+++ b/auth/none.go
@@ -14,8 +14,8 @@ const MethodNoAuth settings.AuthMethod = "noauth"
 type NoAuth struct{}
 
 // Auth uses authenticates user 1.
-func (a NoAuth) Auth(r *http.Request, sto users.Store, root string) (*users.User, error) {
-	return sto.Get(root, uint(1))
+func (a NoAuth) Auth(r *http.Request, usr users.Store, stg *settings.Settings, srv *settings.Server) (*users.User, error) {
+	return usr.Get(srv.Root, uint(1))
 }
 
 // LoginPage tells that no auth doesn't require a login page.

--- a/auth/proxy.go
+++ b/auth/proxy.go
@@ -18,9 +18,9 @@ type ProxyAuth struct {
 }
 
 // Auth authenticates the user via an HTTP header.
-func (a ProxyAuth) Auth(r *http.Request, sto users.Store, root string) (*users.User, error) {
+func (a ProxyAuth) Auth(r *http.Request, usr users.Store, stg *settings.Settings, srv *settings.Server) (*users.User, error) {
 	username := r.Header.Get(a.Header)
-	user, err := sto.Get(root, username)
+	user, err := usr.Get(srv.Root, username)
 	if err == errors.ErrNotExist {
 		return nil, os.ErrPermission
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -35,6 +35,7 @@ func addConfigFlags(flags *pflag.FlagSet) {
 
 	flags.String("auth.method", string(auth.MethodJSONAuth), "authentication type")
 	flags.String("auth.header", "", "HTTP header for auth.method=proxy")
+	flags.String("auth.command", "", "command for auth.method=hook")
 
 	flags.String("recaptcha.host", "https://www.google.com", "use another host for ReCAPTCHA. recaptcha.net might be useful in China")
 	flags.String("recaptcha.key", "", "ReCaptcha site key")
@@ -112,6 +113,20 @@ func getAuthentication(flags *pflag.FlagSet, defaults ...interface{}) (settings.
 			}
 		}
 		auther = jsonAuth
+	}
+
+	if method == auth.MethodHookAuth {
+		command := mustGetString(flags, "auth.command")
+
+		if command == "" {
+			command = defaultAuther["command"].(string)
+		}
+
+		if command == "" {
+			checkErr(nerrors.New("you must set the flag 'auth.command' for method 'hook'"))
+		}
+
+		auther = &auth.HookAuth{Command: command}
 	}
 
 	if auther == nil {

--- a/cmd/config_import.go
+++ b/cmd/config_import.go
@@ -70,6 +70,8 @@ The path must be for a json or yaml file.`,
 			auther = getAuther(auth.NoAuth{}, rawAuther).(*auth.NoAuth)
 		case auth.MethodProxyAuth:
 			auther = getAuther(auth.ProxyAuth{}, rawAuther).(*auth.ProxyAuth)
+		case auth.MethodHookAuth:
+			auther = getAuther(&auth.HookAuth{}, rawAuther).(*auth.HookAuth)
 		default:
 			checkErr(errors.New("invalid auth method"))
 		}

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -45,7 +45,7 @@
         </button>
 
         <button
-          v-if="authMethod == 'json'"
+          v-if="canLogout"
           @click="logout"
           class="action"
           id="logout"
@@ -117,7 +117,7 @@ import {
   signup,
   disableExternal,
   noAuth,
-  authMethod,
+  loginPage,
 } from "@/utils/constants";
 import { files as api } from "@/api";
 import ProgressBar from "vue-simple-progress";
@@ -137,8 +137,7 @@ export default {
     signup: () => signup,
     version: () => version,
     disableExternal: () => disableExternal,
-    noAuth: () => noAuth,
-    authMethod: () => authMethod,
+    canLogout: () => !noAuth && loginPage,
   },
   asyncComputed: {
     usage: {

--- a/http/auth.go
+++ b/http/auth.go
@@ -107,7 +107,7 @@ var loginHandler = func(w http.ResponseWriter, r *http.Request, d *data) (int, e
 		return http.StatusInternalServerError, err
 	}
 
-	user, err := auther.Auth(r, d.store.Users, d.server.Root)
+	user, err := auther.Auth(r, d.store.Users, d.settings, d.server)
 	if err == os.ErrPermission {
 		return http.StatusForbidden, nil
 	} else if err != nil {

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -45,6 +45,7 @@ type Server struct {
 	ResizePreview         bool   `json:"resizePreview"`
 	EnableExec            bool   `json:"enableExec"`
 	TypeDetectionByHeader bool   `json:"typeDetectionByHeader"`
+	AuthHook              string `json:"authHook"`
 }
 
 // Clean cleans any variables that might need cleaning.

--- a/storage/bolt/auth.go
+++ b/storage/bolt/auth.go
@@ -20,6 +20,8 @@ func (s authBackend) Get(t settings.AuthMethod) (auth.Auther, error) {
 		auther = &auth.JSONAuth{}
 	case auth.MethodProxyAuth:
 		auther = &auth.ProxyAuth{}
+	case auth.MethodHookAuth:
+		auther = &auth.HookAuth{}
 	case auth.MethodNoAuth:
 		auther = &auth.NoAuth{}
 	default:

--- a/storage/bolt/importer/conf.go
+++ b/storage/bolt/importer/conf.go
@@ -28,8 +28,9 @@ type oldDefs struct {
 }
 
 type oldAuth struct {
-	Method string `json:"method" yaml:"method" toml:"method"` // default none proxy
-	Header string `json:"header" yaml:"header" toml:"header"`
+	Method  string `json:"method" yaml:"method" toml:"method"` // default none proxy
+	Header  string `json:"header" yaml:"header" toml:"header"`
+	Command string `json:"command" yaml:"command" toml:"command"`
 }
 
 type oldConf struct {
@@ -149,6 +150,9 @@ func importConf(db *storm.DB, path string, sto *storage.Storage) error {
 	case "proxy":
 		auther = &auth.ProxyAuth{Header: cfg.Auth.Header}
 		s.AuthMethod = auth.MethodProxyAuth
+	case "hook":
+		auther = &auth.HookAuth{Command: cfg.Auth.Command}
+		s.AuthMethod = auth.MethodHookAuth
 	case "none":
 		auther = &auth.NoAuth{}
 		s.AuthMethod = auth.MethodNoAuth


### PR DESCRIPTION
Implements an auther that allows to specify a command that will be executed when a user tries to logs in, provides credentials via environment variables and interprets the standard output to control the authentication. This is the simple way that i found for users to extend the authentication system, the usage is uncomplicated and the code should be easy to maintain. In addition to existing hooks, it makes FileBrowser able to fulfill more specific needs and to be integrated with different systems and technologies.

### Usage
```
filebrowser config set --auth.method=hook --auth.command="/path/to/command arg"
```

### Specification

- Output from the hook command must be on a valid key-value format separated by line, invalid parameters are ignored and authentication is blocked when no hook action is provided.
- Controlling the authentication is done by using `allow`, `block` and `pass` keywords. Each keyword changes the behavior of the login, it can grant or prevent the user authentication with `allow` and `block`, and the `pass` keyword is used for the database based authentication.
- Passwords are stored and updated on success login attempts, allowing it to be used with the database based authentication method.
- User settings can be provided to the hook output, allowing customized experience per user basis, default values are used for omitted fields. For existing users, the settings can be changed by providing the wanted values, omitted fields will remain unchanged.

### Hook command output fields

```ini
hook.action        = auth|block|pass
user.scope         = /path/to/
user.locale        = ar|de|en|es|fr|is|it|ja|ko|nl-be|pl|pt-br|pt|ro|ru|sv-se|zh-cn|zh-tw
user.viewMode      = list|mosaic
user.singleClick   = true|false
user.sorting.by    = name|size|modified
user.sorting.asc   = true|false
user.commands      = cmd1 cmd2...
user.hideDotfiles  = true|false
user.perm.admin    = true|false
user.perm.execute  = true|false
user.perm.create   = true|false
user.perm.rename   = true|false
user.perm.modify   = true|false
user.perm.delete   = true|false
user.perm.share    = true|false
user.perm.download = true|false
```

Output example, trailing whitespace is ignored:

```ini
hook.action        = auth
user.scope         = /home/
user.locale        = en
user.viewMode      = mosaic
user.singleClick   = false
user.sorting.by    = modified
user.sorting.asc   = false
user.commands      = ls rm mkdir touch
user.hideDotfiles  = false
user.perm.admin    = false
user.perm.execute  = true
user.perm.create   = true
user.perm.rename   = true
user.perm.modify   = true
user.perm.delete   = true
user.perm.share    = true
user.perm.download = true
```

### Hook command examples

Bash script for LDAP authentication:

```bash
#!/bin/bash

# Runs ldapwhoami with provided password and username appended to the base DN
ldapwhoami -H ldap://172.17.0.2:1389 -D cn=$USERNAME,ou=users,dc=example,dc=org -w $PASSWORD > /dev/null 2>&1

# Authenticate only when ldapwhoami exit without errors (code 0)
if [[ $? -eq 0 ]]; then
    echo "hook.action=auth"
else
    echo "hook.action=block"
fi
```

Python script for RADIUS authentication:

```python
from __future__ import print_function
from pyrad.client import Client
from pyrad.dictionary import Dictionary
import pyrad.packet
import os

username = os.environ['USERNAME']
password = os.environ['PASSWORD']

srv = Client(server="172.17.0.2", secret=b"Kah3choteereethiejeimaeziecumi",
             dict=Dictionary("dictionary"))

# create request
req = srv.CreateAuthPacket(code=pyrad.packet.AccessRequest,
                           User_Name=username, NAS_Identifier="172.17.0.2")
req["User-Password"] = req.PwCrypt(password)

# send request
reply = srv.SendPacket(req)

if reply.code == pyrad.packet.AccessAccept:
    print("hook.action=auth")
else:
    print("hook.action=block")
```