### PR TITLE
fix: typo in zh-cn.json causes build error #2903

### DIFF
--- a/frontend/src/i18n/zh-cn.json
+++ b/frontend/src/i18n/zh-cn.json
@@ -37,7 +37,7 @@
     "toggleSidebar": "切换侧边栏",
     "update": "更新",
     "upload": "上传",
-    "openFile": "打开文件"
+    "openFile": "打开文件",
     "continue": "继续"
   },
   "download": {
@@ -161,7 +161,7 @@
     "upload": "上传",
     "uploadFiles": "正在上传 {files} ...",
     "uploadMessage": "选择上传选项。",
-    "optionalPassword": "密码（选填，不填即无密码）"
+    "optionalPassword": "密码（选填，不填即无密码）",
     "resolution": "分辨率"
   },
   "search": {


### PR DESCRIPTION
**Description**

Fixed typo in zh-cn.json causing error in frontend build 

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.
