### PR TITLE
Feature: Display Image Resolutions in File Details

### DIFF
--- a/files/file.go
+++ b/files/file.go
@@ -278,6 +278,7 @@ func (i *FileInfo) detectType(modify, saveContent, readHeader bool) error {
 }
 
 func calculateImageResolution(fs afero.Fs, filePath string) (*ImageResolution, error) {
+	file, err := fs.Open(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/files/file.go
+++ b/files/file.go
@@ -6,7 +6,9 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
+	"github.com/spf13/afero"
 	"hash"
+	"image"
 	"io"
 	"log"
 	"mime"
@@ -16,8 +18,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/spf13/afero"
 
 	"github.com/filebrowser/filebrowser/v2/errors"
 	"github.com/filebrowser/filebrowser/v2/rules"
@@ -44,6 +44,7 @@ type FileInfo struct {
 	Checksums  map[string]string `json:"checksums,omitempty"`
 	Token      string            `json:"token,omitempty"`
 	currentDir []os.FileInfo     `json:"-"`
+	Resolution *ImageResolution  `json:"resolution,omitempty"`
 }
 
 // FileOptions are the options when getting a file info.
@@ -56,6 +57,11 @@ type FileOptions struct {
 	Token      string
 	Checker    rules.Checker
 	Content    bool
+}
+
+type ImageResolution struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
 }
 
 // NewFileInfo creates a File object from a path and a given user. This File
@@ -234,8 +240,14 @@ func (i *FileInfo) detectType(modify, saveContent, readHeader bool) error {
 	case strings.HasPrefix(mimetype, "audio"):
 		i.Type = "audio"
 		return nil
-	case strings.HasPrefix(mimetype, "image"):
+	case strings.HasPrefix(mimetype, "image"), strings.HasPrefix(mimetype, "video"):
 		i.Type = "image"
+		resolution, err := calculateImageResolution(i.Fs, i.Path)
+		if err != nil {
+			log.Printf("Error calculating image resolution: %v", err)
+		} else {
+			i.Resolution = resolution
+		}
 		return nil
 	case strings.HasSuffix(mimetype, "pdf"):
 		i.Type = "pdf"
@@ -262,6 +274,29 @@ func (i *FileInfo) detectType(modify, saveContent, readHeader bool) error {
 	}
 
 	return nil
+}
+
+func calculateImageResolution(fs afero.Fs, path string) (*ImageResolution, error) {
+	file, err := fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func(file afero.File) {
+		err := file.Close()
+		if err != nil {
+
+		}
+	}(file)
+
+	config, _, err := image.DecodeConfig(file)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ImageResolution{
+		Width:  config.Width,
+		Height: config.Height,
+	}, nil
 }
 
 func (i *FileInfo) readFirstBytes() []byte {
@@ -359,6 +394,15 @@ func (i *FileInfo) readListing(checker rules.Checker, readHeader bool) error {
 			Extension:  filepath.Ext(name),
 			Path:       fPath,
 			currentDir: dir,
+		}
+
+		if !file.IsDir && strings.HasPrefix(mime.TypeByExtension(file.Extension), "image/") {
+			resolution, err := calculateImageResolution(file.Fs, file.Path)
+			if err != nil {
+				log.Printf("Error calculating resolution for image %s: %v", file.Path, err)
+			} else {
+				file.Resolution = resolution
+			}
 		}
 
 		if file.IsDir {

--- a/files/file.go
+++ b/files/file.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
-	"github.com/spf13/afero"
 	"hash"
 	"image"
 	"io"
@@ -18,6 +17,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/spf13/afero"
 
 	"github.com/filebrowser/filebrowser/v2/errors"
 	"github.com/filebrowser/filebrowser/v2/rules"
@@ -276,8 +277,7 @@ func (i *FileInfo) detectType(modify, saveContent, readHeader bool) error {
 	return nil
 }
 
-func calculateImageResolution(fs afero.Fs, filepath string) (*ImageResolution, error) {
-	file, err := fs.Open(filepath)
+func calculateImageResolution(fs afero.Fs, filePath string) (*ImageResolution, error) {
 	if err != nil {
 		return nil, err
 	}

--- a/files/file.go
+++ b/files/file.go
@@ -276,8 +276,8 @@ func (i *FileInfo) detectType(modify, saveContent, readHeader bool) error {
 	return nil
 }
 
-func calculateImageResolution(fs afero.Fs, path string) (*ImageResolution, error) {
-	file, err := fs.Open(path)
+func calculateImageResolution(fs afero.Fs, filepath string) (*ImageResolution, error) {
+	file, err := fs.Open(filepath)
 	if err != nil {
 		return nil, err
 	}

--- a/files/file.go
+++ b/files/file.go
@@ -240,7 +240,7 @@ func (i *FileInfo) detectType(modify, saveContent, readHeader bool) error {
 	case strings.HasPrefix(mimetype, "audio"):
 		i.Type = "audio"
 		return nil
-	case strings.HasPrefix(mimetype, "image"), strings.HasPrefix(mimetype, "video"):
+	case strings.HasPrefix(mimetype, "image"):
 		i.Type = "image"
 		resolution, err := calculateImageResolution(i.Fs, i.Path)
 		if err != nil {
@@ -281,12 +281,11 @@ func calculateImageResolution(fs afero.Fs, path string) (*ImageResolution, error
 	if err != nil {
 		return nil, err
 	}
-	defer func(file afero.File) {
-		err := file.Close()
-		if err != nil {
-
+	defer func() {
+		if cErr := file.Close(); cErr != nil {
+			log.Printf("Failed to close file: %v", cErr)
 		}
-	}(file)
+	}()
 
 	config, _, err := image.DecodeConfig(file)
 	if err != nil {

--- a/frontend/src/components/prompts/Info.vue
+++ b/frontend/src/components/prompts/Info.vue
@@ -12,10 +12,17 @@
       <p class="break-word" v-if="selected.length < 2">
         <strong>{{ $t("prompts.displayName") }}</strong> {{ name }}
       </p>
+
       <p v-if="!dir || selected.length > 1">
         <strong>{{ $t("prompts.size") }}:</strong>
         <span id="content_length"></span> {{ humanSize }}
       </p>
+
+      <div v-if="resolution">
+        <strong>{{ $t("prompts.resolution") }}:</strong>
+        {{ resolution.width }} x {{ resolution.height }}
+      </div>
+
       <p v-if="selected.length < 2" :title="modTime">
         <strong>{{ $t("prompts.lastModified") }}:</strong> {{ humanTime }}
       </p>
@@ -125,6 +132,18 @@ export default {
           ? this.req.isDir
           : this.req.items[this.selected[0]].isDir)
       );
+    },
+    resolution: function() {
+      if (this.selectedCount === 1) {
+        const selectedItem = this.req.items[this.selected[0]];
+        if (selectedItem && selectedItem.type === 'image') {
+          return selectedItem.resolution;
+        }
+      }
+      else if (this.req && this.req.type === 'image') {
+        return this.req.resolution;
+      }
+      return null;
     },
   },
   methods: {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -161,7 +161,8 @@
     "upload": "Upload",
     "uploadFiles": "Uploading {files} files...",
     "uploadMessage": "Select an option to upload.",
-    "optionalPassword": "Optional password"
+    "optionalPassword": "Optional password",
+    "resolution": "Resolution"
   },
   "search": {
     "images": "Images",


### PR DESCRIPTION
![image](https://github.com/filebrowser/filebrowser/assets/8551020/8a07a430-785c-4a15-8ddd-770c6042a168)

After a long hiatus, I'm excited to submit this pull request. One inconvenience we've often faced is the inability to view the resolution of image files. To address this, I've implemented a feature that allows users to see the resolution of image files when they check the file details. 

The supported extensions include:
> jpg, jpeg, gif, bmp, png, tif, tiff, webp

Unfortunately, this feature does not extend to video files. Determining the resolution of video files would require the FFmpeg library. Rather than making this decision unilaterally, I believe it's best to seek consensus from project committers and the community before proceeding with such an implementation. However, I'm fully prepared to develop this functionality should there be a demand for it.

I hope this simple yet useful feature enhancement will benefit many users.
Looking forward to your feedback and suggestions.
Thank you!