### PR TITLE
Fix the progess bar hidden when rotated in mobile

### DIFF
--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -160,7 +160,9 @@ main .spinner .bounce2 {
   width: 100%;
   height: 100%;
   z-index: 9999;
-  overflow: hidden;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 #previewer header {


### PR DESCRIPTION
**Description**

When rotated in mobile, the video player's progess bar was hidden because of the fixed height of header.
So i made some changes for #PREVIEWER css.and fix the problem. 

