### PR TITLE
Makes breadcrumbs sticky

### DIFF
--- a/frontend/src/css/base.css
+++ b/frontend/src/css/base.css
@@ -100,6 +100,11 @@ main {
 .breadcrumbs {
   height: 3em;
   border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  position: -webkit-sticky;
+  position: sticky;
+  top: 64px;
+  z-index: 1000;
+  background: var(--background);
 }
 
 .breadcrumbs span,


### PR DESCRIPTION
In a dense folder, having to go back up to change the directory is time consuming : I propose to make the breadcrumbs sticky for practicity. Tested on mobile/tablet/desktop with chromium browser ( edge ), safari and firefox.