### PR TITLE
Encrypt the password obtained from the flags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ func init() {
 	persistent.StringP("database", "d", "./filebrowser.db", "database path")
 	flags.Bool("noauth", false, "use the noauth auther when using quick setup")
 	flags.String("username", "admin", "username for the first user when using quick config")
-	flags.String("password", "", "hashed password for the first user when using quick config (default \"admin\")")
+	flags.String("password", "admin", "hashed password for the first user when using quick config (default \"admin\")")
 
 	addServerFlags(flags)
 }
@@ -361,18 +361,9 @@ func quickSetup(flags *pflag.FlagSet, d pythonData) {
 	username := getParam(flags, "username")
 	password := getParam(flags, "password")
 
-	if password == "" {
-		password, err = users.HashPwd("admin")
-		checkErr(err)
-	}
-
-	if username == "" || password == "" {
-		log.Fatal("username and password cannot be empty during quick setup")
-	}
-
 	user := &users.User{
 		Username:     username,
-		Password:     password,
+		Password:     users.HashPwd(password),
 		LockPassword: false,
 	}
 


### PR DESCRIPTION
The password set via flags (--password) does not work because it must be encrypted
I don't know if this is a bug, but I decided to fix it, since the description of the flag does not indicate that it should be encrypted
