### PR TITLE
fix: removed duplicate z-index

### DIFF
--- a/frontend/src/css/dashboard.css
+++ b/frontend/src/css/dashboard.css
@@ -175,7 +175,6 @@ table tr>*:last-child {
   max-width: 25em;
   width: 90%;
   max-height: 95%;
-  z-index: 99999;
   animation: .1s show forwards;
 }
 


### PR DESCRIPTION
**Description**
This is a very simple change.
Removed the redundant usage of z-index in .card.floating.
Thank you!