### PR TITLE
fix: 403 error error when uploading

### DIFF
--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -40,7 +40,7 @@ func tusPostHandler() handleFunc {
 			return errToStatus(err), err
 		}
 
-		fileFlags := os.O_CREATE
+		fileFlags := os.O_CREATE | os.O_WRONLY
 		if r.URL.Query().Get("override") == "true" {
 			fileFlags |= os.O_TRUNC
 		}


### PR DESCRIPTION
**Description**
After version 2.24.0, 403 error occurs when file replacement is performed during tus based upload.
to solve this, I added **os.O_WRONLY** to fileFlags.
thank you!