### PR TITLE
bug: docker - fix for linuxserver baseimage build.

### DIFF
--- a/docker/root/etc/cont-init.d/20-config
+++ b/docker/root/etc/cont-init.d/20-config
@@ -1,15 +1,17 @@
 #!/usr/bin/with-contenv bash
 
-# make folders
-mkdir -p /database
-
 # copy config
 if [ ! -f "/config/settings.json" ]; then
   cp -a /defaults/settings.json /config/settings.json
 fi
 
+# check if db exists
+if [ ! -f "/database/filebrowser.db" ]; then
+  touch "/database/filebrowser.db"
+fi
+
 # permissions
-chown abc:abc \
-	/config/settings.json \
+chown -R "$PUID:$PGID" \
+	/config \
 	/database \
 	/srv


### PR DESCRIPTION
Fix permission error, and missing filebrowser.db.  
Should resolve https://github.com/filebrowser/filebrowser/issues/2217

**Description**
<!--
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.
-->

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [ ] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
The readme would have to be updated, as you want to mount the directories instead of the files.  
This seems to be the overall default nowaday, and seems to be the reason most people fail at deploying this.  
Current way of deploying require a few extra manual steps, the files will have to exist before running the docker commands (neither checks in 20-config will have any effect), as it will create directories with the same name should the files not exist.
```yaml
docker run \
    -v /path/to/root:/srv \
    -v /path/to/database:/database \
    -v /path/to/config:/config \
    -e PUID=$(id -u) \
    -e PGID=$(id -g) \
    -p 8080:80 \
    filebrowser/filebrowser:s6
```

I've built and tested this using binaries from your latest release, and the [Dockerfile.s6](https://github.com/filebrowser/filebrowser/blob/master/Dockerfile.s6)