### PR TITLE
Fix encoding issue on password for shared files.

### DIFF
--- a/frontend/src/api/pub.js
+++ b/frontend/src/api/pub.js
@@ -5,7 +5,7 @@ export async function fetch(url, password = "") {
   url = removePrefix(url);
 
   const res = await fetchURL(`/api/public/share${url}`, {
-    headers: { "X-SHARE-PASSWORD": password },
+    headers: { "X-SHARE-PASSWORD": unescape(encodeURIComponent(password)) },
   });
 
   if (res.status === 200) {

--- a/frontend/src/api/pub.js
+++ b/frontend/src/api/pub.js
@@ -3,9 +3,11 @@ import { baseURL } from "@/utils/constants";
 
 export async function fetch(url, password = "") {
   url = removePrefix(url);
+  let deiso = new TextDecoder("iso88591");
+  let enutf8 = new TextEncoder();
 
   const res = await fetchURL(`/api/public/share${url}`, {
-    headers: { "X-SHARE-PASSWORD": unescape(encodeURIComponent(password)) },
+    headers: { "X-SHARE-PASSWORD": deiso.decode(enutf8.encode(password)) },
   });
 
   if (res.status === 200) {


### PR DESCRIPTION
**Description**
<!--
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.
-->
At the moment, when using special characters in password for file sharing (e.g. accentuated letters "éèà"), it causes problems with encoding. When accessing the shared link and asked for the password, it always returns "Wrong credentials" even if the password is correct due to UTF-8/ISO-8859-1 incompatibilities.  
This PR fixes this issue.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.


<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
