### PR TITLE
feat: allow cli to configure whether home directory is automatically created

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -31,6 +31,7 @@ func addConfigFlags(flags *pflag.FlagSet) {
 	addServerFlags(flags)
 	addUserFlags(flags)
 	flags.BoolP("signup", "s", false, "allow users to signup")
+	flags.Bool("create-user-dir", false, "generate user's home directory automatically")
 	flags.String("shell", "", "shell command to which other commands should be appended")
 
 	flags.String("auth.method", string(auth.MethodJSONAuth), "authentication type")

--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -29,11 +29,12 @@ override the options.`,
 		authMethod, auther := getAuthentication(flags)
 
 		s := &settings.Settings{
-			Key:        generateKey(),
-			Signup:     mustGetBool(flags, "signup"),
-			Shell:      convertCmdStrToCmdArray(mustGetString(flags, "shell")),
-			AuthMethod: authMethod,
-			Defaults:   defaults,
+			Key:           generateKey(),
+			Signup:        mustGetBool(flags, "signup"),
+			CreateUserDir: mustGetBool(flags, "create-user-dir"),
+			Shell:         convertCmdStrToCmdArray(mustGetString(flags, "shell")),
+			AuthMethod:    authMethod,
+			Defaults:      defaults,
 			Branding: settings.Branding{
 				Name:                  mustGetString(flags, "branding.name"),
 				DisableExternal:       mustGetBool(flags, "branding.disableExternal"),

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -49,6 +49,8 @@ you want to change. Other options will remain unchanged.`,
 				hasAuth = true
 			case "shell":
 				set.Shell = convertCmdStrToCmdArray(mustGetString(flags, flag.Name))
+			case "create-user-dir":
+				set.CreateUserDir = mustGetBool(flags, flag.Name)
 			case "branding.name":
 				set.Branding.Name = mustGetString(flags, flag.Name)
 			case "branding.color":


### PR DESCRIPTION
**Description**
It is now possible to configure via cli whether the home directory is automatically created or not.
I tested this with the following command:
```bash
./filebrowser config init --create-user-dir
./filebrowser config set --create-user-dir=false
```

:rotating_light: Before submitting your PR, please read [community](https://github.com/filebrowser/community), and indicate which issues (in any of the repos) are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] DO make sure that related issues are opened in other repositories. I.e., the frontend, caddy plugins or the web page need to be updated accordingly.
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
