### PR TITLE
feat: filter ANSI color for shell

### DIFF
--- a/frontend/src/components/Shell.vue
+++ b/frontend/src/components/Shell.vue
@@ -114,9 +114,9 @@ export default {
         },
         () => {
           results.text = results.text
-              // eslint-disable-next-line no-control-regex
-              .replace(/\u001b\[[0-9;]+m/g, '') // Filter ANSI color for now
-              .trimEnd();
+            // eslint-disable-next-line no-control-regex
+            .replace(/\u001b\[[0-9;]+m/g, "") // Filter ANSI color for now
+            .trimEnd();
           this.canInput = true;
           this.$refs.input.focus();
           this.scroll();

--- a/frontend/src/components/Shell.vue
+++ b/frontend/src/components/Shell.vue
@@ -113,7 +113,10 @@ export default {
           this.scroll();
         },
         () => {
-          results.text = results.text.trimEnd();
+          results.text = results.text
+              // eslint-disable-next-line no-control-regex
+              .replace(/\u001b\[[0-9;]+m/g, '') // Filter ANSI color for now
+              .trimEnd();
           this.canInput = true;
           this.$refs.input.focus();
           this.scroll();


### PR DESCRIPTION
**Description**
<!--
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.
-->

File Browser supports `Execute on shell`. But shell result may contain ANSI color. Before this project support colored shell, we can filter ANSI color for now.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->

None.
