### PR TITLE
fix(healthcheck): use address configured if not empty

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 PORT=${FB_PORT:-$(jq .port /.filebrowser.json)}
-curl -f http://localhost:$PORT/health || exit 1
+ADDRESS=${FB_ADDRESS:-$(jq .address /.filebrowser.json)}
+ADDRESS=${ADDRESS:-localhost}
+curl -f http://$ADDRESS:$PORT/health || exit 1


### PR DESCRIPTION
Problem is I have `FB_ADDRESS=10.0.0.28` (my internal bridged network), and the healthcheck always fail with `localhost`:

```sh
/ # curl -f http://localhost:80/health
curl: (7) Failed to connect to localhost port 80 after 0 ms: Couldn't connect to server
```

Changing `localhost` to the value of `$FB_ADDRESS` fixes it:

```sh
/ # curl -f http://10.0.0.28:80/health
{"status":"OK"}
```

The proposed changes pick the address using the following:

1. Use `$FB_ADDRESS` content if not empty;
2. Fallback on "address" value in /.filebrowser.json
3. Fallback on `localhost`


