### PR TITLE
fix: build on FreeBSD and non-Linux platforms

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 DATE ?= $(shell date +%FT%T%z)
 BASE_PATH := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 VERSION ?= $(shell git describe --tags --always --match=v* 2> /dev/null || \


### PR DESCRIPTION
**Description**
`bash` is installed in `/usr/local/bin/bash` on FreeBSD. This patch should make the build work without modification for FreeBSD and Linux.

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.