### PR TITLE
fix: remove GOMAXPROCS setting

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"runtime"
-
 	"github.com/filebrowser/filebrowser/v2/cmd"
 )
 
 func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
 	cmd.Execute()
 }


### PR DESCRIPTION
**Description**
<!--
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.
--> After go version 1.5, we don't need to use GOMAXPROCS to set to use available cpu cores. By default, Go programs run with GOMAXPROCS set to the number of cores available. [Golang official docs](https://go.dev/doc/go1.5)

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
