### PR TITLE
feat: remain in the same position when back from a subfolder

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -247,6 +247,10 @@ export default {
       this.addSelected(this.index);
     },
     open: function () {
+      window.sessionStorage.setItem(
+        this.$route.path,
+        JSON.stringify([document.documentElement.scrollTop, this.index])
+      );
       this.$router.push({ path: this.url });
     },
   },

--- a/frontend/src/components/prompts/Rename.vue
+++ b/frontend/src/components/prompts/Rename.vue
@@ -92,7 +92,7 @@ export default {
       try {
         await api.move([{ from: oldLink, to: newLink }]);
         if (!this.isListing) {
-          this.$router.push({ path: newLink });
+          this.$router.replace({ path: newLink });
           return;
         }
 

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <header-bar v-if="error || req.type == null" showMenu showLogo />
+    <header-bar v-if="error || req.type == undefined" showMenu showLogo />
 
     <breadcrumbs base="/files" />
     <listing />
@@ -47,6 +47,7 @@ export default {
     return {
       error: null,
       width: window.innerWidth,
+      parentDir: false,
     };
   },
   computed: {
@@ -69,25 +70,27 @@ export default {
   },
   watch: {
     $route: function (to, from) {
-      if (from.path.endsWith("/")) { 
-        if (to.path.endsWith("/"))   {
+      if (
+        to.path.endsWith("/") &&
+        from.path.startsWith(to.path) &&
+        from.path.length > to.path.length
+      ) {
+        this.parentDir = "true";
+      } else {
+        this.parentDir = "false";
+        window.sessionStorage.removeItem(to.path);
+      }
+      if (from.path.endsWith("/")) {
+        if (to.path.endsWith("/")) {
           window.sessionStorage.setItem("listFrozen", "false");
-          this.fetchData();
-          return;
         } else {
           window.sessionStorage.setItem("listFrozen", "true");
-          this.fetchData();
-          return;        
         }
       } else if (to.path.endsWith("/")) {
         this.$store.commit("updateRequest", {});
-        this.fetchData();
-        return;
-      } else {
-        this.fetchData();
-        return;
-      } 
-    }, 
+      }
+      this.fetchData();
+    },
     reload: function (value) {
       if (value === true) {
         this.fetchData();
@@ -116,7 +119,11 @@ export default {
       this.$store.commit("closeHovers");
 
       // Set loading to true and reset the error.
-      if (window.sessionStorage.getItem("listFrozen") !=="true" && window.sessionStorage.getItem("modified") !=="true"){ 
+      if (
+        window.sessionStorage.getItem("listFrozen") !== "true" &&
+        window.sessionStorage.getItem("modified") !== "true" &&
+        this.parentDir !== "true"
+      ) {
         this.setLoading(true);
       }
       this.error = null;

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -1,9 +1,5 @@
 <template>
-  <div 
-    id="editor-container"
-    @touchmove.prevent.stop 
-    @wheel.prevent.stop
-  >
+  <div id="editor-container" @touchmove.prevent.stop @wheel.prevent.stop>
     <header-bar>
       <action icon="close" :label="$t('buttons.close')" @action="close()" />
       <title>{{ req.name }}</title>
@@ -28,7 +24,6 @@ import { mapState } from "vuex";
 import { files as api } from "@/api";
 import { theme } from "@/utils/constants";
 import buttons from "@/utils/buttons";
-import url from "@/utils/url";
 
 import { version as ace_version } from "ace-builds";
 import ace from "ace-builds/src-min-noconflict/ace.js";
@@ -148,8 +143,7 @@ export default {
 
       this.$store.commit("updateRequest", {});
 
-      let uri = url.removeLastDir(this.$route.path) + "/";
-      this.$router.push({ path: uri });
+      history.back();
     },
   },
 };

--- a/frontend/src/views/files/Listing.vue
+++ b/frontend/src/views/files/Listing.vue
@@ -383,9 +383,12 @@ export default {
   },
   watch: {
     req: function () {
-      if (window.sessionStorage.getItem("listFrozen") !=="true" && window.sessionStorage.getItem("modified") !=="true"){
+      if (
+        window.sessionStorage.getItem("listFrozen") !== "true" &&
+        window.sessionStorage.getItem("modified") !== "true"
+      ) {
         // Reset the show value
-        this.showLimit = 50;
+        this.showLimit = this.req.numDirs + this.req.numFiles;
 
         // Ensures that the listing is displayed
         Vue.nextTick(() => {
@@ -394,11 +397,21 @@ export default {
 
           // Fill and fit the window with listing items
           this.fillWindow(true);
+          if (window.sessionStorage.getItem(this.$route.path)) {
+            document.documentElement.scrollTop = JSON.parse(
+              window.sessionStorage.getItem(this.$route.path)
+            )[0];
+            if (!this.isMobile)
+              this.addSelected(
+                JSON.parse(window.sessionStorage.getItem(this.$route.path))[1]
+              );
+            window.sessionStorage.removeItem(this.$route.path);
+          }
         });
       }
       if (this.req.isDir) {
         window.sessionStorage.setItem("listFrozen", "false");
-        window.sessionStorage.setItem("modified", "false"); 
+        window.sessionStorage.setItem("modified", "false");
       }
     },
   },
@@ -882,9 +895,13 @@ export default {
       const windowHeight = window.innerHeight;
 
       // Quantity of items needed to fill 2x of the window height
-      const showQuantity = Math.ceil(
-        (windowHeight + windowHeight * 2) / this.itemWeight
-      );
+      const showQuantity = window.sessionStorage.getItem(this.$route.path)
+        ? Math.ceil(
+            (JSON.parse(window.sessionStorage.getItem(this.$route.path))[0] +
+              windowHeight * 2) /
+              this.itemWeight
+          )
+        : Math.ceil((windowHeight + windowHeight * 2) / this.itemWeight);
 
       // Less items to display than current
       if (this.showLimit > showQuantity && !fit) return;

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -1,12 +1,12 @@
 <template>
   <div
     id="previewer"
-    @touchmove.prevent.stop 
+    @touchmove.prevent.stop
     @wheel.prevent.stop
     @mousemove="toggleNavigation"
     @touchstart="toggleNavigation"
   >
-    <header-bar  v-if="showNav">
+    <header-bar v-if="showNav">
       <action icon="close" :label="$t('buttons.close')" @action="close()" />
       <title>{{ name }}</title>
       <action
@@ -346,8 +346,7 @@ export default {
     close() {
       this.$store.commit("updateRequest", {});
 
-      let uri = url.removeLastDir(this.$route.path) + "/";
-      this.$router.push({ path: uri });
+      history.back();
     },
     download() {
       window.open(this.downloadUrl);


### PR DESCRIPTION
This is a update of #3052
When you return back from a subfolder, you will stay in the last position of the list. And the dir you entered before will be highlighted in PC. 
 

(I also formated the file using latest .eslintrc.json)

![23](https://github.com/filebrowser/filebrowser/assets/76441520/71722be9-19e5-4608-8a94-a8bdb6472dc5)

By the way, the commit message's format is so strict. The subject should start with fix:, and fix: can't be Fix:, and the subject should not end with a ".",  and the optional box should keep empty.  
Otherwise, we need to re-pull the whole request. 