### PR TITLE
Remove redundant calls to baseURL/url #2581

### DIFF
--- a/frontend/src/api/files.js
+++ b/frontend/src/api/files.js
@@ -2,7 +2,7 @@ import { createURL, fetchURL, removePrefix, removeTusEndpoint } from "./utils";
 import { baseURL } from "@/utils/constants";
 import store from "@/store";
 import { upload as postTus, useTus } from "./tus";
-import {tusEndpoint} from "../utils/constants";
+import { tusEndpoint } from "../utils/constants";
 
 export async function fetch(url) {
   url = removePrefix(url);
@@ -90,7 +90,7 @@ export async function post(url, content = "", overwrite = false, onupload) {
     // Tus is disabled / not applicable
     !(await useTus(content));
   if (!useResourcesApi) {
-    url = removeTusEndpoint(tusEndpoint, url)
+    url = removeTusEndpoint(tusEndpoint, url);
   }
   return useResourcesApi
     ? postResources(url, content, overwrite, onupload)

--- a/frontend/src/api/files.js
+++ b/frontend/src/api/files.js
@@ -1,7 +1,8 @@
-import { createURL, fetchURL, removePrefix } from "./utils";
+import { createURL, fetchURL, removePrefix, removeTusEndpoint } from "./utils";
 import { baseURL } from "@/utils/constants";
 import store from "@/store";
 import { upload as postTus, useTus } from "./tus";
+import {tusEndpoint} from "../utils/constants";
 
 export async function fetch(url) {
   url = removePrefix(url);
@@ -88,7 +89,9 @@ export async function post(url, content = "", overwrite = false, onupload) {
       !["http:", "https:"].includes(window.location.protocol)) ||
     // Tus is disabled / not applicable
     !(await useTus(content));
-
+  if (!useResourcesApi) {
+    url = removeTusEndpoint(tusEndpoint, url)
+  }
   return useResourcesApi
     ? postResources(url, content, overwrite, onupload)
     : postTus(url, content, overwrite, onupload);

--- a/frontend/src/api/files.js
+++ b/frontend/src/api/files.js
@@ -1,8 +1,7 @@
-import { createURL, fetchURL, removePrefix, removeTusEndpoint } from "./utils";
+import { createURL, fetchURL, removePrefix } from "./utils";
 import { baseURL } from "@/utils/constants";
 import store from "@/store";
 import { upload as postTus, useTus } from "./tus";
-import { tusEndpoint } from "../utils/constants";
 
 export async function fetch(url) {
   url = removePrefix(url);
@@ -89,9 +88,6 @@ export async function post(url, content = "", overwrite = false, onupload) {
       !["http:", "https:"].includes(window.location.protocol)) ||
     // Tus is disabled / not applicable
     !(await useTus(content));
-  if (!useResourcesApi) {
-    url = removeTusEndpoint(tusEndpoint, url);
-  }
   return useResourcesApi
     ? postResources(url, content, overwrite, onupload)
     : postTus(url, content, overwrite, onupload);

--- a/frontend/src/api/tus.js
+++ b/frontend/src/api/tus.js
@@ -1,5 +1,5 @@
 import * as tus from "tus-js-client";
-import { tusEndpoint, tusSettings } from "@/utils/constants";
+import { baseURL, tusEndpoint, tusSettings } from "@/utils/constants";
 import store from "@/store";
 import { removePrefix } from "@/api/utils";
 import { fetchURL } from "./utils";
@@ -7,20 +7,25 @@ import { fetchURL } from "./utils";
 const RETRY_BASE_DELAY = 1000;
 const RETRY_MAX_DELAY = 20000;
 
-export async function upload(url, content = "", overwrite = false, onupload) {
+export async function upload(
+  filePath,
+  content = "",
+  overwrite = false,
+  onupload
+) {
   if (!tusSettings) {
     // Shouldn't happen as we check for tus support before calling this function
     throw new Error("Tus.io settings are not defined");
   }
 
-  url = removePrefix(url);
-  let resourceUrl = `${tusEndpoint}${url}?override=${overwrite}`;
+  filePath = removePrefix(filePath);
+  let resourcePath = `${tusEndpoint}${filePath}?override=${overwrite}`;
 
-  await createUpload(resourceUrl);
+  await createUpload(resourcePath);
 
   return new Promise((resolve, reject) => {
     let upload = new tus.Upload(content, {
-      uploadUrl: resourceUrl,
+      uploadUrl: `${baseURL}${resourcePath}`,
       chunkSize: tusSettings.chunkSize,
       retryDelays: computeRetryDelays(tusSettings),
       parallelUploads: 1,
@@ -46,8 +51,8 @@ export async function upload(url, content = "", overwrite = false, onupload) {
   });
 }
 
-async function createUpload(resourceUrl) {
-  let headResp = await fetchURL(resourceUrl, {
+async function createUpload(resourcePath) {
+  let headResp = await fetchURL(resourcePath, {
     method: "POST",
   });
   if (headResp.status !== 201) {

--- a/frontend/src/api/utils.js
+++ b/frontend/src/api/utils.js
@@ -83,3 +83,10 @@ export function createURL(endpoint, params = {}, auth = true) {
 
   return url.toString();
 }
+
+export function removeTusEndpoint(tusEndpoint, url) {
+  if (url.startsWith(tusEndpoint)) {
+    return url.substring(tusEndpoint.length);
+  }
+  return url;
+}

--- a/frontend/src/api/utils.js
+++ b/frontend/src/api/utils.js
@@ -9,6 +9,10 @@ export async function fetchURL(url, opts, auth = true) {
 
   let { headers, ...rest } = opts;
 
+  if (url.startsWith(baseURL)) {
+    url = url.substring(baseURL.length);
+  }
+  
   let res;
   try {
     res = await fetch(`${baseURL}${url}`, {

--- a/frontend/src/api/utils.js
+++ b/frontend/src/api/utils.js
@@ -78,10 +78,3 @@ export function createURL(endpoint, params = {}, auth = true) {
 
   return url.toString();
 }
-
-export function removeTusEndpoint(tusEndpoint, url) {
-  if (url.startsWith(tusEndpoint)) {
-    return url.substring(tusEndpoint.length);
-  }
-  return url;
-}

--- a/frontend/src/api/utils.js
+++ b/frontend/src/api/utils.js
@@ -8,7 +8,6 @@ export async function fetchURL(url, opts, auth = true) {
   opts.headers = opts.headers || {};
 
   let { headers, ...rest } = opts;
-  
   let res;
   try {
     res = await fetch(`${baseURL}${url}`, {

--- a/frontend/src/api/utils.js
+++ b/frontend/src/api/utils.js
@@ -8,10 +8,6 @@ export async function fetchURL(url, opts, auth = true) {
   opts.headers = opts.headers || {};
 
   let { headers, ...rest } = opts;
-
-  if (url.startsWith(baseURL)) {
-    url = url.substring(baseURL.length);
-  }
   
   let res;
   try {

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -17,7 +17,7 @@ const resizePreview = window.FileBrowser.ResizePreview;
 const enableExec = window.FileBrowser.EnableExec;
 const tusSettings = window.FileBrowser.TusSettings;
 const origin = window.location.origin;
-const tusEndpoint = `${baseURL}/api/tus`;
+const tusEndpoint = `/api/tus`;
 
 export {
   name,


### PR DESCRIPTION
There is an issue where `${baseURL}` may be called twice when uploading through tus.

The scenario can be reproduced as follows:

1. Run `./filebrowser --baseUrl baseUrl`
2. When attempting to upload, a 404 error occurs as the POST request is invoked with `baseUrl/url/baseUrl/url`
3. However, there is no redundant call in the subsequent HEAD request

This seems to happen because, as the `const tusEndpoint` of `constants.js` is transferred to the `fetchURL` of `utils.js`, the predefined `baseURL` is added once more to the fetch

To resolve this, the `baseURL` is removed before calling `fetchURL` if it already exists.

For more details, please refer to the following issue. (#2581)
