### PR TITLE
feat: Implement abort upload functionality

### DIFF
--- a/frontend/src/components/prompts/UploadFiles.vue
+++ b/frontend/src/components/prompts/UploadFiles.vue
@@ -7,7 +7,14 @@
     <div class="card floating">
       <div class="card-title">
         <h2>{{ $t("prompts.uploadFiles", { files: filesInUploadCount }) }}</h2>
-
+        <button
+          class="action"
+          @click="abortAll"
+          aria-label="Abort upload"
+          title="Abort upload"
+        >
+        <i class="material-icons">{{ "cancel" }}</i>
+        </button>
         <button
           class="action"
           @click="toggle"
@@ -42,7 +49,9 @@
 </template>
 
 <script>
-import { mapGetters } from "vuex";
+import { mapGetters, mapMutations } from "vuex";
+import { abortAllUploads } from "@/api/tus";
+import buttons from "@/utils/buttons";
 
 export default {
   name: "uploadFiles",
@@ -53,10 +62,20 @@ export default {
   },
   computed: {
     ...mapGetters(["filesInUpload", "filesInUploadCount"]),
+    ...mapMutations(['resetUpload']),
   },
   methods: {
     toggle: function () {
       this.open = !this.open;
+    },
+    abortAll() {
+      if (confirm('Are you sure you want to abort?')) {
+        abortAllUploads();
+        buttons.done('upload');
+        this.open = false;
+        this.$store.commit('resetUpload');
+        this.$store.commit("setReload", true);
+      }
     },
   },
 };

--- a/frontend/src/components/prompts/UploadFiles.vue
+++ b/frontend/src/components/prompts/UploadFiles.vue
@@ -69,7 +69,7 @@ export default {
       this.open = !this.open;
     },
     abortAll() {
-      if (confirm('Are you sure you want to abort?')) {
+      if (confirm(this.$t('upload.abortUpload'))) {
         abortAllUploads();
         buttons.done('upload');
         this.open = false;

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -45,6 +45,9 @@
     "downloadFolder": "Download Folder",
     "downloadSelected": "Download Selected"
   },
+  "upload": {
+    "abortUpload": "Are you sure you want to abort?"
+  },
   "errors": {
     "forbidden": "You don't have permissions to access this.",
     "internal": "Something really went wrong.",

--- a/frontend/src/store/getters.js
+++ b/frontend/src/store/getters.js
@@ -4,7 +4,7 @@ const getters = {
   isListing: (state, getters) => getters.isFiles && state.req.isDir,
   selectedCount: (state) => state.selected.length,
   progress: (state) => {
-    if (state.upload.progress.length == 0) {
+    if (state.upload.progress.length === 0) {
       return 0;
     }
 
@@ -14,9 +14,7 @@ const getters = {
     return Math.ceil((sum / totalSize) * 100);
   },
   filesInUploadCount: (state) => {
-    let total =
-      Object.keys(state.upload.uploads).length + state.upload.queue.length;
-    return total;
+    return Object.keys(state.upload.uploads).length + state.upload.queue.length;
   },
   filesInUpload: (state) => {
     let files = [];

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -97,6 +97,13 @@ const mutations = {
     state.clipboard.key = "";
     state.clipboard.items = [];
   },
+  resetUpload(state) {
+    state.upload.uploads = {};
+    state.upload.queue = [];
+    state.upload.progress = [];
+    state.upload.sizes = [];
+    state.upload.id = 0;
+  },
 };
 
 export default mutations;


### PR DESCRIPTION
Unfortunately, until now, there was no way to abort uploads in filebrowser. The only option was to refresh the browser.
To address this, I've implemented the abortUpload feature.
When uploading directories or multiple files, most files tend to complete their transfer very quickly, so the option to abort a single file was not considered. This feature is primarily focused on aborting and resetting all ongoing uploads.

![image](https://github.com/filebrowser/filebrowser/assets/8551020/76da84ca-f0fe-41c6-9d28-19e0d1f98c8c)
![image](https://github.com/filebrowser/filebrowser/assets/8551020/b888412c-2a49-4f88-b4b6-85b0b254b591)

