### PR TITLE
fix: delete message when delete file from preview

### DIFF
--- a/frontend/src/components/prompts/Delete.vue
+++ b/frontend/src/components/prompts/Delete.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="card floating">
     <div class="card-content">
-      <p v-if="selectedCount === 1">
+      <p v-if="!this.isListing || selectedCount === 1">
         {{ $t("prompts.deleteMessageSingle") }}
       </p>
       <p v-else>


### PR DESCRIPTION
**Description**
(see https://github.com/filebrowser/filebrowser/issues/2860)

When you delete a file from the preview, the variable `selectedCount` (from the vuex store) is `0` because the file is not "selected" but only "opened in preview",

A preview will always be of a single file, therefore the message should always be of a single deletion (`deleteMessageSingle`).
I used `this.isListing` as used later in the file to determine whether it is a single or multiple deletion:
https://github.com/filebrowser/filebrowser/blob/master/frontend/src/components/prompts/Delete.vue#L49

I'd love for you to merge the fix, or if you have a suggestion for an alternative implementation I'd love to hear it.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
