### PR TITLE
fix: missing video controls on mobile

### DIFF
--- a/frontend/src/css/mobile.css
+++ b/frontend/src/css/mobile.css
@@ -2,6 +2,10 @@
   nav {
     width: 10em
   }
+  /* Mobile Only fix div hidden by bottom navigation bar of mobile browser when using height: 100vh */
+  #previewer .preview {
+    height: calc(100% - 4em) !important;
+  }
 }
 
 @media (max-width: 1024px) {


### PR DESCRIPTION
This fix related to this issue https://github.com/filebrowser/filebrowser/issues/2166

I checked this browsers:
`Chrome` 
`Brave`
`Firefox`
And it happened in all of them, no controls of videos.

I tested this fix and it worked in these 3 browsers.
To test it by yourself: 
Simply open any video in filebrowser with your android browser.

I found the reason for the problem and the solution here:
https://chanind.github.io/javascript/2019/09/28/avoid-100vh-on-mobile-web.html