### PR TITLE
fix: moment locale

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -38,7 +38,7 @@
 import { enableThumbs } from "@/utils/constants";
 import { mapMutations, mapGetters, mapState } from "vuex";
 import { filesize } from "@/utils";
-import moment from "moment";
+import moment from "moment/min/moment-with-locales";
 import { files as api } from "@/api";
 import * as upload from "@/utils/upload";
 

--- a/frontend/src/components/prompts/Info.vue
+++ b/frontend/src/components/prompts/Info.vue
@@ -89,7 +89,7 @@
 <script>
 import { mapState, mapGetters } from "vuex";
 import { filesize } from "@/utils";
-import moment from "moment";
+import moment from "moment/min/moment-with-locales";
 import { files as api } from "@/api";
 
 export default {

--- a/frontend/src/components/prompts/Share.vue
+++ b/frontend/src/components/prompts/Share.vue
@@ -128,7 +128,7 @@
 <script>
 import { mapState, mapGetters } from "vuex";
 import { share as api, pub as pub_api } from "@/api";
-import moment from "moment";
+import moment from "moment/min/moment-with-locales";
 import Clipboard from "clipboard";
 
 export default {

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -1,5 +1,5 @@
 import * as i18n from "@/i18n";
-import moment from "moment";
+import moment from "moment/min/moment-with-locales";
 
 const mutations = {
   closeHovers: (state) => {

--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -183,7 +183,7 @@
 import { mapState, mapMutations, mapGetters } from "vuex";
 import { pub as api } from "@/api";
 import { filesize } from "@/utils";
-import moment from "moment";
+import moment from "moment/min/moment-with-locales";
 
 import HeaderBar from "@/components/header/HeaderBar.vue";
 import Action from "@/components/header/Action.vue";

--- a/frontend/src/views/settings/Shares.vue
+++ b/frontend/src/views/settings/Shares.vue
@@ -63,7 +63,7 @@
 <script>
 import { share as api, users } from "@/api";
 import { mapState, mapMutations } from "vuex";
-import moment from "moment";
+import moment from "moment/min/moment-with-locales";
 import Clipboard from "clipboard";
 import Errors from "@/views/Errors.vue";
 


### PR DESCRIPTION
**Description**

Currently the localization of human time does not work (it is always displayed in English, even when the user's language is different)
So I just imported from moment-with-locale

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
