### PR TITLE
Display filesize as base 2 (KiB instead of KB) (Fixes #2744)

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -37,7 +37,7 @@
 <script>
 import { enableThumbs } from "@/utils/constants";
 import { mapMutations, mapGetters, mapState } from "vuex";
-import { filesize } from "filesize";
+import { filesize } from "@/utils";
 import moment from "moment";
 import { files as api } from "@/api";
 import * as upload from "@/utils/upload";

--- a/frontend/src/components/prompts/Info.vue
+++ b/frontend/src/components/prompts/Info.vue
@@ -81,7 +81,7 @@
 
 <script>
 import { mapState, mapGetters } from "vuex";
-import { filesize } from "filesize";
+import { filesize } from "@/utils";
 import moment from "moment";
 import { files as api } from "@/api";
 
@@ -142,7 +142,7 @@ export default {
       try {
         const hash = await api.checksum(link, algo);
         // eslint-disable-next-line
-        event.target.innerHTML = hash
+        event.target.innerHTML = hash;
       } catch (e) {
         this.$showError(e);
       }

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -1,0 +1,6 @@
+import { partial } from "filesize";
+
+/**
+ * Formats filesize as KiB/MiB/...
+ */
+export const filesize = partial({ base: 2 });

--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -182,7 +182,7 @@
 <script>
 import { mapState, mapMutations, mapGetters } from "vuex";
 import { pub as api } from "@/api";
-import { filesize } from "filesize";
+import { filesize } from "@/utils";
 import moment from "moment";
 
 import HeaderBar from "@/components/header/HeaderBar.vue";


### PR DESCRIPTION
Backport from vue3 branch to display filesizes as KiB/MiB etc.
(Fixes #2744)

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.
