### PR TITLE
Added initial support for OpenGraph meta-tags

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -28,6 +28,13 @@
   <meta name="msapplication-TileImage" content="[{[ .StaticURL ]}]/img/icons/mstile-144x144.png">
   <meta name="msapplication-TileColor" content="[{[ if .Color -]}][{[ .Color ]}][{[ else ]}]#2979ff[{[ end ]}]">
 
+   <!-- Meta-information for OpenGraph embedding -->
+   <meta property="og:url" content="[{[ .BaseURL ]}][{[ .Path ]}]">
+   <meta property="og:type" content="website">
+   <meta property="og:title" content="[{[ if .Name -]}][{[ .Name ]}][{[ else ]}]File Browser[{[ end ]}]">
+   <meta property="og:description" content="[{[ .Path ]}]">
+   <meta property="og:image" content="[{[ .StaticURL ]}]/img/icons/android-chrome-512x512.png">
+
   <!-- Inject Some Variables and generate the manifest json -->
   <script>
     window.FileBrowser = JSON.parse('[{[ .Json ]}]');

--- a/http/static.go
+++ b/http/static.go
@@ -18,7 +18,7 @@ import (
 	"github.com/filebrowser/filebrowser/v2/version"
 )
 
-func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, fSys fs.FS, file, contentType string) (int, error) {
+func handleWithStaticData(w http.ResponseWriter, r *http.Request, d *data, fSys fs.FS, file, contentType string) (int, error) {
 	w.Header().Set("Content-Type", contentType)
 
 	auther, err := d.store.Auth.Get(d.settings.AuthMethod)
@@ -43,6 +43,8 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, fSys 
 		"EnableThumbs":    d.server.EnableThumbnails,
 		"ResizePreview":   d.server.ResizePreview,
 		"EnableExec":      d.server.EnableExec,
+		"Origin":          r.URL.Scheme + r.Host,
+		"Path":            r.URL.Path,
 	}
 
 	if d.settings.Branding.Files != "" {


### PR DESCRIPTION
**Description**
The OpenGraph protocol allows for rich embeds in social media apps. It requires certain meta-tags to be set appropriately:
* url: should be the canonical URL of the resource
* type: a valid content type, e.g. 'website'
* title: a short title of the resource
* description: a sentence or two to describe the resource
* image: an image related to the resource

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).


**Further comments**
As the crawlers that read OpenGraph meta-tags do not typically use JavaScript, the content of the tags needs to be set by Go. My understanding of Go is quite limited, so I was unable to reliably set the FQDN of the server - this needs to exist for both the url, and the image (cannot be a relative link to the image)
