### PR TITLE
feat: allow setting theme via cli

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -42,6 +42,7 @@ func addConfigFlags(flags *pflag.FlagSet) {
 	flags.String("recaptcha.secret", "", "ReCaptcha secret")
 
 	flags.String("branding.name", "", "replace 'File Browser' by this name")
+	flags.String("branding.theme", "", "set the theme")
 	flags.String("branding.color", "", "set the theme color")
 	flags.String("branding.files", "", "path to directory with images and custom styles")
 	flags.Bool("branding.disableExternal", false, "disable external links such as GitHub links")
@@ -150,6 +151,7 @@ func printSettings(ser *settings.Server, set *settings.Settings, auther auth.Aut
 	fmt.Fprintf(w, "\tDisable external links:\t%t\n", set.Branding.DisableExternal)
 	fmt.Fprintf(w, "\tDisable used disk percentage graph:\t%t\n", set.Branding.DisableUsedPercentage)
 	fmt.Fprintf(w, "\tColor:\t%s\n", set.Branding.Color)
+	fmt.Fprintf(w, "\tTheme:\t%s\n", set.Branding.Theme)
 	fmt.Fprintln(w, "\nServer:")
 	fmt.Fprintf(w, "\tLog:\t%s\n", ser.Log)
 	fmt.Fprintf(w, "\tPort:\t%s\n", ser.Port)

--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -38,6 +38,7 @@ override the options.`,
 				Name:                  mustGetString(flags, "branding.name"),
 				DisableExternal:       mustGetBool(flags, "branding.disableExternal"),
 				DisableUsedPercentage: mustGetBool(flags, "branding.disableUsedPercentage"),
+				Theme:                 mustGetString(flags, "branding.theme"),
 				Files:                 mustGetString(flags, "branding.files"),
 			},
 		}

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -53,6 +53,8 @@ you want to change. Other options will remain unchanged.`,
 				set.Branding.Name = mustGetString(flags, flag.Name)
 			case "branding.color":
 				set.Branding.Color = mustGetString(flags, flag.Name)
+			case "branding.theme":
+				set.Branding.Theme = mustGetString(flags, flag.Name)
 			case "branding.disableExternal":
 				set.Branding.DisableExternal = mustGetBool(flags, flag.Name)
 			case "branding.disableUsedPercentage":


### PR DESCRIPTION
Adds the option of setting the theme via the CLI. For example:

```
filebrowser config set --branding.theme dark
```

Added to option both `config init` and `config set`. It's also printed alongside the other settings when they are shown as the output of `config set`.

- ref: https://github.com/filebrowser/filebrowser/issues/1711