### PR TITLE
feat: rtl support

### DIFF
--- a/frontend/src/css/_shell.css
+++ b/frontend/src/css/_shell.css
@@ -16,6 +16,10 @@
   transition: .2s ease transform;
 }
 
+body.rtl .shell {
+  direction: ltr;
+}
+
 .shell__result {
   display: flex;
   padding: 0.5em;

--- a/frontend/src/css/base.css
+++ b/frontend/src/css/base.css
@@ -5,6 +5,10 @@ body {
   color: #333333;
 }
 
+body.rtl {
+  direction: rtl;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -58,6 +62,11 @@ nav {
   left: 0;
 }
 
+body.rtl nav {
+  left: unset;
+  right: 0;
+}
+
 nav .action {
   width: 100%;
   display: block;
@@ -67,6 +76,11 @@ nav .action {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+body.rtl .action {
+  direction: rtl;
+  text-align: right;
 }
 
 nav > div {
@@ -99,6 +113,10 @@ main {
   color: inherit;
   transition: 0.1s ease-in;
   border-radius: 0.125em;
+}
+
+body.rtl .breadcrumbs a {
+  transform: translateX(-16em);
 }
 
 .breadcrumbs a:hover {

--- a/frontend/src/css/dashboard.css
+++ b/frontend/src/css/dashboard.css
@@ -8,6 +8,10 @@
   flex-wrap: wrap;
 }
 
+body.rtl .dashboard .row {
+  margin-right: 16em;
+}
+
 .dashboard .row .column {
   display: flex;
   padding: 0 .5em;
@@ -58,6 +62,10 @@ p code {
   display: flex;
   flex-grow: 1;
   border-bottom: 2px solid rgba(0, 0, 0, 0.05);
+}
+
+body.rtl #nav .wrapper {
+  margin-right: 16em;
 }
 
 .dashboard #nav ul {
@@ -138,6 +146,13 @@ table tr>*:first-child {
   padding-left: 1em;
 }
 
+body.rtl table tr>* {
+  padding-left: unset;
+  padding-right: 1em;
+  text-align: right;
+  direction: ltr;
+}
+
 table tr>*:last-child {
   padding-right: 1em;
 }
@@ -179,6 +194,11 @@ table tr>*:last-child {
 
 .card .card-title>*:first-child {
   margin-right: auto;
+}
+
+body.rtl .card .card-title>*:first-child {
+  margin-right: 0;
+  text-align: right;
 }
 
 .card>div {
@@ -461,4 +481,10 @@ table tr>*:last-child {
 .card .card-action.full .action .title {
   font-size: 1.5em;
   font-weight: 500;
+}
+
+/*** RTL - Fix disk usage information (in english) ***/
+body.rtl .credits {
+  text-align: right;
+  direction: ltr;
 }

--- a/frontend/src/css/header.css
+++ b/frontend/src/css/header.css
@@ -135,8 +135,23 @@ header .menu-button {
   z-index: 1;
 }
 
+body.rtl #search #result {
+  direction: ltr;
+}
+
 #search #result>div>*:first-child {
   margin-top: 0;
+}
+
+body.rtl #search #result {
+  direction: rtl;
+  text-align: right;
+}
+
+/*** RTL - Keep search result LTR because it has paths (in english) ***/
+body.rtl #search #result ul>* {
+  direction: ltr;
+  text-align: left;
 }
 
 #search.active #result {
@@ -222,6 +237,10 @@ header .menu-button {
   font-size: 1em;
   color: #212121;
   padding: .5em;
+}
+
+body.rtl #search .boxes h3 {
+  text-align: right;
 }
 
 #search .boxes>div {

--- a/frontend/src/css/listing.css
+++ b/frontend/src/css/listing.css
@@ -2,6 +2,10 @@
   --item-selected: white;
 }
 
+body.rtl #listing {
+  margin-right: 16em;
+}
+
 #listing h2 {
   margin: 0 0 0 0.5em;
   font-size: .9em;

--- a/frontend/src/css/mobile.css
+++ b/frontend/src/css/mobile.css
@@ -40,6 +40,13 @@
     transform-origin: top right;
     z-index: 99999;
   }
