### PR TITLE
feat: Add open in new tab link

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -30,6 +30,10 @@
       <p class="modified">
         <time :datetime="modified">{{ humanTime() }}</time>
       </p>
+
+      <a class="" target=”_blank” @click="openInNewTab">
+        open in new tab
+      </a>
     </div>
   </div>
 </template>
@@ -248,6 +252,10 @@ export default {
     },
     open: function () {
       this.$router.push({ path: this.url });
+    },
+    openInNewTab: function () {
+      const routeUrl = this.$router.resolve({path: this.url});
+      window.open(routeUrl.href, '_blank');
     },
   },
 };


### PR DESCRIPTION
**Description**
For each file in the file list, add a link to open it in a new tab.
This is useful when you have a folder with a lot of files, as otherwise when hitting the back button, you may have to scroll the file list again.

My current code doesn't display a pretty button or anything, but it works for me. Would you open to integrate a feature like that?

:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).
- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build. / I ran `make test frontend`

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->

Screenshot of filebrowser serving itself with this PR:
<img width="669" alt="image" src="https://github.com/filebrowser/filebrowser/assets/975826/daa55af2-d8ed-4c3a-abdb-8edd92d9004d">

