### PR TITLE
feat(login): separate error messages for login validation

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -122,7 +122,8 @@
     "submit": "Login",
     "username": "Username",
     "usernameTaken": "Username already taken",
-    "wrongCredentials": "Wrong credentials"
+    "wrongCredentials": "Wrong credentials",
+    "captchaNeeded": "Captcha Needed"
   },
   "permanent": "Permanent",
   "prompts": {

--- a/frontend/src/i18n/ja.json
+++ b/frontend/src/i18n/ja.json
@@ -96,7 +96,7 @@
     "ru": "Русский",
     "sk": "Slovenčina",
     "svSE": "",
-    "tr" : "Türkçe",
+    "tr": "Türkçe",
     "ua": "Українська",
     "zhCN": "中文 (简体)",
     "zhTW": "中文 (繁體)"
@@ -111,7 +111,8 @@
     "submit": "ログイン",
     "username": "ユーザ名",
     "usernameTaken": "Username already taken",
-    "wrongCredentials": "ユーザ名またはパスワードが間違っています。"
+    "wrongCredentials": "ユーザ名またはパスワードが間違っています。",
+    "captchaNeeded": "キャプチャが必要です"
   },
   "permanent": "永久",
   "prompts": {

--- a/frontend/src/i18n/zh-cn.json
+++ b/frontend/src/i18n/zh-cn.json
@@ -117,7 +117,8 @@
     "submit": "登录",
     "username": "用户名",
     "usernameTaken": "用户名已经被使用",
-    "wrongCredentials": "用户名或密码错误"
+    "wrongCredentials": "用户名或密码错误",
+    "captchaNeeded": "需要验证"
   },
   "permanent": "永久",
   "prompts": {

--- a/frontend/src/i18n/zh-tw.json
+++ b/frontend/src/i18n/zh-tw.json
@@ -96,7 +96,7 @@
     "ru": "Русский",
     "sk": "Slovenčina",
     "svSE": "Swedish（Sweden）",
-    "tr" : "Türkçe",
+    "tr": "Türkçe",
     "ua": "Українська",
     "zhCN": "中文 (简体)",
     "zhTW": "中文 (繁體)"
@@ -111,7 +111,8 @@
     "submit": "登入",
     "username": "帳號",
     "usernameTaken": "用戶名已存在",
-    "wrongCredentials": "帳號或密碼錯誤"
+    "wrongCredentials": "帳號或密碼錯誤",
+    "captchaNeeded": "需要驗證碼"
   },
   "permanent": "永久",
   "prompts": {

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -97,7 +97,7 @@ export default {
         captcha = window.grecaptcha.getResponse();
 
         if (captcha === "") {
-          this.error = this.$t("login.wrongCredentials");
+          this.error = this.$t("login.captchaNeeded");
           return;
         }
       }


### PR DESCRIPTION
**Description**
<!--
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.
-->
This commit separates the error messages for credential and captcha validation on the login page. Previously, both types of errors displayed the same message, which was confusing for users. Now, distinct messages are shown depending on the error, improving user experience.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [ ] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
