### PR TITLE
Added ability to share folder for view rendering

### DIFF
--- a/frontend/src/api/share.js
+++ b/frontend/src/api/share.js
@@ -34,3 +34,6 @@ export async function create(url, password = "", expires = "", unit = "hours") {
 export function getShareURL(share) {
   return createURL("share/" + share.hash, {}, false);
 }
+export function getViewURL(share) {
+  return createURL("api/public/view/" + share.hash + "/index.html", {}, false);
+}

--- a/frontend/src/components/prompts/Share.vue
+++ b/frontend/src/components/prompts/Share.vue
@@ -32,7 +32,7 @@
                 <i class="material-icons">content_paste</i>
               </button>
             </td>
-            <td class="small">
+            <td class="small" v-if="!hasDownloadLink()">
               <button
                 class="action copy-clipboard"
                 :data-clipboard-text="buildViewLink(link)"

--- a/frontend/src/components/prompts/Share.vue
+++ b/frontend/src/components/prompts/Share.vue
@@ -32,6 +32,16 @@
                 <i class="material-icons">content_paste</i>
               </button>
             </td>
+            <td class="small">
+              <button
+                class="action copy-clipboard"
+                :data-clipboard-text="buildViewLink(link)"
+                :aria-label="$t('buttons.copyToClipboard')"
+                :title="$t('buttons.copyToClipboard')"
+              >
+                <i class="material-icons">content_paste_search</i>
+              </button>
+            </td>
             <td class="small" v-if="hasDownloadLink()">
               <button
                 class="action copy-clipboard"
@@ -224,6 +234,9 @@ export default {
     },
     buildLink(share) {
       return api.getShareURL(share);
+    },
+    buildViewLink(share) {
+      return api.getViewURL(share);
     },
     hasDownloadLink() {
       return (

--- a/http/http.go
+++ b/http/http.go
@@ -88,6 +88,7 @@ func NewHandler(
 
 	public := api.PathPrefix("/public").Subrouter()
 	public.PathPrefix("/dl").Handler(monkey(publicDlHandler, "/api/public/dl/")).Methods("GET")
+	public.PathPrefix("/view").Handler(monkey(publicViewHandler, "/api/public/view/")).Methods("GET")
 	public.PathPrefix("/share").Handler(monkey(publicShareHandler, "/api/public/share/")).Methods("GET")
 
 	return stripPrefix(server.BaseURL, r), nil

--- a/http/public.go
+++ b/http/public.go
@@ -115,6 +115,15 @@ var publicDlHandler = withHashFile(func(w http.ResponseWriter, r *http.Request, 
 	return rawDirHandler(w, r, d, file)
 })
 
+var publicViewHandler = withHashFile(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	file := d.raw.(*files.FileInfo)
+	if !file.IsDir {
+		return rawFileHandler(w, r, file, false)
+	}
+
+	return rawDirHandler(w, r, d, file, false)
+})
+
 func authenticateShareRequest(r *http.Request, l *share.Link) (int, error) {
 	if l.PasswordHash == "" {
 		return 0, nil


### PR DESCRIPTION
Myself and a number of issues have been raised requesting the ability to have html content that can be served and rendered instead of only downloaded.

This PR is starting that conversation and adds a functional but crude implementation of the designed feature

- A folder has a new share icon that allows for sharing a "view" folder. Any file in that folder is now viewable
- Adds new /view route to router to handle this. Simply removes the Content-Disposition header conditionally

A user could now share a directory that contains a HTML, Vue or React for website for example directly from within FileBrowser

**Current limitations**
- Only available directly on sharing a folder
- Share icon not added everywhere you might want to share a folder/file directly for rendering

Looking for feedback before completion.

