### PR TITLE
Add RISC-V support to project

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,7 @@ build:
     - 386
     - arm
     - arm64
+    - riscv64
   goarm:
     - 5
     - 6
@@ -113,6 +114,24 @@ dockers:
       - "filebrowser/filebrowser:v{{ .Major }}-armv7"
     extra_files:
       - docker_config.json
+  -
+    dockerfile: Dockerfile.riscv64
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--platform=linux/riscv64"
+    goos: linux
+    goarch: riscv64
+    image_templates:
+      - "filebrowser/filebrowser:{{ .Tag }}-riscv64"
+      - "filebrowser/filebrowser:v{{ .Major }}-riscv64"
+    extra_files:
+      - docker_config.json
 ## s6 based docker images
   -
     dockerfile: Dockerfile.s6
@@ -195,18 +214,21 @@ docker_manifests:
       - "filebrowser/filebrowser:{{ .Tag }}-arm64"
       - "filebrowser/filebrowser:{{ .Tag }}-armv6"
       - "filebrowser/filebrowser:{{ .Tag }}-armv7"
+      - "filebrowser/filebrowser:{{ .Tag }}-riscv64"
   - name_template: "filebrowser/filebrowser:{{ .Tag }}"
     image_templates:
       - "filebrowser/filebrowser:{{ .Tag }}-amd64"
       - "filebrowser/filebrowser:{{ .Tag }}-arm64"
       - "filebrowser/filebrowser:{{ .Tag }}-armv6"
       - "filebrowser/filebrowser:{{ .Tag }}-armv7"
+      - "filebrowser/filebrowser:{{ .Tag }}-riscv64"
   - name_template: "filebrowser/filebrowser:v{{ .Major }}"
     image_templates:
       - "filebrowser/filebrowser:v{{ .Major }}-amd64"
       - "filebrowser/filebrowser:v{{ .Major }}-arm64"
       - "filebrowser/filebrowser:v{{ .Major }}-armv6"
       - "filebrowser/filebrowser:v{{ .Major }}-armv7"
+      - "filebrowser/filebrowser:v{{ .Major }}-riscv64"
 ## s6 image manifests
   - name_template: "filebrowser/filebrowser:s6"
     image_templates:

--- a/Dockerfile.riscv64
+++ b/Dockerfile.riscv64
@@ -1,0 +1,15 @@
+FROM riscv64/alpine:edge
+RUN apk --update add ca-certificates \
+                     mailcap \
+                     curl
+
+HEALTHCHECK --start-period=2s --interval=5s --timeout=3s \
+  CMD curl -f http://localhost/health || exit 1
+
+VOLUME /srv
+EXPOSE 80
+
+COPY docker_config.json /.filebrowser.json
+COPY filebrowser /filebrowser
+
+ENTRYPOINT [ "/filebrowser" ]


### PR DESCRIPTION


**Description**
<!--
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.
-->

Adjust goreleaser config to add build and docker support.

RISC-V is an open standard instruction set architecture, which is under rapid development. Distributions including AOSP, Arch Linux, Debian, Gentoo Linux, Fedora, OpenEuler, etc are also actively doing porting work for this architecture.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->

Add new arch-specific alpine Dockerfile as there is not yet any linux/riscv64 support for `alpine:latest`.
https://hub.docker.com/r/riscv64/alpine

I tried to look at how other architectures were set up: if there is any config missing just let me know and I will add it.
