### PR TITLE
Fix createURL

### DIFF
--- a/frontend/src/api/utils.js
+++ b/frontend/src/api/utils.js
@@ -63,8 +63,8 @@ export function removePrefix(url) {
 
 export function createURL(endpoint, params = {}, auth = true) {
   let prefix = baseURL;
-  if (prefix[prefix.length] != '/') {
-    prefix = prefix + '/';
+  if (prefix[prefix.length] !== "/") {
+    prefix = prefix + "/";
   }
   const url = new URL(prefix + encodePath(endpoint), origin);
 

--- a/frontend/src/api/utils.js
+++ b/frontend/src/api/utils.js
@@ -62,7 +62,11 @@ export function removePrefix(url) {
 }
 
 export function createURL(endpoint, params = {}, auth = true) {
-  const url = new URL(encodePath(endpoint), origin + baseURL);
+  let prefix = baseURL;
+  if (prefix[prefix.length] != '/') {
+    prefix = prefix + '/';
+  }
+  const url = new URL(prefix + encodePath(endpoint), origin);
 
   const searchParams = {
     ...(auth && { auth: store.state.jwt }),


### PR DESCRIPTION
The Javascript URL object takes a second argument which is the base to
use for the URL. However it only accepts the "root" of the base. So
arguments such as http://localhost/example get silently turned into
http://localhost/

This change places the baseURL within the path element, after making
sure that it ends with a slash (/).
