### PR TITLE
Feat: auto hiding headerbar in preview to enlarge the preview window

### DIFF
--- a/frontend/src/css/mobile.css
+++ b/frontend/src/css/mobile.css
@@ -2,10 +2,6 @@
   nav {
     width: 10em
   }
-  /* Mobile Only fix div hidden by bottom navigation bar of mobile browser when using height: 100vh */
-  #previewer .preview {
-    height: calc(100% - 4em) !important;
-  }
 }
 
 @media (max-width: 1024px) {

--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -152,8 +152,7 @@ main .spinner .bounce2 {
 /* PREVIEWER */
 
 #previewer {
-  background-color: rgba(0, 0, 0, 0.99);
-  padding-top: 4em;
+  background-color: rgba(0, 0, 0, 0.9);
   position: fixed;
   top: 0;
   left: 0;
@@ -166,15 +165,25 @@ main .spinner .bounce2 {
 #previewer header {
   background: none;
   color: #fff;
+  border-bottom: 0px;
+  box-shadow: 0px 0px 0px;
+  z-index: 19999;
 }
 
 #previewer header > .action i {
   color: #fff;
+  text-shadow: 1px 1px 1px #000000;
+}
+
+#previewer header > title {
+  white-space: nowrap; 
+  text-shadow: 1px 1px 1px #000000;
 }
 
 @media (min-width: 738px) {
   #previewer header #dropdown .action i {
     color: #fff;
+  text-shadow: 1px 1px 1px #000000;
   }
 }
 
@@ -188,7 +197,7 @@ main .spinner .bounce2 {
 
 #previewer .preview {
   text-align: center;
-  height: calc(100vh - 4em);
+  height: 100%;
 }
 
 #previewer .preview pre {
@@ -202,6 +211,12 @@ main .spinner .bounce2 {
   max-height: 100%;
   margin: 0;
 }
+
+#previewer .preview audio {
+  width: 95%;
+  height: 88%;
+}
+
 
 #previewer .preview video {
   height: 100%;
@@ -247,7 +262,7 @@ main .spinner .bounce2 {
 #previewer > button {
   margin: 0;
   position: fixed;
-  top: calc(50% + 1.85em);
+  top: 50%;
   transform: translateY(-50%);
   background-color: rgba(80, 80, 80, 0.5);
   color: white;

--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -152,7 +152,7 @@ main .spinner .bounce2 {
 /* PREVIEWER */
 
 #previewer {
-  background-color: rgba(0, 0, 0, 0.9);
+  background-color: rgba(0, 0, 0, 0.99);
   position: fixed;
   top: 0;
   left: 0;

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -1,6 +1,8 @@
 <template>
   <div
     id="previewer"
+    @touchmove.prevent.stop 
+    @wheel.prevent.stop
     @mousemove="toggleNavigation"
     @touchstart="toggleNavigation"
   >

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -1,12 +1,10 @@
 <template>
   <div
     id="previewer"
-    @touchmove.prevent.stop 
-    @wheel.prevent.stop
     @mousemove="toggleNavigation"
     @touchstart="toggleNavigation"
   >
-    <header-bar>
+    <header-bar  v-if="showNav">
       <action icon="close" :label="$t('buttons.close')" @action="close()" />
       <title>{{ name }}</title>
       <action


### PR DESCRIPTION
In the preview, the headerbar is always on the screen. It makes the pic can't show in full screen of browser. I change it to a common way, auto hide the transparent headerbar with the left and right arrow. and enlarge the preview box to show pic, video.

before:
![pic1](https://github.com/filebrowser/filebrowser/assets/76441520/773a9608-f964-4275-b5a9-ec95b9c2edd2)

after:
![pic2](https://github.com/filebrowser/filebrowser/assets/76441520/7c103ee2-b53e-4912-b224-7a197d63bb0f)
