### PR TITLE
fix: Follow `$FB_PORT` when set

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-PORT=$(jq .port /.filebrowser.json)
+PORT=${FB_PORT:-$(jq .port /.filebrowser.json)}
 curl -f http://localhost:$PORT/health || exit 1


### PR DESCRIPTION
When the `FB_PORT` environment variable is set, respect its value. Otherwise, pick the port from the configuration.

**Description**
<!--
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.
-->

When run as a Docker container, the healthcheck will fail if the server port is set using the `FB_PORT` environment variable. This provides a fix by respecting the value of that variable in the healthcheck implementation, otherwise defaulting to the one from the configuration file.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [ ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
