### PR TITLE
Issues #2522: Only a section of items being returned in a directory.

### DIFF
--- a/frontend/src/views/files/Listing.vue
+++ b/frontend/src/views/files/Listing.vue
@@ -606,10 +606,12 @@ export default {
     },
     colunmsResize() {
       // Update the columns size based on the window width.
+      let items = css(["#listing.mosaic .item", ".mosaic#listing .item"]);
+      if (!items) return;
+
       let columns = Math.floor(
         document.querySelector("main").offsetWidth / this.columnWidth
       );
-      let items = css(["#listing.mosaic .item", ".mosaic#listing .item"]);
       if (columns === 0) columns = 1;
       items.style.width = `calc(${100 / columns}% - 1em)`;
     },


### PR DESCRIPTION
**Description**
<!--
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.
-->
This is a quick fix for issue #2522. From what I've seen, the issue seems to happen at Listing.vue:colunmsResize:614:
1. As the css() call may return null, items becomes null and as a result, causes an exception. 
2. This exceptions stops the creation of the window listeners in the mounted() function.
3. Since there is no scroll event expanding the items on the page, only the initial amount of items is shown.

A quick return on items being null seems to fix the issue.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
