### PR TITLE
feat: add a audio player function in shared folder

### DIFF
--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -29,7 +29,7 @@
     <breadcrumbs :base="'/share/' + hash" />
 
     <div v-if="loading">
-      <h2 class="message delayed" style="padding-top: 3em !important;">
+      <h2 class="message delayed" style="padding-top: 3em !important">
         <div class="spinner">
           <div class="bounce1"></div>
           <div class="bounce2"></div>
@@ -73,21 +73,26 @@
     </div>
     <div v-else>
       <div class="share">
-        <div class="share__box share__box__info"
+        <div
+          class="share__box share__box__info"
           style="
             position: -webkit-sticky;
             position: sticky;
-            top:-20.5em;
-            z-index:999;"
+            top: -20.5em;
+            z-index: 999;
+            "
         >
-          <div class="share__box__header" style="height:3em">
+          <div class="share__box__header" style="height: 3em">
             {{
               req.isDir
                 ? $t("download.downloadFolder")
                 : $t("download.downloadFile")
             }}
           </div>
-          <div v-if="!this.req.isDir" class="share__box__element share__box__center share__box__icon">
+          <div 
+            v-if="!this.req.isDir"
+            class="share__box__element share__box__center share__box__icon"
+          >
             <i class="material-icons">{{ icon }}</i>
           </div>
           <div class="share__box__element" style="height:3em">
@@ -180,7 +185,6 @@
 
       	      <audio id="myaudio"
       	        :src="raw"
-      	        controls="controls" 
                 :autoplay="tag"
 		controls @ended= "playEnd"
 		style="position: relative; bottom: 0"
@@ -373,7 +377,7 @@ export default {
     },
     switchMusic(switchX) {
       let i = this.req.items[this.selected[0]].index + switchX
-      while (true) {
+      while (i+2) {
       	if(switchX == -1 && i == -1) {
 	  i = this.req.items.length + switchX;
 	} else if (switchX == 1 && i == this.req.items.length) {

--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -163,7 +163,6 @@
                 justify-content: space-between;"
       	    >
               <p style="margin: 0.5em; height: 3em;">{{req.items[this.selected[0]].name}}</p>
-
               <div style="height:4em; width:100%; position:relative;">
                 <button @click="play" v-if="!this.tag" style="fontSize:4em !important; left:0; right:0; margin=auto; border:0px; background: white;" class="material-icons">play_circle_filled</button>
                 <button @click="play" v-if="this.tag"  style="fontSize:4em !important; left:0; right:0; margin=auto; border:0px; background: white;" class="material-icons">pause_circle_filled</button>
@@ -173,16 +172,12 @@
                 flex-direction: row;
                 justify-content: space-between;"
               >
-
                 <button @click="switchMusic(-1)" style="fontSize:2em !important;  border:0px; background: white;" class="material-icons">fast_rewind</button>
-
                 <button @click="switchLoopMode" v-if="this.loopMode == 'once'" style="fontSize:2em !important; border:0px;outline:none; background: white; " class="material-icons">skip_next</button>
                 <button @click="switchLoopMode" v-if="this.loopMode == 'singleLoop'" style="fontSize:2em !important; background: white;" class="material-icons">repeat_one</button>
                 <button @click="switchLoopMode" v-if="this.loopMode == 'listLoop'" style="fontSize:2em !important; background: white; " class="material-icons">repeat</button>
-
                 <button @click="switchMusic(1)" style="fontSize:2em !important; border:0px; background: white;" class="material-icons">fast_forward</button>
               </div>
-
       	      <audio id="myaudio"
       	        :src="raw"
                 :autoplay="tag"
@@ -238,7 +233,6 @@
             </item>
       
 
-
             <div
               :class="{ active: $store.state.multiple }"
               id="multiple-selection"
@@ -276,7 +270,6 @@ import { mapState, mapMutations, mapGetters } from "vuex";
 import { pub as api } from "@/api";
 import { filesize } from "@/utils";
 import moment from "moment/min/moment-with-locales";
-
 import HeaderBar from "@/components/header/HeaderBar.vue";
 import Action from "@/components/header/Action.vue";
 import Breadcrumbs from "@/components/Breadcrumbs.vue";
@@ -307,7 +300,6 @@ export default {
   }),
   watch: {
     $route: function () {
-
       this.fetchData();
     },
   },
@@ -402,13 +394,11 @@ export default {
       } else {
         this.loopMode = "once";
       }
-      console.log(this.loopMode);
     },
     playEnd() {
       if (this.loopMode == "singleLoop") document.getElementById('myaudio').play();
       if (this.loopMode == "listLoop") this.switchMusic(1);
     },
-    
     fetchData: async function () {
       // Reset view information.
       this.$store.commit("setReload", false);


### PR DESCRIPTION
I just find after closing the phone's screen, the music in html can still keep playing with the mp3 list. So I add this function in the shared folder.  Then not only the users but also the visitors can use filebrowser as an audio player. It's cool.

to play the current song one time, and click prev, next button to switch songs:
![11](https://github.com/filebrowser/filebrowser/assets/76441520/541e540c-97af-4ac2-8de1-42bef5e7f3db)


 to play the current song repeatly:
![22](https://github.com/filebrowser/filebrowser/assets/76441520/39fa9190-e515-41a1-9f99-6bf46b03c19f)


to play all the audio files in current folder repeatly:
![33](https://github.com/filebrowser/filebrowser/assets/76441520/57806792-d37b-49b4-b264-26afc0f75106)


