### PR TITLE
build: add riscv64 binary releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,7 @@ build:
     - 386
     - arm
     - arm64
+    - riscv64
   goarm:
     - 5
     - 6


### PR DESCRIPTION
**Description**
<!--
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.
-->

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
GoReleaser generally supports `riscv64` and the build went well on my repo: https://github.com/MichaIng/filebrowser/actions/runs/5718238916/job/15494436890

We could add RISC-V Docker image builds as well, but I'd need to have a closer look into the workflow for this. `buildx` however supports `riscv64` as well.