### PR TITLE
fix: changing the default IP address to 0.0.0.0 root.go

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func init() {
 }
 
 func addServerFlags(flags *pflag.FlagSet) {
-	flags.StringP("address", "a", "127.0.0.1", "address to listen on")
+	flags.StringP("address", "a", "0.0.0.0", "address to listen on")
 	flags.StringP("log", "l", "stdout", "log output")
 	flags.StringP("port", "p", "8080", "port to listen on")
 	flags.StringP("cert", "t", "", "tls certificate")
@@ -181,7 +181,11 @@ user created with the credentials from options "username" and "password".`,
 
 		defer listener.Close()
 
-		log.Println("Listening on", listener.Addr().String())
+		if strings.Contains(adr, "0.0.0.0") {
+			log.Println("Listening on 127.0.0.1:" + server.Port)
+		} else {
+			log.Println("Listening on", listener.Addr().String())
+		}
 		//nolint: gosec
 		if err := http.Serve(listener, handler); err != nil {
 			log.Fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -180,9 +180,8 @@ user created with the credentials from options "username" and "password".`,
 		checkErr(err)
 
 		defer listener.Close()
-
 		if strings.Contains(adr, "0.0.0.0") {
-			log.Println("Listening on 127.0.0.1:" + server.Port)
+			log.Println("Listening on 0.0.0.0:" + server.Port +". You can access the FileBrowser at 127.0.0.1:" + server.Port)
 		} else {
 			log.Println("Listening on", listener.Addr().String())
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -181,7 +181,7 @@ user created with the credentials from options "username" and "password".`,
 
 		defer listener.Close()
 		if strings.Contains(adr, "0.0.0.0") {
-			log.Println("Listening on 0.0.0.0:" + server.Port +". You can access the FileBrowser at 127.0.0.1:" + server.Port)
+			log.Println("Listening on 0.0.0.0:" + server.Port + ". You can access the FileBrowser at 127.0.0.1:" + server.Port)
 		} else {
 			log.Println("Listening on", listener.Addr().String())
 		}


### PR DESCRIPTION
This is an update to #3023

The default IP address is 127.0.0.1. It always cause some problems when new users running filebrowser. This "127.0.0.1" only allow users to visit from 127.0.0.1:8080 or localhost:8080. They can't visit from 192.168.1.x:8080 or from public website. https://github.com/filebrowser/filebrowser/issues/3008, https://github.com/filebrowser/filebrowser/issues/2584

So, I change this default IP address to 0.0.0.0. Then we can visit from 127.0.0.1:8080 or localhost:8080, or 192.168.1.x:8080, or public website.

Since 0.0.0.0:8080 is weird, and can't be visited directly. So in cmd window, we still show it as 127.0.0.1:8080. 