### PR TITLE
fix: Refactor path resolution logic for project root

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -14,10 +14,15 @@ const plugins = [
   compression({ include: /\.js$/i, deleteOriginalAssets: true }),
 ];
 
+function getProjectRoot() {
+  const currentFile = new URL(import.meta.url).pathname;
+  return currentFile.substring(0, currentFile.lastIndexOf("/")) + "/";
+}
+
 const resolve = {
   alias: {
     vue: "vue/dist/vue.esm.js",
-    "@/": fileURLToPath(new URL("./src/", import.meta.url)),
+    "@/": getProjectRoot() + "src/",
   },
 };
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,5 +1,5 @@
 import { fileURLToPath, URL } from "node:url";
-
+import path from "node:path";
 import { defineConfig } from "vite";
 import legacy from "@vitejs/plugin-legacy";
 import vue2 from "@vitejs/plugin-vue2";
@@ -14,15 +14,10 @@ const plugins = [
   compression({ include: /\.js$/i, deleteOriginalAssets: true }),
 ];
 
-function getProjectRoot() {
-  const currentFile = new URL(import.meta.url).pathname;
-  return currentFile.substring(0, currentFile.lastIndexOf("/")) + "/";
-}
-
 const resolve = {
   alias: {
     vue: "vue/dist/vue.esm.js",
-    "@/": getProjectRoot() + "src/",
+    "@/": `${path.resolve(__dirname, "src")}/`,
   },
 };
 


### PR DESCRIPTION
With the introduction of Vite in filebrowser, there have been incidents where debug, serve, and build became inoperable. Considering that there were no issues in the git action, it seems likely that this issue can occur under certain circumstances.

My development environment is node v18.16.1 on Windows, but I encounter the problem as shown in the attached screenshot.
I've made a few changes to address this. Please review.

![image](https://github.com/filebrowser/filebrowser/assets/8551020/6a802af9-5367-4ac0-9013-e2d291ed9665)
