### PR TITLE
fix: use incorrect suffix and return no 500(#1972、#1967)

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -85,7 +85,7 @@
       v-if="$router.currentRoute.path.includes('/files/')"
       style="width: 90%; margin: 2em 2.5em 3em 2.5em"
     >
-      <progress-bar :val="usage.usedPercentage" :size="large"></progress-bar>
+      <progress-bar :val="usage.usedPercentage" size="large"></progress-bar>
       <br />
       {{ usage.used }} of {{ usage.total }} used
     </div>
@@ -102,9 +102,9 @@
         >
         <span> {{ version }}</span>
       </span>
-      <span
-        ><a @click="help">{{ $t("sidebar.help") }}</a></span
-      >
+      <span>
+        <a @click="help">{{ $t("sidebar.help") }}</a>
+      </span>
     </p>
   </nav>
 </template>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -85,7 +85,7 @@
       v-if="$router.currentRoute.path.includes('/files/')"
       style="width: 90%; margin: 2em 2.5em 3em 2.5em"
     >
-      <progress-bar :val="usage.usedPercentage" size="large"></progress-bar>
+      <progress-bar :val="usage.usedPercentage" size="small"></progress-bar>
       <br />
       {{ usage.used }} of {{ usage.total }} used
     </div>

--- a/http/resource.go
+++ b/http/resource.go
@@ -351,12 +351,19 @@ var diskUsage = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (
 		return errToStatus(err), err
 	}
 	fPath := file.RealPath()
-	usage, err := disk.UsageWithContext(r.Context(), fPath)
-	if err != nil {
-		return errToStatus(err), err
+	if file.IsDir {
+		usage, err := disk.UsageWithContext(r.Context(), fPath)
+		if err != nil {
+			return errToStatus(err), err
+		}
+		return renderJSON(w, r, &DiskUsageResponse{
+			Total: usage.Total,
+			Used:  usage.Used,
+		})
+	} else {
+		return renderJSON(w, r, &DiskUsageResponse{
+			Total: 0,
+			Used:  0,
+		})
 	}
-	return renderJSON(w, r, &DiskUsageResponse{
-		Total: usage.Total,
-		Used:  usage.Used,
-	})
 })

--- a/http/resource.go
+++ b/http/resource.go
@@ -351,19 +351,19 @@ var diskUsage = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (
 		return errToStatus(err), err
 	}
 	fPath := file.RealPath()
-	if file.IsDir {
-		usage, err := disk.UsageWithContext(r.Context(), fPath)
-		if err != nil {
-			return errToStatus(err), err
-		}
-		return renderJSON(w, r, &DiskUsageResponse{
-			Total: usage.Total,
-			Used:  usage.Used,
-		})
-	} else {
+	if !file.IsDir {
 		return renderJSON(w, r, &DiskUsageResponse{
 			Total: 0,
 			Used:  0,
 		})
 	}
+
+	usage, err := disk.UsageWithContext(r.Context(), fPath)
+	if err != nil {
+		return errToStatus(err), err
+	}
+	return renderJSON(w, r, &DiskUsageResponse{
+		Total: usage.Total,
+		Used:  usage.Used,
+	})
 })


### PR DESCRIPTION
When watch Video at filebrowser, there will be a `500` server error at right bottom of the page #1972 
The reason is SideBar.vue will check disk useage when route changes, but when path is a file, server will return a `500` error
Before:
    file: 500 error
    dir: true useage
After:
    file: 0 useage
    dir: true useage