### PR TITLE
to zoom pics when dblclick at first time

### DIFF
--- a/frontend/src/components/files/ExtendedImage.vue
+++ b/frontend/src/components/files/ExtendedImage.vue
@@ -44,6 +44,7 @@ export default {
       lastX: null,
       lastY: null,
       inDrag: false,
+      touches: 0,
       lastTouchDistance: 0,
       moveDisabled: false,
       disabledTimer: null,


### PR DESCRIPTION
Fixed a small double click bug.
The bug is : when you browse the pics in your phone's browser,  for example, you click the right-middle button to show the next pic, and double click the screen to zoom out the new pic, but nothing happened. You need to double click it again to zoom it. 