+
+  body.rtl #dropdown {
+    right: unset;
+    left: 1em;
+    transform-origin: top left;
+  }
+
   #dropdown > div {
     display: block;
   }
@@ -95,9 +102,20 @@
     transition: .1s ease left;
     left: -17em;
   }
+
+  body.rtl nav {
+    left: unset;
+    right: -17em;
+  }
   nav.active {
     left: 0;
   }
+
+  body.rtl nav.active {
+    left: unset;
+    right: 0;
+  }
+
   header .search-button,
   header .menu-button {
     display: inherit;
@@ -108,6 +126,23 @@
   #listing {
     margin-bottom: 5em;
   }
+
+  body.rtl #listing {
+    margin-right: unset;
+  }
+
+  body.rtl .breadcrumbs {
+    transform: translateX(16em);
+  }
+
+  body.rtl #nav .wrapper {
+    margin-right: unset;
+  }
+  
+  body.rtl .dashboard .row {
+    margin-right: unset;
+  }
+
   main {
     margin: 0 1em;
     width: calc(100% - 2em);

--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -315,6 +315,11 @@ main .spinner .bounce2 {
   padding: 0 1em;
 }
 
+/*** RTL - flip and position arrow of path ***/
+body.rtl .breadcrumbs .chevron {
+  transform: scaleX(-1) translateX(16em);
+}
+
 #editor-container .breadcrumbs span {
   font-size: .75rem;
 }
@@ -404,3 +409,22 @@ main .spinner .bounce2 {
 }
 
 @import './mobile.css';
+
+/* * * * * * * * * * * * * * * *
+ *         RTL overrides       *
+ * * * * * * * * * * * * * * * */
+
+body.rtl .card-content textarea {
+  direction: ltr;
+  text-align: left;
+}
+
+body.rtl .card-content .small + input {
+  direction: ltr;
+  text-align: left;
+}
+
+body.rtl .card.floating .card-content .file-list {
+  direction: ltr;
+  text-align: left;
+}

--- a/frontend/src/i18n/index.js
+++ b/frontend/src/i18n/index.js
@@ -100,6 +100,8 @@ const removeEmpty = (obj) =>
       {}
     );
 
