### PR TITLE
fix: solve broken Docker build with alpine image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *
 !docker/*
+!docker_config.json
 !filebrowser


### PR DESCRIPTION
**Description**
Commit b8f35ce excluded `docker_config.json` by changing .dockerignore rules and this was not reverted by 46d8046. This commit adds the exception back.

Fixes #2484

**Testing**

```
 2023-05-31 21:47:50 ⌚  LAPTOP-VA in ~/code/filebrowser/filebrowser
± |fix-docker-build ✓| → docker build . -t test
[+] Building 2.1s (9/9) FINISHED                                                                                                                                                                                                 
 => [internal] load build definition from Dockerfile                                                                                                                                                                        0.0s
 => => transferring dockerfile: 389B                                                                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                                                           0.1s
 => => transferring context: 84B                                                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                                                            2.0s
 => [1/4] FROM docker.io/library/alpine:latest@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11                                                                                                      0.0s
 => [internal] load build context                                                                                                                                                                                           0.0s
 => => transferring context: 72B                                                                                                                                                                                            0.0s
 => CACHED [2/4] RUN apk --update add ca-certificates                      mailcap                      curl                                                                                                                0.0s
 => CACHED [3/4] COPY docker_config.json /.filebrowser.json                                                                                                                                                                 0.0s
 => CACHED [4/4] COPY filebrowser /filebrowser                                                                                                                                                                              0.0s
 => exporting to image                                                                                                                                                                                                      0.0s
 => => exporting layers                                                                                                                                                                                                     0.0s
 => => writing image sha256:e8b379024d8b41b8b00fc7e93910f5bce5dd93ca76091c8239efedf81394c3e6                                                                                                                                0.0s
 => => naming to docker.io/library/test  
```