### PR TITLE
feat: Add a script to quickly generate branding images

### DIFF
--- a/scripts/branding-from-svg.sh
+++ b/scripts/branding-from-svg.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+svg_input="$1"
+destination_folder="${2:-.}"
+
+if [ -z "$svg_input" ]; then
+  echo "Usage: $0 <input_svg_file> [destination_folder]"
+  echo "Converts an SVG input to various image formats and sizes based on a predefined list."
+  exit 1
+fi
+
+if [ ! -d "$destination_folder" ]; then
+  echo "Destination folder does not exist. Creating: $destination_folder"
+  mkdir -p "$destination_folder"
+fi
+
+entries=(
+  "android-chrome-192x192.png"
+  "android-chrome-512x512.png"
+  "apple-touch-icon.png"
+  "favicon-16x16.png"
+  "favicon-32x32.png"
+  "favicon.ico"
+  "mstile-144x144.png"
+  "mstile-150x150.png"
+  "mstile-310x150.png"
+  "mstile-310x310.png"
+  "mstile-70x70.png"
+  "safari-pinned-tab.svg"
+)
+
+for entry in "${entries[@]}"; do
+  name="${entry%.*}"
+  extension="${entry##*.}"
+  output="$destination_folder/${name}_output.${extension}"
+
+  # Convert SVG to specified dimensions and format
+  case "$extension" in
+    "png")
+      convert -background none -resize "${name: -4}"x"${name: -4}" "$svg_input" "$output"
+      ;;
+    "ico")
+      convert "$svg_input" -bordercolor white -border 0 -alpha off "$output"
+      ;;
+    "svg")
+      # SVGs don't need conversion, just copy
+      cp "$svg_input" "$output"
+      ;;
+    *)
+      echo "Unsupported file format: $entry"
+      continue
+      ;;
+  esac
+
+  echo "Converted $svg_input to $output"
+done


### PR DESCRIPTION
**Description**
<!--
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.
-->

This pull request adds a simple script that uses ImageMagick to convert a SVG file to the formats and file names required for the custom branding feature.
The intention is to reduce friction for using the custom branding feature.

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [ x ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ x ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ x ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ x ] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [ x ] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->

I expect to add this to the docs eventually.
