### PR TITLE
fix: error while using fallback of dir move

### DIFF
--- a/fileutils/file.go
+++ b/fileutils/file.go
@@ -17,12 +17,12 @@ func MoveFile(fs afero.Fs, src, dst string) error {
 		return nil
 	}
 	// fallback
-	err := CopyFile(fs, src, dst)
+	err := Copy(fs, src, dst)
 	if err != nil {
 		_ = fs.Remove(dst)
 		return err
 	}
-	if err := fs.Remove(src); err != nil {
+	if err := fs.RemoveAll(src); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Fix #1936 

## What's actually wrong in this ISSUE

When a folder need to recover an existing one, `fs.Rename` will not work and `MoveFile` function will going a fallback.
However, the fallback usage is not correct and will cause error when it start to **copy & remove the folder** but **treated it in a single file way**.

## How I fix this isssue

By using `Copy` install of `CopyFile` & `RemoveAll` install of `Remove`. `CopyFile` & `Remove` are only effective when the moving object is file.
