### PR TITLE
Modify the delete confirmation interface logic.

### DIFF
--- a/frontend/src/components/prompts/Delete.vue
+++ b/frontend/src/components/prompts/Delete.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="card floating">
     <div class="card-content">
-      <p v-if="req.kind !== 'listing'">
+      <p v-if="selectedCount === 1">
         {{ $t("prompts.deleteMessageSingle") }}
       </p>
       <p v-else>


### PR DESCRIPTION
**Description**
When selecting multiple files, the original deletion confirmation interface displays the confirmation dialog text of a single file, which does not conform to normal program logic.
Before modification:
![old0](https://user-images.githubusercontent.com/113674190/191464061-06ff8d61-7a85-4432-9cae-148422643bff.png)
![old](https://user-images.githubusercontent.com/113674190/191464273-5846f158-b0c6-4e4b-b5a4-5ad1525e3551.png)
After modification:
![new](https://user-images.githubusercontent.com/113674190/191464784-4265499f-0a5c-41da-a38f-eec4c99444b6.png)
