### PR TITLE
Feature

### DIFF
--- a/files/file.go
+++ b/files/file.go
@@ -27,7 +27,6 @@ import (
 type FileInfo struct {
 	*Listing
 	Fs              afero.Fs          `json:"-"`
-	Dir             string            `json:"dir"`
 	Path            string            `json:"path"`
 	Name            string            `json:"name"`
 	Size            int64             `json:"size"`
@@ -106,10 +105,8 @@ func stat(opts FileOptions) (*FileInfo, error) {
 		if err != nil {
 			return nil, err
 		}
-		dir, _ := filepath.Split(opts.Path)
 		file = &FileInfo{
 			Fs:        opts.Fs,
-			Dir:       dir,
 			Path:      opts.Path,
 			Name:      info.Name(),
 			ModTime:   info.ModTime(),
@@ -144,10 +141,8 @@ func stat(opts FileOptions) (*FileInfo, error) {
 		return file, nil
 	}
 
-	dir, _ := filepath.Split(opts.Path)
 	file = &FileInfo{
 		Fs:        opts.Fs,
-		Dir:       dir,
 		Path:      opts.Path,
 		Name:      info.Name(),
 		ModTime:   info.ModTime(),
@@ -222,8 +217,6 @@ func (i *FileInfo) Thumbnail() (*FileInfo, error) {
 
 	path := ThumbnailPath(realPath)
 
-	dir, _ := filepath.Split(path)
-
 	info, err := os.Stat(path)
 
 	if err != nil {
@@ -232,7 +225,6 @@ func (i *FileInfo) Thumbnail() (*FileInfo, error) {
 
 	file := &FileInfo{
 		Fs:        i.Fs,
-		Dir:       dir,
 		Path:      path,
 		Name:      info.Name(),
 		ModTime:   info.ModTime(),

--- a/fileutils/dir.go
+++ b/fileutils/dir.go
@@ -6,10 +6,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-// CopyDir copies a directory from source to dest and all
-// of its sub-directories. It doesn't stop if it finds an error
-// during the copy. Returns an error if any.
-func CopyDir(fs afero.Fs, source, dest string) error {
+func CreateDir(fs afero.Fs, source, dest string) error {
 	// Get properties of source.
 	srcinfo, err := fs.Stat(source)
 	if err != nil {
@@ -18,6 +15,18 @@ func CopyDir(fs afero.Fs, source, dest string) error {
 
 	// Create the destination directory.
 	err = fs.MkdirAll(dest, srcinfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CopyDir copies a directory from source to dest and all
+// of its sub-directories. It doesn't stop if it finds an error
+// during the copy. Returns an error if any.
+func CopyDir(fs afero.Fs, source, dest string) error {
+	err := CreateDir(fs, source, dest)
 	if err != nil {
 		return err
 	}

--- a/fileutils/dir.go
+++ b/fileutils/dir.go
@@ -6,7 +6,10 @@ import (
 	"github.com/spf13/afero"
 )
 
-func CreateDir(fs afero.Fs, source, dest string) error {
+// CopyDir copies a directory from source to dest and all
+// of its sub-directories. It doesn't stop if it finds an error
+// during the copy. Returns an error if any.
+func CopyDir(fs afero.Fs, source, dest string) error {
 	// Get properties of source.
 	srcinfo, err := fs.Stat(source)
 	if err != nil {
@@ -15,18 +18,6 @@ func CreateDir(fs afero.Fs, source, dest string) error {
 
 	// Create the destination directory.
 	err = fs.MkdirAll(dest, srcinfo.Mode())
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// CopyDir copies a directory from source to dest and all
-// of its sub-directories. It doesn't stop if it finds an error
-// during the copy. Returns an error if any.
-func CopyDir(fs afero.Fs, source, dest string) error {
-	err := CreateDir(fs, source, dest)
 	if err != nil {
 		return err
 	}

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -8,6 +8,7 @@
     @dragover="dragOver"
     @drop="drop"
     @click="itemClick"
+    :data-thumbs-enabled="isThumbsEnabled"
     :data-dir="isDir"
     :data-type="type"
     :aria-label="name"
@@ -15,7 +16,7 @@
   >
     <div>
       <img
-        v-if="readOnly == undefined && type === 'image' && isThumbsEnabled"
+        v-if="hasThumbnailUrl"
         v-lazy="thumbnailUrl"
       />
       <i v-else class="material-icons"></i>
@@ -52,6 +53,7 @@ export default {
   props: [
     "name",
     "isDir",
+    "isThumbsEnabled",
     "url",
     "type",
     "size",
@@ -90,8 +92,8 @@ export default {
 
       return `${baseURL}/api/preview/thumb/${path}?k=${key}&inline=true`;
     },
-    isThumbsEnabled() {
-      return enableThumbs;
+    hasThumbnailUrl() {
+      return this.readOnly == undefined && this.isThumbsEnabled && enableThumbs;
     },
   },
   methods: {

--- a/frontend/src/views/files/Listing.vue
+++ b/frontend/src/views/files/Listing.vue
@@ -221,6 +221,7 @@
             v-bind:index="item.index"
             v-bind:name="item.name"
             v-bind:isDir="item.isDir"
+            v-bind:isThumbsEnabled="item.isThumbsEnabled"
             v-bind:url="item.url"
             v-bind:modified="item.modified"
             v-bind:type="item.type"

--- a/http/preview.go
+++ b/http/preview.go
@@ -59,6 +59,18 @@ func previewHandler(imgSvc ImgService, fileCache FileCache, enableThumbnails, re
 
 		setContentDisposition(w, r, file)
 
+		thumbnail, err := files.NewThumbnailInfo(files.FileOptions{
+			Fs:         d.user.Fs,
+			Path:       "/" + vars["path"],
+			Modify:     d.user.Perm.Modify,
+			Expand:     true,
+			ReadHeader: d.server.TypeDetectionByHeader,
+			Checker:    d,
+		})
+		if err == nil && thumbnail != nil {
+			return rawFileHandler(w, r, thumbnail)
+		}
+
 		switch file.Type {
 		case "image":
 			return handleImagePreview(w, r, imgSvc, fileCache, file, previewSize, enableThumbnails, resizePreview)


### PR DESCRIPTION
I added support for thumbnails as described [here](https://github.com/filebrowser/filebrowser/issues/1916). The thumbnails are not automatically generated. However, to generate thumbnails for images and videos you can use this command:

```
file="/path/to/video.mp4"
ffmpeg -i "${file}" -ss 00:00:1.000 -vf "scale='ceil(max(1024/iw,1024/ih)*iw):-1',crop=1024:1024:(iw-1024)/2:(ih-1024)/2,setsar=1" -frames:v 1 $XDG_CACHE_HOME'\\thumbnails\\xx-large\\'"$(echo -n ""${file}"" | md5sum | cut -f 1 -d ' ')"'.png'
```

Or this command for windows:

```
$file = "c:\path\to\video.mp4"
$stringAsStream = [System.IO.MemoryStream]::new()
$writer = [System.IO.StreamWriter]::new($stringAsStream)
$writer.write($file)
$writer.Flush()
$stringAsStream.Position = 0
$thumbnail = $Env:XDG_CACHE_HOME + "/thumbnails/xx-large/" + (Get-FileHash -InputStream $stringAsStream -Algorithm MD5 | Select-Object Hash).hash.ToLower() + ".png"
ffmpeg -i "$file" -ss 00:00:1.000 -vf "scale='ceil(max(1024/iw,1024/ih)*iw):-1',crop=1024:1024:(iw-1024)/2:(ih-1024)/2,setsar=1" -frames:v 1 $thumbnail
```

As per [this spec](https://specifications.freedesktop.org/thumbnail-spec/thumbnail-spec-latest.html#THUMBSIZE), the largest thumbnail size is 1024x1024 and those ffmpeg commands will make thumbnail of that size.
