### PR TITLE
relocate the "save" button in the editor in mobile browser

### DIFF
--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -4,15 +4,13 @@
       <action icon="close" :label="$t('buttons.close')" @action="close()" />
       <title>{{ req.name }}</title>
 
-      <template #actions>
-        <action
-          v-if="user.perm.modify"
-          id="save-button"
-          icon="save"
-          :label="$t('buttons.save')"
-          @action="save()"
-        />
-      </template>
+      <action
+        v-if="user.perm.modify"
+        id="save-button"
+        icon="save"
+        :label="$t('buttons.save')"
+        @action="save()"
+      />
     </header-bar>
 
     <breadcrumbs base="/files" noLink />


### PR DESCRIPTION
**before:**
In the template, there is only one button. We can put it outside. It will be more convenient.
![1](https://user-images.githubusercontent.com/76441520/137055694-c42aafe1-1244-4f5f-9bc8-6248023df1b9.png)

![2](https://user-images.githubusercontent.com/76441520/137055831-8cf175f3-5ddc-4010-8464-90b365067b06.png)

**after:**
![3](https://user-images.githubusercontent.com/76441520/137055962-b244f178-6567-4360-9a0d-9ca160ec2a43.png)



