### PR TITLE
fix: show the current used filebrowser.db in cmd window

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -87,16 +87,23 @@ func python(fn pythonFunc, cfg pythonConfig) cobraFunc {
 		data := pythonData{hadDB: true}
 
 		path := getParam(cmd.Flags(), "database")
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			panic(err)
+		}
 		exists, err := dbExists(path)
 
 		if err != nil {
 			panic(err)
 		} else if exists && cfg.noDB {
-			log.Fatal(path + " already exists")
+			log.Fatal(absPath + " already exists")
 		} else if !exists && !cfg.noDB && !cfg.allowNoDB {
-			log.Fatal(path + " does not exist. Please run 'filebrowser config init' first.")
+			log.Fatal(absPath + " does not exist. Please run 'filebrowser config init' first.")
+		} else if !exists && !cfg.noDB {
+			log.Println(absPath + " does not exist. initialing...")
 		}
 
+		log.Println("Using database: " + absPath)
 		data.hadDB = exists
 		db, err := storm.Open(path)
 		checkErr(err)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -100,7 +100,7 @@ func python(fn pythonFunc, cfg pythonConfig) cobraFunc {
 		} else if !exists && !cfg.noDB && !cfg.allowNoDB {
 			log.Fatal(absPath + " does not exist. Please run 'filebrowser config init' first.")
 		} else if !exists && !cfg.noDB {
-			log.Println(absPath + " does not exist. initialing...")
+			log.Println("Warning: filebrowser.db can't be found. Initialing in " + strings.TrimRight(absPath, "filebrowser.db"))
 		}
 
 		log.Println("Using database: " + absPath)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -100,7 +100,7 @@ func python(fn pythonFunc, cfg pythonConfig) cobraFunc {
 		} else if !exists && !cfg.noDB && !cfg.allowNoDB {
 			log.Fatal(absPath + " does not exist. Please run 'filebrowser config init' first.")
 		} else if !exists && !cfg.noDB {
-			log.Println("Warning: filebrowser.db can't be found. Initialing in " + strings.TrimRight(absPath, "filebrowser.db"))
+			log.Println("Warning: filebrowser.db can't be found. Initialing in " + strings.TrimSuffix(absPath, "filebrowser.db"))
 		}
 
 		log.Println("Using database: " + absPath)


### PR DESCRIPTION
Filebrowser will initial a new filebrowser.db automatically **in the cmd root folder** **without warning** if the filebrowser.db can't be found. It may confuse the users and they may use a wrong database. After the modification,  it will show a warning , and the current used filebrowser.db with abs path will show in the cmd window.

![5](https://github.com/filebrowser/filebrowser/assets/76441520/d7bba55f-5d92-46bd-afb5-cbce62094544)

