### PR TITLE
Fix config init for `branding.disableUsedPercentage`

### DIFF
--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -37,7 +37,7 @@ override the options.`,
 			Branding: settings.Branding{
 				Name:                  mustGetString(flags, "branding.name"),
 				DisableExternal:       mustGetBool(flags, "branding.disableExternal"),
-				DisableUsedPercentage: mustGetBool(flags, "branding.DisableUsedPercentage"),
+				DisableUsedPercentage: mustGetBool(flags, "branding.disableUsedPercentage"),
 				Files:                 mustGetString(flags, "branding.files"),
 			},
 		}


### PR DESCRIPTION


**Description**
Since #2136, running `filebrowser config init` shows an error due to case-sensitive typo in `config_init.go`.

This PR fixes #2576.  

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.
