### PR TITLE
fix: before and after hook on upload event (Fixs #2721 #2626 #2600)

### DIFF
--- a/frontend/src/api/files.js
+++ b/frontend/src/api/files.js
@@ -91,6 +91,7 @@ export async function post(url, content = "", overwrite = false, onupload) {
   return useResourcesApi
     ? postResources(url, content, overwrite, onupload)
     : postTus(url, content, overwrite, onupload);
+
 }
 
 async function postResources(url, content = "", overwrite = false, onupload) {
@@ -161,6 +162,11 @@ export function copy(items, overwrite = false, rename = false) {
 export async function checksum(url, algo) {
   const data = await resourceAction(`${url}?checksum=${algo}`, "GET");
   return (await data.json()).checksums[algo];
+}
+
+export async function runHook(url) {
+  const data = await resourceAction(`${url}?runhookafter=true`, "GET");
+  return await data.json();
 }
 
 export function getDownloadURL(file, inline) {

--- a/frontend/src/store/modules/upload.js
+++ b/frontend/src/store/modules/upload.js
@@ -60,7 +60,9 @@ const actions = {
     context.commit("addJob", item);
     context.dispatch("processUploads");
   },
-  finishUpload: (context, item) => {
+  finishUpload: async (context, item) => {
+    await api.runHook(item.path).catch(Vue.prototype.$showError);
+
     context.commit("setProgress", { id: item.id, loaded: item.file.size });
     context.commit("removeJob", item.id);
     context.dispatch("processUploads");

--- a/http/resource.go
+++ b/http/resource.go
@@ -38,6 +38,16 @@ var resourceGetHandler = withUser(func(w http.ResponseWriter, r *http.Request, d
 		file.Listing.ApplySort()
 		return renderJSON(w, r, file)
 	}
+	if runhookafter := r.URL.Query().Get("runhookafter"); runhookafter != "" {
+		err := d.RunHookAfter(func() error {
+			return nil
+		}, "upload", r.URL.Path, "", d.user)
+		if err != nil {
+			return http.StatusInternalServerError, err
+		}
+		// do not waste bandwidth if we just want the run hook
+		file.Content = ""
+	}
 
 	if checksum := r.URL.Query().Get("checksum"); checksum != "" {
 		err := file.Checksum(checksum)

--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -59,7 +59,12 @@ func tusPostHandler() handleFunc {
 		if err := openFile.Close(); err != nil {
 			return errToStatus(err), err
 		}
-
+		err = d.RunHookBefore(func() error {
+			return nil
+		}, "upload", r.URL.Path, "", d.user)
+		if err != nil {
+			return errToStatus(err), err
+		}
 		return http.StatusCreated, nil
 	})
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -17,6 +17,39 @@ type Runner struct {
 	*settings.Settings
 }
 
+func (r *Runner) RunHookBefore(fn func() error, evt, path, dst string, user *users.User) error {
+	path = user.FullPath(path)
+	dst = user.FullPath(dst)
+
+	if r.Enabled {
+		if val, ok := r.Commands["before_"+evt]; ok {
+			for _, command := range val {
+				err := r.exec(command, "before_"+evt, path, dst, user)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+func (r *Runner) RunHookAfter(fn func() error, evt, path, dst string, user *users.User) error {
+	path = user.FullPath(path)
+	dst = user.FullPath(dst)
+	if r.Enabled {
+		if val, ok := r.Commands["after_"+evt]; ok {
+			for _, command := range val {
+				err := r.exec(command, "after_"+evt, path, dst, user)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 // RunHook runs the hooks for the before and after event.
 func (r *Runner) RunHook(fn func() error, evt, path, dst string, user *users.User) error {
 	path = user.FullPath(path)


### PR DESCRIPTION
From 2.24.0 upload changes to tus.io, but the hooks do not be implemented.
There is a request before upload start, but I've not found how to know the upload finished in backend, therefore I implement it in frontend.