### PR TITLE
fix: editor discard prompt

### DIFF
--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -129,6 +129,7 @@ export default {
 
       try {
         await api.put(this.$route.path, this.editor.getValue());
+        this.editor.session.getUndoManager().markClean();
         buttons.success(button);
       } catch (e) {
         buttons.done(button);
@@ -136,9 +137,7 @@ export default {
       }
     },
     close() {
-      const originalContent = this.req.content;
-      const currentContent = this.editor.getValue();
-      if (originalContent !== currentContent) {
+      if (!this.editor.session.getUndoManager().isClean()) {
         this.$store.commit("showHover", "discardEditorChanges");
         return;
       }


### PR DESCRIPTION
**Description**
Currently the editor changes discard prompt is bugged and appears in the following two situations where it should not:
- when the file is empty, like right after its creation
- after the file has been saved

This PR aims to solve both issues.

:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.
