### PR TITLE
feature: frontend: add option to copy download links from shares

### DIFF
--- a/frontend/src/components/prompts/Share.vue
+++ b/frontend/src/components/prompts/Share.vue
@@ -32,6 +32,16 @@
                 <i class="material-icons">content_paste</i>
               </button>
             </td>
+            <td class="small" v-if="hasDownloadLink()">
+              <button
+                class="action copy-clipboard"
+                :data-clipboard-text="buildDownloadLink(link)"
+                :aria-label="$t('buttons.copyDownloadLinkToClipboard')"
+                :title="$t('buttons.copyDownloadLinkToClipboard')"
+              >
+                <i class="material-icons">content_paste_go</i>
+              </button>
+            </td>
             <td class="small">
               <button
                 class="action"
@@ -117,7 +127,7 @@
 
 <script>
 import { mapState, mapGetters } from "vuex";
-import { share as api } from "@/api";
+import { share as api, pub as pub_api } from "@/api";
 import moment from "moment";
 import Clipboard from "clipboard";
 
@@ -214,6 +224,14 @@ export default {
     },
     buildLink(share) {
       return api.getShareURL(share);
+    },
+    hasDownloadLink() {
+      return (
+        this.selected.length === 1 && !this.req.items[this.selected[0]].isDir
+      );
+    },
+    buildDownloadLink(share) {
+      return pub_api.getDownloadURL(share);
     },
     sort() {
       this.links = this.links.sort((a, b) => {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -5,6 +5,7 @@
     "copy": "Copy",
     "copyFile": "Copy file",
     "copyToClipboard": "Copy to clipboard",
+    "copyDownloadLinkToClipboard": "Copy download link to clipboard",
     "create": "Create",
     "delete": "Delete",
     "download": "Download",


### PR DESCRIPTION
**Description**
This is a small pull request that adds an option to quickly copy public download links from:

- Single-file shares:
![Screenshot_20230429_124301](https://user-images.githubusercontent.com/4929005/235298551-bad523bb-bede-4291-88d1-98906b4afd1b.png)

- Single files inside directory shares:
![Screenshot_20230429_124432](https://user-images.githubusercontent.com/4929005/235298603-6e2aed7a-4527-4c4f-8dec-4ce4b3a5e75a.png)


This saves a few clicks when sharing a video to play with VLC (streaming).

**NOTE:** It requires a new translation entry: buttons.copyDownloadLinkToClipboard