### PR TITLE
Audit Logger

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -4,10 +4,9 @@ import "log"
 
 var auditLogger *log.Logger
 
-func init() {
-	setupAuditLogger()
-}
-
-func setupAuditLogger() {
-	auditLogger = log.Default()
+func getAuditLogger() *log.Logger {
+	if auditLogger == nil {
+		auditLogger = log.Default()
+	}
+	return auditLogger
 }

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -1,0 +1,13 @@
+package audit
+
+import "log"
+
+var auditLogger *log.Logger
+
+func init() {
+	setupAuditLogger()
+}
+
+func setupAuditLogger() {
+	auditLogger = log.Default()
+}

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -1,0 +1,16 @@
+package audit
+
+import (
+	"log"
+	"testing"
+)
+
+func TestSetupAuditLogger(t *testing.T) {
+	auditLogger = nil
+
+	setupAuditLogger()
+
+	if auditLogger != log.Default() {
+		t.Error("Audit logger isn't set to the default logger!")
+	}
+}

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -8,9 +8,12 @@ import (
 func TestSetupAuditLogger(t *testing.T) {
 	auditLogger = nil
 
-	setupAuditLogger()
+	result := getAuditLogger()
 
-	if auditLogger != log.Default() {
-		t.Error("Audit logger isn't set to the default logger!")
+	if result != log.Default() {
+		t.Error("Audit logger wasn't initialized with the default logger!")
+	}
+	if auditLogger != result {
+		t.Error("Audit logger wasn't set globally!")
 	}
 }

--- a/audit/log.go
+++ b/audit/log.go
@@ -22,5 +22,5 @@ func createLogMessage(info ResourceActivity) string {
 }
 
 func logToAuditLogger(message string) {
-	auditLogger.Println(message)
+	getAuditLogger().Println(message)
 }

--- a/audit/log.go
+++ b/audit/log.go
@@ -1,0 +1,26 @@
+package audit
+
+import "fmt"
+
+// LogResourceActivity prints an entry to the audit log with information about the given event, file and user.
+//
+// The event should be describing the activity that was performed, e.g. Deletion.
+// This results in a log entry like "Deletion of file with path /srv/test.txt by user test (42)".
+func LogResourceActivity(info ResourceActivity) {
+	message := createLogMessage(info)
+	logToAuditLogger(message)
+}
+
+func createLogMessage(info ResourceActivity) string {
+	return fmt.Sprintf(
+		"%v of resource with path %v by user %v (%v)",
+		info.Event,
+		info.ResourcePath,
+		info.User.Username,
+		info.User.ID,
+	)
+}
+
+func logToAuditLogger(message string) {
+	auditLogger.Println(message)
+}

--- a/audit/log_test.go
+++ b/audit/log_test.go
@@ -2,9 +2,10 @@ package audit
 
 import (
 	"bytes"
-	"github.com/filebrowser/filebrowser/v2/users"
 	"log"
 	"testing"
+
+	"github.com/filebrowser/filebrowser/v2/users"
 )
 
 func TestLogFileActivity(t *testing.T) {

--- a/audit/log_test.go
+++ b/audit/log_test.go
@@ -1,0 +1,59 @@
+package audit
+
+import (
+	"bytes"
+	"github.com/filebrowser/filebrowser/v2/users"
+	"log"
+	"testing"
+)
+
+func TestLogFileActivity(t *testing.T) {
+	resultBuffer := setupTestLogger()
+
+	info := ResourceActivity{
+		Event:        "Deletion",
+		ResourcePath: "/srv/test.txt",
+		User: &users.User{
+			Username: "test",
+			ID:       42,
+		},
+	}
+
+	LogResourceActivity(info)
+
+	result := resultBuffer.String()
+	expectedResult := "Deletion of resource with path /srv/test.txt by user test (42)\n"
+	if result != expectedResult {
+		t.Errorf("Log entry should be \"%v\" but is \"%v\"", expectedResult, result)
+	}
+}
+
+func TestLogFileActivityDirectory(t *testing.T) {
+	resultBuffer := setupTestLogger()
+
+	info := ResourceActivity{
+		Event:        "Creation",
+		ResourcePath: "/srv/test.txt",
+		User: &users.User{
+			Username: "test",
+			ID:       42,
+		},
+	}
+
+	LogResourceActivity(info)
+
+	result := resultBuffer.String()
+	expectedResult := "Creation of resource with path /srv/test.txt by user test (42)\n"
+	if result != expectedResult {
+		t.Errorf("Log entry should be \"%v\" but is \"%v\"", expectedResult, result)
+	}
+}
+
+func setupTestLogger() *bytes.Buffer {
+	var testBuffer bytes.Buffer
+	testLogger := log.New(&testBuffer, "", 0)
+
+	auditLogger = testLogger
+
+	return &testBuffer
+}

--- a/audit/types.go
+++ b/audit/types.go
@@ -1,0 +1,11 @@
+package audit
+
+import (
+	"github.com/filebrowser/filebrowser/v2/users"
+)
+
+type ResourceActivity struct {
+	Event        string
+	ResourcePath string
+	User         *users.User
+}

--- a/http/resource.go
+++ b/http/resource.go
@@ -11,6 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/spf13/afero"
 
@@ -240,8 +243,9 @@ func resourcePatchHandler(fileCache FileCache) handleFunc {
 		}, action, src, dst, d.user)
 
 		if err == nil {
+			titleAction := cases.Title(language.English).String(action)
 			audit.LogResourceActivity(audit.ResourceActivity{
-				Event:        "Patch",
+				Event:        fmt.Sprintf("%v with destination %v", titleAction, dst),
 				ResourcePath: r.URL.Path,
 				User:         d.user,
 			})


### PR DESCRIPTION
**Description**
<!--
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.
-->
Implemented an audit logger for creating, updating, patching and deleting a resource via the REST API.
The current implementation uses the default logger of the builtin log package to log the audit log messages.

However the implementation can easily be changed to use another log destination e.g. a file.
This would be useful if the audit log should be written to a separate file to show it in the UI.

Fixes #2369 
