### PR TITLE
[Performance] Assume file type is image from extension

### DIFF
--- a/files/file.go
+++ b/files/file.go
@@ -356,9 +356,15 @@ func (i *FileInfo) readListing(checker rules.Checker, readHeader bool) error {
 			if isInvalidLink {
 				file.Type = "invalid_link"
 			} else {
-				err := file.detectType(true, false, readHeader)
-				if err != nil {
-					return err
+				extensionLowerCase := strings.ToLower(file.Extension)
+				if extensionLowerCase == ".apng" || extensionLowerCase == ".avif" || extensionLowerCase == ".jpg" ||
+					extensionLowerCase == ".jpeg" || extensionLowerCase == ".png" || extensionLowerCase == ".gif" ||
+					extensionLowerCase == ".jfif" || extensionLowerCase == ".pjpeg" || extensionLowerCase == ".pjp" ||
+					extensionLowerCase == ".svg" || extensionLowerCase == ".webp" {
+
+					file.Type = "image"
+				} else {
+					file.Type = "other"
 				}
 			}
 		}


### PR DESCRIPTION
**Description**
For filebrowser to know if it should show a thumbnail for pictures, it needs to know whether the file is an image or not. If it's not.
The way it is currently done is when you open a folder, for each file the header is read to determine if it's an image or not. This can get very slow for large amounts of files.

A faster way of doing this is just looking at the extension of the file, and checking if it's an image extension. I simply replaced the function call to check each file's extension with an if statement, that checks if the extension is any of the ones listed in [this page](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types).

In my case, it improved the loading speed of a folder with 1240 pictures from 30 seconds to just about 1 second.

Addresses issue #2375