+export const rtlLanguages = ["he", "ar"];
+
 const i18n = new VueI18n({
   locale: detectLocale(),
   fallbackLocale: "en",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -12,7 +12,7 @@ import ProfileSettings from "@/views/settings/Profile";
 import Shares from "@/views/settings/Shares";
 import Errors from "@/views/Errors";
 import store from "@/store";
-import { baseURL, name } from "@/utils/constants";
+import { baseURL, name, rtlLanguages } from "@/utils/constants";
 import i18n from "@/i18n";
 
 Vue.use(Router);
@@ -157,6 +157,17 @@ const router = new Router({
 router.beforeEach((to, from, next) => {
   const title = i18n.t(titles[to.name]);
   document.title = title + " - " + name;
+
+  /*** RTL related settings per route ****/
+  const rtlSet = document.querySelector("body").classList.contains("rtl");
+  const shouldSetRtl = rtlLanguages.includes(i18n.locale);
+  // Add RTL
+  if (shouldSetRtl && rtlSet === false) {
+    document.querySelector("body").classList.add("rtl");
+    //Remove RTL
+  } else if (rtlSet === true && shouldSetRtl === false) {
+    document.querySelector("body").classList.remove("rtl");
+  }
 
   if (to.matched.some((record) => record.meta.requiresAuth)) {
     if (!store.getters.isLogged) {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -12,8 +12,8 @@ import ProfileSettings from "@/views/settings/Profile";
 import Shares from "@/views/settings/Shares";
 import Errors from "@/views/Errors";
 import store from "@/store";
-import { baseURL, name, rtlLanguages } from "@/utils/constants";
-import i18n from "@/i18n";
+import { baseURL, name } from "@/utils/constants";
+import i18n, { rtlLanguages } from "@/i18n";
 
 Vue.use(Router);
 
@@ -161,12 +161,13 @@ router.beforeEach((to, from, next) => {
   /*** RTL related settings per route ****/
   const rtlSet = document.querySelector("body").classList.contains("rtl");
   const shouldSetRtl = rtlLanguages.includes(i18n.locale);
-  // Add RTL
-  if (shouldSetRtl && rtlSet === false) {
-    document.querySelector("body").classList.add("rtl");
-    //Remove RTL
-  } else if (rtlSet === true && shouldSetRtl === false) {
-    document.querySelector("body").classList.remove("rtl");
+  switch (true) {
+    case shouldSetRtl && !rtlSet:
+      document.querySelector("body").classList.add("rtl");
+      break;
+    case !shouldSetRtl && rtlSet:
+      document.querySelector("body").classList.remove("rtl");
+      break;
   }
 
   if (to.matched.some((record) => record.meta.requiresAuth)) {

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -15,6 +15,7 @@ const enableThumbs = window.FileBrowser.EnableThumbs;
 const resizePreview = window.FileBrowser.ResizePreview;
 const enableExec = window.FileBrowser.EnableExec;
 const origin = window.location.origin;
+const rtlLanguages = ["he", "ar"];
 
 export {
   name,
@@ -33,4 +34,5 @@ export {
   resizePreview,
   enableExec,
   origin,
+  rtlLanguages,
 };

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -15,7 +15,6 @@ const enableThumbs = window.FileBrowser.EnableThumbs;
 const resizePreview = window.FileBrowser.ResizePreview;
 const enableExec = window.FileBrowser.EnableExec;
 const origin = window.location.origin;
-const rtlLanguages = ["he", "ar"];
 
 export {
   name,
@@ -34,5 +33,4 @@ export {
   resizePreview,
   enableExec,
   origin,
-  rtlLanguages,
 };

--- a/frontend/src/views/settings/Profile.vue
+++ b/frontend/src/views/settings/Profile.vue
@@ -75,7 +75,7 @@
 import { mapState, mapMutations } from "vuex";
 import { users as api } from "@/api";
 import Languages from "@/components/settings/Languages";
-import i18n from "@/i18n";
+import i18n, { rtlLanguages } from "@/i18n";
 
 export default {
   name: "settings",
@@ -144,7 +144,9 @@ export default {
           singleClick: this.singleClick,
           dateFormat: this.dateFormat,
         };
-        const shouldReload = data.locale != i18n.locale;
+        const shouldReload =
+          rtlLanguages.includes(data.locale) !==
+          rtlLanguages.includes(i18n.locale);
         await api.update(data, [
           "locale",
           "hideDotfiles",

--- a/frontend/src/views/settings/Profile.vue
+++ b/frontend/src/views/settings/Profile.vue
@@ -75,6 +75,7 @@
 import { mapState, mapMutations } from "vuex";
 import { users as api } from "@/api";
 import Languages from "@/components/settings/Languages";
+import i18n from "@/i18n";
 
 export default {
   name: "settings",
@@ -143,6 +144,7 @@ export default {
           singleClick: this.singleClick,
           dateFormat: this.dateFormat,
         };
+        const shouldReload = data.locale != i18n.locale;
         await api.update(data, [
           "locale",
           "hideDotfiles",
@@ -150,6 +152,9 @@ export default {
           "dateFormat",
         ]);
         this.updateUser(data);
+        if (shouldReload) {
+          location.reload();
+        }
         this.$showSuccess(this.$t("settings.settingsUpdated"));
       } catch (e) {
         this.$showError(e);


### PR DESCRIPTION
Added full RTL localization support
I tested it on mobile / desktop and it works well

All the styles that were added are only applied when
`body` has `class` named `rtl`
and this class added to every route if `i18n.locale` equals to one of `constants.rtlLanguages[]` which are currently hebrew and arabic.

Also in the settings, when the user update the settings I checked if he updated the language as well, if so I reload the page so the styles will take effect (the default behavior isn't to refresh the page)