### PR TITLE
fix: change two default values

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func init() {
 }
 
 func addServerFlags(flags *pflag.FlagSet) {
-	flags.StringP("address", "a", "127.0.0.1", "address to listen on")
+	flags.StringP("address", "a", "0.0.0.0", "address to listen on")
 	flags.StringP("log", "l", "stdout", "log output")
 	flags.StringP("port", "p", "8080", "port to listen on")
 	flags.StringP("cert", "t", "", "tls certificate")
@@ -69,7 +69,7 @@ func addServerFlags(flags *pflag.FlagSet) {
 	flags.Bool("disable-thumbnails", false, "disable image thumbnails")
 	flags.Bool("disable-preview-resize", false, "disable resize of image previews")
 	flags.Bool("disable-exec", false, "disables Command Runner feature")
-	flags.Bool("disable-type-detection-by-header", false, "disables type detection by reading file headers")
+	flags.Bool("enable-type-detection-by-header", false, "enables type detection by reading file headers")
 }
 
 var rootCmd = &cobra.Command{
@@ -181,7 +181,11 @@ user created with the credentials from options "username" and "password".`,
 
 		defer listener.Close()
 
-		log.Println("Listening on", listener.Addr().String())
+		if strings.Contains(adr, "0.0.0.0") {
+			log.Println("Listening on localhost:" + server.Port)
+		} else {
+			log.Println("Listening on", listener.Addr().String())
+		}
 		//nolint: gosec
 		if err := http.Serve(listener, handler); err != nil {
 			log.Fatal(err)
@@ -256,8 +260,8 @@ func getRunParams(flags *pflag.FlagSet, st *storage.Storage) *settings.Server {
 	_, disablePreviewResize := getParamB(flags, "disable-preview-resize")
 	server.ResizePreview = !disablePreviewResize
 
-	_, disableTypeDetectionByHeader := getParamB(flags, "disable-type-detection-by-header")
-	server.TypeDetectionByHeader = !disableTypeDetectionByHeader
+	_, enableTypeDetectionByHeader := getParamB(flags, "enable-type-detection-by-header")
+	server.TypeDetectionByHeader = enableTypeDetectionByHeader
 
 	_, disableExec := getParamB(flags, "disable-exec")
 	server.EnableExec = !disableExec

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -87,16 +87,22 @@ func python(fn pythonFunc, cfg pythonConfig) cobraFunc {
 		data := pythonData{hadDB: true}
 
 		path := getParam(cmd.Flags(), "database")
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			panic(err)
+		}
 		exists, err := dbExists(path)
 
 		if err != nil {
 			panic(err)
 		} else if exists && cfg.noDB {
-			log.Fatal(path + " already exists")
+			log.Fatal(absPath + " already exists")
 		} else if !exists && !cfg.noDB && !cfg.allowNoDB {
-			log.Fatal(path + " does not exist. Please run 'filebrowser config init' first.")
+			log.Fatal(absPath + " does not exist. Please run 'filebrowser config init' first.")
+		} else if !exists && !cfg.noDB {
+			log.Println(absPath + " does not exist. initialing...")
 		}
-
+		log.Println("Using database: " + absPath )
 		data.hadDB = exists
 		db, err := storm.Open(path)
 		checkErr(err)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -102,7 +102,8 @@ func python(fn pythonFunc, cfg pythonConfig) cobraFunc {
 		} else if !exists && !cfg.noDB {
 			log.Println(absPath + " does not exist. initialing...")
 		}
-		log.Println("Using database: " + absPath )
+
+		log.Println("Using database: " + absPath)
 		data.hadDB = exists
 		db, err := storm.Open(path)
 		checkErr(err)


### PR DESCRIPTION
There are two default values that cause some problems and always confuse new users again and again, 
1. The default IP address is 127.0.0.1. This only allow users to visit from 127.0.0.1:8080 or localhost:8080. They can't visit from 192.168.1.x:8080 or from public website. #3008, #2584
So, I change this default IP address to 0.0.0.0. Then we can visit from 127.0.0.1:8080 or localhost:8080, or 192.168.1.x:8080, or public website.

2.  The default value of "--disable-type-detection-by-header" is "false". The users may take 30 seconds to wait for the showing of a list with thousands of files, and sometimes may get an error code, especially in low-end server. #1836, #1689, 
So, I change this to "--enable-type-detection-by-header" "false".  By default we don't need it to run filebrowser. 

And also, if a filebrowser.db does not exist in current cmd root folder, it will iniatial a new one automatically in this cmd root folder without warning. It may confuse the users and they may use a wrong database.  After the modification, the abs path of database will show in the cmd window.

![screenshot](https://github.com/filebrowser/filebrowser/assets/76441520/e93fb8cf-ca1b-4625-b468-cfb88b2905c9)
BTW, we use localhost instead of "0.0.0.0", because "0.0.0.0:8080" looks so weird, and can't be visited directly.

