### PR TITLE
fix: To avoid the front-end calling api/renew loop, set the 'X-Renew-Token' header to false

### DIFF
--- a/http/auth.go
+++ b/http/auth.go
@@ -173,6 +173,7 @@ var signupHandler = func(w http.ResponseWriter, r *http.Request, d *data) (int, 
 }
 
 var renewHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	w.Header().Set("X-Renew-Token", "false")
 	return printToken(w, r, d, d.user)
 })
 


### PR DESCRIPTION
fix: To avoid the front-end calling api/renew loop, set the 'X-Renew-Token' header to false

**Description**

front-end calling api/renew loop, cause of the api/renew api return 'X-Renew-Token' is true.


:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->

To solved this issue #2113 