### PR TITLE
feat: request logging

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,6 +70,8 @@ func addServerFlags(flags *pflag.FlagSet) {
 	flags.Bool("disable-preview-resize", false, "disable resize of image previews")
 	flags.Bool("disable-exec", false, "disables Command Runner feature")
 	flags.Bool("disable-type-detection-by-header", false, "disables type detection by reading file headers")
+	flags.Bool("enable-request-log", false, "enable logging all the request")
+	flags.String("request-log-format", "%{user_name} %{ip} %{method} %{path} %{response_size}", "logging format for the request")
 }
 
 var rootCmd = &cobra.Command{
@@ -261,6 +263,12 @@ func getRunParams(flags *pflag.FlagSet, st *storage.Storage) *settings.Server {
 
 	_, disableExec := getParamB(flags, "disable-exec")
 	server.EnableExec = !disableExec
+
+	_, enableRequestLog := getParamB(flags, "enable-request-log")
+	server.EnableRequestLog = enableRequestLog
+
+	requestLogFormat := getParam(flags, "request-log-format")
+	server.RequestLogFormat = requestLogFormat
 
 	if val, set := getParamB(flags, "token-expiration-time"); set {
 		server.TokenExpirationTime = val

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,6 +72,7 @@ func addServerFlags(flags *pflag.FlagSet) {
 	flags.Bool("disable-type-detection-by-header", false, "disables type detection by reading file headers")
 	flags.Bool("enable-request-log", false, "enable logging all the request")
 	flags.String("request-log-format", "%{user_name} %{ip} %{method} %{path} %{response_size}", "logging format for the request")
+	flags.String("request-log-output", "system", "destination for request logs, available options: system (golang logging), file://path/to/log.txt (local file), udp://host:port (syslog server by UDP), tcp://host:port (syslog server by TCP). By default: system.")
 }
 
 var rootCmd = &cobra.Command{
@@ -269,6 +270,9 @@ func getRunParams(flags *pflag.FlagSet, st *storage.Storage) *settings.Server {
 
 	requestLogFormat := getParam(flags, "request-log-format")
 	server.RequestLogFormat = requestLogFormat
+
+	requestLogOutput := getParam(flags, "request-log-output")
+	server.RequestLogOutput = requestLogOutput
 
 	if val, set := getParamB(flags, "token-expiration-time"); set {
 		server.TokenExpirationTime = val

--- a/http/http.go
+++ b/http/http.go
@@ -39,11 +39,11 @@ func NewHandler(
 	r = r.SkipClean(true)
 
 	monkey := func(fn handleFunc, prefix string) http.Handler {
-		return handle(fn, prefix, store, server)
+		return handle(RequestLogHandleFunc(fn, server), prefix, store, server)
 	}
 
-	r.HandleFunc("/health", healthHandler)
-	r.PathPrefix("/static").Handler(static)
+	r.HandleFunc("/health", RequestLogHandlerFunc(healthHandler, server))
+	r.PathPrefix("/static").Handler(RequestLogHandler(static, server))
 	r.NotFoundHandler = index
 
 	api := r.PathPrefix("/api").Subrouter()

--- a/http/http.go
+++ b/http/http.go
@@ -44,7 +44,7 @@ func NewHandler(
 
 	r.HandleFunc("/health", RequestLogHandlerFunc(healthHandler, server))
 	r.PathPrefix("/static").Handler(RequestLogHandler(static, server))
-	r.NotFoundHandler = index
+	r.NotFoundHandler = RequestLogHandler(index, server)
 
 	api := r.PathPrefix("/api").Subrouter()
 

--- a/http/log_writer.go
+++ b/http/log_writer.go
@@ -1,0 +1,99 @@
+package http
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	LOG_TYPE_SYSTEM     = "system"
+	LOG_TYPE_FILE       = "file"
+	LOG_TYPE_SYSLOG_UDP = "syslog-udp"
+	LOG_TYPE_SYSLOG_TCP = "syslog-tcp"
+)
+
+type LogWriter struct {
+	Type         string
+	Uri          string
+	syslogWriter *SyslogWriter
+	fileWriter   *os.File
+}
+
+func (w *LogWriter) Connect() bool {
+	if w.Type == LOG_TYPE_SYSTEM {
+		return true
+	}
+	if w.Type == LOG_TYPE_FILE && w.fileWriter != nil {
+		return true
+	}
+	if (w.Type == LOG_TYPE_SYSLOG_TCP || w.Type == LOG_TYPE_SYSLOG_UDP) && w.syslogWriter != nil {
+		return true
+	}
+	if w.Type == LOG_TYPE_FILE {
+		w.fileWriter = _openFile(w.Uri)
+	} else if w.Type == LOG_TYPE_SYSLOG_UDP {
+		w.syslogWriter = MakeSyslogWriter("udp", w.Uri)
+	} else if w.Type == LOG_TYPE_SYSLOG_TCP {
+		w.syslogWriter = MakeSyslogWriter("tcp", w.Uri)
+	}
+	return w.syslogWriter != nil || w.fileWriter != nil
+}
+
+func _openFile(path string) *os.File {
+	d := filepath.Dir(path)
+	err := os.MkdirAll(d, 0644)
+	if err != nil {
+		log.Println("ERROR: fail to create dir " + d)
+		return nil
+	}
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		log.Println("ERROR: fail to open file " + path)
+		log.Println(err)
+		return nil
+	}
+	return file
+}
+
+func (w *LogWriter) Write(msg string) {
+	if w.Type == LOG_TYPE_SYSTEM {
+		log.Println(msg)
+	} else if w.Type == LOG_TYPE_FILE {
+		if w.Connect() {
+			w.fileWriter.Write([]byte(msg + "\n"))
+		}
+	} else if w.Type == LOG_TYPE_SYSLOG_TCP || w.Type == LOG_TYPE_SYSLOG_UDP {
+		if w.Connect() {
+			w.syslogWriter.Write(msg)
+		}
+	} else {
+		log.Println("Unsupported request log output type " + w.Type)
+	}
+}
+
+func MakeLogWriter(output string) *LogWriter {
+	if output == LOG_TYPE_SYSTEM {
+		return &LogWriter{Type: LOG_TYPE_SYSTEM}
+	} else if strings.HasPrefix(output, "udp://") {
+		return &LogWriter{Type: LOG_TYPE_SYSLOG_UDP, Uri: output[6:]}
+	} else if strings.HasPrefix(output, "tcp://") {
+		return &LogWriter{Type: LOG_TYPE_SYSLOG_TCP, Uri: output[6:]}
+	} else if strings.HasPrefix(output, "file://") {
+		return &LogWriter{Type: LOG_TYPE_FILE, Uri: output[7:]}
+	}
+	log.Fatal("Unsupported log output: " + output)
+	return &LogWriter{}
+}
+
+func (w *LogWriter) Close() {
+	if w.fileWriter != nil {
+		w.fileWriter.Close()
+		w.fileWriter = nil
+	}
+	if w.syslogWriter != nil {
+		w.syslogWriter.Close()
+		w.syslogWriter = nil
+	}
+}

--- a/http/request_log.go
+++ b/http/request_log.go
@@ -125,6 +125,14 @@ func (h *myHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.f(w, r)
 }
 
+func _getHeader(r *http.Request, name string) string {
+	v := r.Header.Get(name)
+	if v == "" {
+		return "-"
+	}
+	return v
+}
+
 func _log(writer *ResponseWriterWrapper, r *http.Request, user *users.User, server *settings.Server) {
 	log_ := RequestLog{
 		user:          user,
@@ -134,8 +142,8 @@ func _log(writer *ResponseWriterWrapper, r *http.Request, user *users.User, serv
 		ip:            realip.FromRequest(r),
 		time:          writer.GetTime(),
 		request_size:  getRequestSize(r),
-		origin:        r.Header.Get("Origin"),
-		referer:       r.Header.Get("Referer"),
+		origin:        _getHeader(r, "Origin"),
+		referer:       _getHeader(r, "Referer"),
 		path:          r.RequestURI,
 		method:        r.Method,
 	}

--- a/http/request_log.go
+++ b/http/request_log.go
@@ -21,6 +21,8 @@ type RequestLog struct {
 	method        string
 	status        int
 	elapsed       float64
+	referer       string
+	origin        string
 }
 
 func (r *RequestLog) user_name() string {
@@ -58,6 +60,8 @@ func LogRequest(w http.ResponseWriter, r *http.Request, format string, log_ Requ
 	if log_.response_size == 0 {
 		log_.response_size = parseSize(w.Header().Get("Content-Length"))
 	}
+	log_.origin = r.Header.Get("Origin")
+	log_.referer = r.Header.Get("Referer")
 	log_.path = r.URL.Path
 	log_.method = r.Method
 	log.Println(formatLog(format, log_))
@@ -76,6 +80,8 @@ func LogRequest(w http.ResponseWriter, r *http.Request, format string, log_ Requ
 //	%{method}
 //	%{status}
 //	%{elapsed}
+//	%{referer}
+//	%{origin}
 func formatLog(format string, log RequestLog) string {
 	format = strings.ReplaceAll(format, "%{user_name}", log.user_name())
 	format = strings.ReplaceAll(format, "%{user_id}", log.user_id())
@@ -88,6 +94,8 @@ func formatLog(format string, log RequestLog) string {
 	format = strings.ReplaceAll(format, "%{method}", log.method)
 	format = strings.ReplaceAll(format, "%{status}", int2string(log.status))
 	format = strings.ReplaceAll(format, "%{elapsed}", float2string(log.elapsed))
+	format = strings.ReplaceAll(format, "%{referer}", log.referer)
+	format = strings.ReplaceAll(format, "%{origin}", log.origin)
 	return format
 }
 

--- a/http/request_log.go
+++ b/http/request_log.go
@@ -162,7 +162,7 @@ func RequestLogHandleFunc(handle handleFunc, server *settings.Server) handleFunc
 		writer := MakeResponseWriterWrapper(w)
 		status, err := handle(writer, r, d)
 		writer.status.set(status)
-		_log(writer, r, nil, server)
+		_log(writer, r, d.user, server)
 		return status, err
 	}
 }

--- a/http/request_log.go
+++ b/http/request_log.go
@@ -43,9 +43,12 @@ func (r *RequestLog) user_id() string {
 
 func (r *RequestLog) user_scope() string {
 	if r.user != nil {
+		if r.user.Scope == "" {
+			return "."
+		}
 		return r.user.Scope
 	}
-	return "."
+	return "-"
 }
 
 func (r *RequestLog) time_string() string {

--- a/http/request_log.go
+++ b/http/request_log.go
@@ -3,7 +3,10 @@ package http
 import (
 	"fmt"
 	"log"
+	"log/syslog"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -12,6 +15,78 @@ import (
 	"github.com/filebrowser/filebrowser/v2/users"
 	"github.com/tomasen/realip"
 )
+
+type LogWriter struct {
+	Type         string
+	Uri          string
+	syslogWriter *syslog.Writer
+	fileWriter   *os.File
+}
+
+var globalLogWriter *LogWriter = nil
+
+func _syslogConnect(type_ string, host string) *syslog.Writer {
+	writer, err := syslog.Dial(type_, host, syslog.LOG_EMERG|syslog.LOG_SYSLOG, "filebrowser")
+	if err != nil {
+		log.Printf("ERROR: fail to connect to the syslog-%s server: %s", type_, host)
+		log.Println(err)
+		return nil
+	} else {
+		return writer
+	}
+}
+
+func (w *LogWriter) Connect() bool {
+	if w.Type == "system" {
+		return true
+	}
+	if w.Type == "file" && w.fileWriter != nil {
+		return true
+	}
+	if (w.Type == "syslog-tcp" || w.Type == "syslog-udp") && w.syslogWriter != nil {
+		return true
+	}
+	if w.Type == "file" {
+		w.fileWriter = _openFile(w.Uri)
+	} else if w.Type == "syslog-udp" {
+		w.syslogWriter = _syslogConnect("udp", w.Uri)
+	} else if w.Type == "syslog-tcp" {
+		w.syslogWriter = _syslogConnect("tcp", w.Uri)
+	}
+	return w.syslogWriter != nil || w.fileWriter != nil
+}
+
+func _openFile(path string) *os.File {
+	d := filepath.Dir(path)
+	err := os.MkdirAll(d, 0644)
+	if err != nil {
+		log.Println("ERROR: fail to create dir " + d)
+		return nil
+	}
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		log.Println("ERROR: fail to open file " + path)
+		log.Println(err)
+		return nil
+	}
+	return file
+}
+
+func (w *LogWriter) Write(msg string) {
+	if w.Type == "system" {
+		log.Println(msg)
+	} else if w.Type == "file" {
+		if w.Connect() {
+			w.fileWriter.Write([]byte(msg + "\n"))
+		}
+	} else if w.Type == "syslog-udp" || w.Type == "syslog-tcp" {
+		if w.Connect() {
+			w.syslogWriter.Emerg(msg)
+		}
+	} else {
+		log.Println("Unsupported request log output type " + w.Type)
+	}
+}
 
 type RequestLog struct {
 	user          *users.User
@@ -115,6 +190,34 @@ func (h *myHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.f(w, r)
 }
 
+func _logToOutput(msg string, writer *LogWriter) {
+	if writer != nil {
+		writer.Write(msg)
+	}
+}
+
+func _getLogWriter(output string) *LogWriter {
+	if output == "system" {
+		return &LogWriter{Type: "system"}
+	} else if strings.HasPrefix(output, "udp://") {
+		return &LogWriter{Type: "syslog-udp", Uri: output[6:]}
+	} else if strings.HasPrefix(output, "tcp://") {
+		return &LogWriter{Type: "syslog-tcp", Uri: output[6:]}
+	} else if strings.HasPrefix(output, "file://") {
+		return &LogWriter{Type: "file", Uri: output[7:]}
+	}
+	log.Fatal("Unsupported log output: " + output)
+	return &LogWriter{}
+}
+
+func _globalLogWriter(output string) *LogWriter {
+	if globalLogWriter == nil {
+		globalLogWriter = _getLogWriter(output)
+	}
+	return globalLogWriter
+
+}
+
 func _log(writer *ResponseWriterWrapper, r *http.Request, user *users.User, server *settings.Server) {
 	log_ := RequestLog{
 		user:          user,
@@ -129,7 +232,10 @@ func _log(writer *ResponseWriterWrapper, r *http.Request, user *users.User, serv
 		path:          r.RequestURI,
 		method:        r.Method,
 	}
-	log.Println(formatLog(server.RequestLogFormat, log_))
+	if log_.status == 0 {
+		log_.status = 200
+	}
+	_globalLogWriter(server.RequestLogOutput).Write(formatLog(server.RequestLogFormat, log_))
 }
 
 func RequestLogHandlerFunc(handler http.HandlerFunc, server *settings.Server) http.HandlerFunc {

--- a/http/request_log.go
+++ b/http/request_log.go
@@ -1,0 +1,129 @@
+package http
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/filebrowser/filebrowser/v2/users"
+)
+
+type RequestLog struct {
+	user          *users.User
+	ip            string
+	time          time.Time
+	request_size  int64
+	response_size int64
+	path          string
+	method        string
+	status        int
+	elapsed       float64
+}
+
+func (r *RequestLog) user_name() string {
+	if r.user != nil {
+		return r.user.Username
+	}
+	return "-"
+}
+
+func (r *RequestLog) user_id() string {
+	if r.user != nil {
+		return fmt.Sprintf("%d", r.user.ID)
+	}
+	return "-"
+}
+
+func (r *RequestLog) user_scope() string {
+	if r.user != nil {
+		return r.user.Scope
+	}
+	return "."
+}
+
+func (r *RequestLog) time_string() string {
+	return r.time.Format(time.RFC3339)
+}
+
+func LogRequest(w http.ResponseWriter, r *http.Request, format string, log_ RequestLog) {
+	if log_.status == 0 {
+		log_.status = 200
+	}
+	log_.ip = getRealIp(r)
+	log_.time = time.Now()
+	log_.request_size = r.ContentLength
+	if log_.response_size == 0 {
+		log_.response_size = parseSize(w.Header().Get("Content-Length"))
+	}
+	log_.path = r.URL.Path
+	log_.method = r.Method
+	log.Println(formatLog(format, log_))
+}
+
+// support placeholders:
+//
+//	%{user_name}
+//	%{user_id}
+//	%{user_scope}
+//	%{ip}
+//	%{time}
+//	%{request_size}
+//	%{response_size}: 0 for Transfer-Encoding=chunked
+//	%{path}
+//	%{method}
+//	%{status}
+//	%{elapsed}
+func formatLog(format string, log RequestLog) string {
+	format = strings.ReplaceAll(format, "%{user_name}", log.user_name())
+	format = strings.ReplaceAll(format, "%{user_id}", log.user_id())
+	format = strings.ReplaceAll(format, "%{user_scope}", log.user_scope())
+	format = strings.ReplaceAll(format, "%{ip}", log.ip)
+	format = strings.ReplaceAll(format, "%{time}", log.time_string())
+	format = strings.ReplaceAll(format, "%{request_size}", int2string(log.request_size))
+	format = strings.ReplaceAll(format, "%{response_size}", int2string(log.response_size))
+	format = strings.ReplaceAll(format, "%{path}", log.path)
+	format = strings.ReplaceAll(format, "%{method}", log.method)
+	format = strings.ReplaceAll(format, "%{status}", int2string(log.status))
+	format = strings.ReplaceAll(format, "%{elapsed}", float2string(log.elapsed))
+	return format
+}
+
+func getRealIp(r *http.Request) string {
+	remoteAddr := r.RemoteAddr
+	forwardedFor := parseFirstItem(r.Header.Get("X-Forwarded-For"))
+	realIp := parseFirstItem(r.Header.Get("X-Real-IP"))
+	if forwardedFor != "" {
+		return forwardedFor
+	}
+	if realIp != "" {
+		return realIp
+	}
+	return remoteAddr
+}
+
+func parseFirstItem(s string) string {
+	items := strings.Split(s, ",")
+	if len(items) == 0 {
+		return ""
+	}
+	return items[0]
+}
+
+func parseSize(d string) int64 {
+	val, err := strconv.ParseInt(d, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return val
+}
+
+func int2string(val any) string {
+	return fmt.Sprintf("%d", val)
+}
+
+func float2string(val float64) string {
+	return fmt.Sprintf("%f", val)
+}

--- a/http/response_writer_wrapper.go
+++ b/http/response_writer_wrapper.go
@@ -1,0 +1,66 @@
+package http
+
+import (
+	"net/http"
+)
+
+type _size struct {
+	value uint64
+}
+
+func (s *_size) get() uint64 {
+	return s.value
+}
+func (s *_size) set(v uint64) {
+	s.value = v
+}
+func (s *_size) add(v uint64) {
+	s.value += v
+}
+
+type _status struct {
+	value int
+}
+
+func (s *_status) get() int {
+	return s.value
+}
+func (s *_status) set(v int) {
+	s.value = v
+}
+
+type ResponseWriterWrapper struct {
+	writer http.ResponseWriter
+	size   *_size
+	status *_status
+}
+
+func MakeResponseWriterWrapper(w http.ResponseWriter) *ResponseWriterWrapper {
+	return &ResponseWriterWrapper{
+		writer: w,
+		size:   &_size{value: 0},
+		status: &_status{value: 0},
+	}
+}
+
+func (r *ResponseWriterWrapper) Write(data []byte) (int, error) {
+	r.size.add(uint64(len(data)))
+	return r.writer.Write(data)
+}
+
+func (r *ResponseWriterWrapper) Header() http.Header {
+	return r.writer.Header()
+}
+
+func (r *ResponseWriterWrapper) WriteHeader(statusCode int) {
+	r.status.set(statusCode)
+	r.writer.WriteHeader(statusCode)
+}
+
+func (r *ResponseWriterWrapper) GetSize() uint64 {
+	return r.size.get()
+}
+
+func (r *ResponseWriterWrapper) GetStatus() int {
+	return r.status.get()
+}

--- a/http/response_writer_wrapper.go
+++ b/http/response_writer_wrapper.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"net/http"
+	"time"
 )
 
 type _size struct {
@@ -33,13 +34,15 @@ type ResponseWriterWrapper struct {
 	writer http.ResponseWriter
 	size   *_size
 	status *_status
+	time   time.Time
 }
 
 func MakeResponseWriterWrapper(w http.ResponseWriter) *ResponseWriterWrapper {
 	return &ResponseWriterWrapper{
 		writer: w,
 		size:   &_size{value: 0},
-		status: &_status{value: 0},
+		status: &_status{value: 200},
+		time:   time.Now(),
 	}
 }
 
@@ -61,6 +64,14 @@ func (r *ResponseWriterWrapper) GetSize() uint64 {
 	return r.size.get()
 }
 
+func (r *ResponseWriterWrapper) GetTime() time.Time {
+	return r.time
+}
+
 func (r *ResponseWriterWrapper) GetStatus() int {
 	return r.status.get()
+}
+
+func (r *ResponseWriterWrapper) GetElapsed() float64 {
+	return time.Now().Sub(r.time).Seconds()
 }

--- a/http/syslog_writer.go
+++ b/http/syslog_writer.go
@@ -1,0 +1,50 @@
+package http
+
+import (
+	"log"
+	"log/syslog"
+)
+
+type SyslogWriter struct {
+	Type   string
+	Host   string
+	Writer *syslog.Writer
+}
+
+func MakeSyslogWriter(type_ string, host string) *SyslogWriter {
+	return &SyslogWriter{
+		Type:   type_,
+		Host:   host,
+		Writer: nil,
+	}
+}
+
+func (w *SyslogWriter) Write(msg string) {
+	if w.Writer == nil {
+		w.Writer = syslogConnect(w.Type, w.Host)
+	}
+	if w.Writer != nil {
+		err := w.Writer.Emerg(msg)
+		if err != nil {
+			log.Println("ERROR: fail to write syslog")
+		}
+	}
+}
+
+func syslogConnect(type_ string, host string) *syslog.Writer {
+	writer, err := syslog.Dial(type_, host, syslog.LOG_EMERG|syslog.LOG_KERN, "filebrowser")
+	if err != nil {
+		log.Printf("ERROR: fail to connect to the syslog-%s server: %s", type_, host)
+		log.Println(err)
+		return nil
+	} else {
+		return writer
+	}
+}
+
+func (w *SyslogWriter) Close() {
+	if w.Writer != nil {
+		w.Writer.Close()
+		w.Writer = nil
+	}
+}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -52,6 +52,7 @@ type Server struct {
 	TokenExpirationTime   string `json:"tokenExpirationTime"`
 	EnableRequestLog      bool   `json:"enableRequestLog"`
 	RequestLogFormat      string `json:"requestLogFormat"`
+	RequestLogOutput      string `json:"requestLogOutput"`
 }
 
 // Clean cleans any variables that might need cleaning.

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -50,6 +50,8 @@ type Server struct {
 	TypeDetectionByHeader bool   `json:"typeDetectionByHeader"`
 	AuthHook              string `json:"authHook"`
 	TokenExpirationTime   string `json:"tokenExpirationTime"`
+	EnableRequestLog      bool   `json:"enableRequestLog"`
+	RequestLogFormat      string `json:"requestLogFormat"`
 }
 
 // Clean cleans any variables that might need cleaning.


### PR DESCRIPTION
**Description**
Logging for every request with template and syslog support. The user name/id in log are also supported.

**Usage**

```bash
filebrowser --enable-request-log --request-log-format="%{user_name} %{ip} %{response_size} %{elapsed}"
filebrowser --enable-request-log --request-log-output=file://out.log
filebrowser --enable-request-log --request-log-output=udp://127.0.0.1:514
```

Supported placeholders

```
//	%{user_name}
//	%{user_id}
//	%{user_scope}
//	%{ip}
//	%{time}
//	%{request_size}
//	%{response_size}
//	%{path}
//	%{method}
//	%{status}
//	%{elapsed}
//      %{origin}
//      %{referer}
```

**Caveat**

  * `%{user_name}`: not work for public resources
  * ''udp://'' and ''tcp://'' are just socket messages, not compliant with any syslog standard.