### PR TITLE
Add a healthcheck script that works with a dynamic port.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM alpine:latest
 RUN apk --update add ca-certificates \
                      mailcap \
-                     curl
+                     curl \
+                     jq
+
+COPY healthcheck.sh /healthcheck.sh
+RUN chmod +x /healthcheck.sh  # Make the script executable
 
 HEALTHCHECK --start-period=2s --interval=5s --timeout=3s \
-  CMD curl -f http://localhost/health || exit 1
+    CMD /healthcheck.sh || exit 1
 
 VOLUME /srv
 EXPOSE 80

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PORT=$(jq .port /.filebrowser.json)
+curl -f http://localhost:$PORT/health || exit 1


### PR DESCRIPTION
**Description**
This PR modifies the docker healthcheck command to run an external script that supports a custom port from the `.filebrowser.json` config file.
