### PR TITLE
fix: shell direction

### DIFF
--- a/frontend/src/components/Shell.vue
+++ b/frontend/src/components/Shell.vue
@@ -2,7 +2,7 @@
   <div
     class="shell"
     :class="{ ['shell--hidden']: !showShell }"
-    :style="{ height: `${this.shellHeight}em` }"
+    :style="{ height: `${this.shellHeight}em`, direction: 'ltr' }"
   >
     <div
       @pointerdown="startDrag()"


### PR DESCRIPTION
**Description**
shell works with English commands and therefore should be displayed from left to right (LTR) even when the user's language is RTL (this is also the case in the terminal of the various operating systems)

:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
