### PR TITLE
Makes breadcrumbs sticky

### DIFF
--- a/frontend/public/themes/dark.css
+++ b/frontend/public/themes/dark.css
@@ -72,6 +72,11 @@ nav > div {
 .breadcrumbs {
   border-color: var(--divider);
   color: var(--textPrimary) !important;
+  position: -webkit-sticky !important;
+  position: sticky !important;
+  top: 64px;
+  z-index: 1000;
+  background: var(--background);
 }
 .breadcrumbs span {
   color: var(--textPrimary) !important;


### PR DESCRIPTION
In a dense folder, having to go back up to change the directory is time consuming : I propose to make the breadcrumbs sticky for practicity. Tested on mobile/tablet/desktop with chromium browser ( edge ), safari and firefox.