### PR TITLE
Display Upload Progress as Percentage and File Size / Total File Size

### DIFF
--- a/frontend/src/api/tus.js
+++ b/frontend/src/api/tus.js
@@ -28,6 +28,8 @@ export async function upload(
   let resourcePath = `${tusEndpoint}${filePath}?override=${overwrite}`;
 
   await createUpload(resourcePath);
+  let uploadSize = content.size || 0; // Get the size of the content being uploaded
+  store.commit('setTotalFileSize', store.state.upload.totalFileSize + uploadSize);
 
   return new Promise((resolve, reject) => {
     let upload = new tus.Upload(content, {
@@ -181,6 +183,12 @@ function calcProgress(filePath) {
   store.commit("setUploadSpeed", speed);
   store.commit("setETA", eta);
   store.commit("setUploadPercentage", uploadPercentage);
+
+  let totalUploaded = 0;
+  for (let file in CURRENT_UPLOAD_LIST) {
+    totalUploaded += CURRENT_UPLOAD_LIST[file].currentBytesUploaded;
+  }
+  store.commit('setTotalUploadedSize', totalUploaded);
 
   fileData.initialBytesUploaded = fileData.currentBytesUploaded;
   fileData.lastProgressTimestamp = Date.now();

--- a/frontend/src/api/tus.js
+++ b/frontend/src/api/tus.js
@@ -135,7 +135,7 @@ function computeETA(state) {
   const remainingSize = totalSize - uploadedSize;
   const speedBytesPerSecond = state.speedMbyte * 1024 * 1024;
   const eta = remainingSize / speedBytesPerSecond;
-  const percentage = (uploadedSize / totalSize) * 100;
+  const uploadPercentage = (uploadedSize / totalSize) * 100;
 
   return { eta, uploadPercentage };
 }

--- a/frontend/src/api/tus.js
+++ b/frontend/src/api/tus.js
@@ -125,7 +125,7 @@ function isTusSupported() {
 
 function computeETA(state) {
   if (state.speedMbyte === 0) {
-    return { eta: Infinity, percentage: 0 };
+    return { eta: Infinity, uploadPercentage: 0 };
   }
   const totalSize = state.sizes.reduce((acc, size) => acc + size, 0);
   const uploadedSize = state.progress.reduce(
@@ -137,7 +137,7 @@ function computeETA(state) {
   const eta = remainingSize / speedBytesPerSecond;
   const percentage = (uploadedSize / totalSize) * 100;
 
-  return { eta, percentage };
+  return { eta, uploadPercentage };
 }
 
 function computeGlobalSpeedAndETA() {
@@ -149,12 +149,12 @@ function computeGlobalSpeedAndETA() {
     totalCount++;
   }
 
-  if (totalCount === 0) return { speed: 0, eta: Infinity, percentage: 0 };
+  if (totalCount === 0) return { speed: 0, eta: Infinity, uploadPercentage: 0 };
 
   const averageSpeed = totalSpeed / totalCount;
-  const { eta, percentage } = computeETA(store.state.upload, averageSpeed);
+  const { eta, uploadPercentage } = computeETA(store.state.upload, averageSpeed);
 
-  return { speed: averageSpeed, eta, percentage };
+  return { speed: averageSpeed, eta, uploadPercentage };
 }
 
 function calcProgress(filePath) {
@@ -177,10 +177,10 @@ function calcProgress(filePath) {
   fileData.currentAverageSpeed =
     ALPHA * avgRecentSpeed + ONE_MINUS_ALPHA * fileData.currentAverageSpeed;
 
-  const { speed, eta, percentage } = computeGlobalSpeedAndETA();
+  const { speed, eta, uploadPercentage } = computeGlobalSpeedAndETA();
   store.commit("setUploadSpeed", speed);
   store.commit("setETA", eta);
-  store.commit("setUploadPercentage", percentage);
+  store.commit("setUploadPercentage", uploadPercentage);
 
   fileData.initialBytesUploaded = fileData.currentBytesUploaded;
   fileData.lastProgressTimestamp = Date.now();

--- a/frontend/src/components/prompts/UploadFiles.vue
+++ b/frontend/src/components/prompts/UploadFiles.vue
@@ -10,7 +10,7 @@
         <div class="upload-info">
           <div class="upload-speed">{{ uploadSpeed.toFixed(2) }} MB/s</div>
           <div class="upload-eta">{{ formattedETA }} remaining</div>
-          <div class="upload-percentage">{{ uploadPercentage.toFixed(2) }}%</div>
+          <div class="upload-percentage">{{ uploadPercentage.toFixed(2) }}% Completed</div>
           <div class="upload-size">
             {{ formatFileSize(totalUploadedSize) }} /
             {{ formatFileSize(totalFileSize) }}

--- a/frontend/src/components/prompts/UploadFiles.vue
+++ b/frontend/src/components/prompts/UploadFiles.vue
@@ -11,6 +11,10 @@
           <div class="upload-speed">{{ uploadSpeed.toFixed(2) }} MB/s</div>
           <div class="upload-eta">{{ formattedETA }} remaining</div>
           <div class="upload-percentage">{{ uploadPercentage.toFixed(2) }}%</div>
+          <div class="upload-size">
+            {{ formatFileSize(totalUploadedSize) }} /
+            {{ formatFileSize(totalFileSize) }}
+          </div>
         </div>
         <button
           class="action"
@@ -71,7 +75,9 @@ export default {
       "filesInUploadCount",
       "uploadSpeed",
       "eta",
-      "uploadPercentage"
+      "uploadPercentage",
+      "totalUploadedSize",
+      "totalFileSize",
     ]),
     ...mapMutations(["resetUpload"]),
     formattedETA() {
@@ -101,6 +107,17 @@ export default {
         this.open = false;
         this.$store.commit("resetUpload");
         this.$store.commit("setReload", true);
+      }
+    },
+    formatFileSize(size) {
+      if (size < 1024) {
+        return size + ' B';
+      } else if (size < 1024 * 1024) {
+        return (size / 1024).toFixed(2) + ' KB';
+      } else if (size < 1024 * 1024 * 1024) {
+        return (size / 1024 / 1024).toFixed(2) + ' MB';
+      } else {
+        return (size / 1024 / 1024 / 1024).toFixed(2) + ' GB';
       }
     },
   },

--- a/frontend/src/components/prompts/UploadFiles.vue
+++ b/frontend/src/components/prompts/UploadFiles.vue
@@ -10,6 +10,7 @@
         <div class="upload-info">
           <div class="upload-speed">{{ uploadSpeed.toFixed(2) }} MB/s</div>
           <div class="upload-eta">{{ formattedETA }} remaining</div>
+          <div class="upload-percentage">{{ uploadPercentage.toFixed(2) }}%</div>
         </div>
         <button
           class="action"
@@ -70,6 +71,7 @@ export default {
       "filesInUploadCount",
       "uploadSpeed",
       "eta",
+      "uploadPercentage"
     ]),
     ...mapMutations(["resetUpload"]),
     formattedETA() {

--- a/frontend/src/store/getters.js
+++ b/frontend/src/store/getters.js
@@ -51,6 +51,7 @@ const getters = {
   },
   uploadSpeed: (state) => state.upload.speedMbyte,
   eta: (state) => state.upload.eta,
+  percentage: (state) => state.upload.percentage
 };
 
 export default getters;

--- a/frontend/src/store/getters.js
+++ b/frontend/src/store/getters.js
@@ -51,7 +51,9 @@ const getters = {
   },
   uploadSpeed: (state) => state.upload.speedMbyte,
   eta: (state) => state.upload.eta,
-  uploadPercentage: (state) => state.upload.uploadPercentage
+  uploadPercentage: (state) => state.upload.uploadPercentage,
+  totalUploadedSize: (state) => state.upload.totalUploadedSize,
+  totalFileSize: (state) => state.upload.totalFileSize
 };
 
 export default getters;

--- a/frontend/src/store/getters.js
+++ b/frontend/src/store/getters.js
@@ -51,7 +51,7 @@ const getters = {
   },
   uploadSpeed: (state) => state.upload.speedMbyte,
   eta: (state) => state.upload.eta,
-  percentage: (state) => state.upload.percentage
+  uploadPercentage: (state) => state.upload.uploadPercentage
 };
 
 export default getters;

--- a/frontend/src/store/modules/upload.js
+++ b/frontend/src/store/modules/upload.js
@@ -13,7 +13,7 @@ const state = {
   uploads: {},
   speedMbyte: 0,
   eta: 0,
-  percentage: 0
+  uploadPercentage: 0
 };
 
 const mutations = {

--- a/frontend/src/store/modules/upload.js
+++ b/frontend/src/store/modules/upload.js
@@ -13,6 +13,7 @@ const state = {
   uploads: {},
   speedMbyte: 0,
   eta: 0,
+  percentage: 0
 };
 
 const mutations = {

--- a/frontend/src/store/modules/upload.js
+++ b/frontend/src/store/modules/upload.js
@@ -13,7 +13,9 @@ const state = {
   uploads: {},
   speedMbyte: 0,
   eta: 0,
-  uploadPercentage: 0
+  uploadPercentage: 0,
+  totalFileSize: 0,
+  totalUploadedSize: 0
 };
 
 const mutations = {

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -104,6 +104,9 @@ const mutations = {
   setETA(state, value) {
     state.upload.eta = value;
   },
+  setUploadPercentage(state, value) {
+    state.upload.percentage = value;
+  },
   resetUpload(state) {
     state.upload.uploads = {};
     state.upload.queue = [];
@@ -112,6 +115,7 @@ const mutations = {
     state.upload.id = 0;
     state.upload.speedMbyte = 0;
     state.upload.eta = 0;
+    state.upload.percentage = 0;
   },
 };
 

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -107,6 +107,12 @@ const mutations = {
   setUploadPercentage(state, value) {
     state.upload.uploadPercentage = value;
   },
+  setTotalUploadedSize(state, value) {
+    state.upload.totalUploadedSize = value;
+  },
+  setTotalFileSize(state, value) {
+    state.upload.totalFileSize = value;
+  },
   resetUpload(state) {
     state.upload.uploads = {};
     state.upload.queue = [];
@@ -116,6 +122,8 @@ const mutations = {
     state.upload.speedMbyte = 0;
     state.upload.eta = 0;
     state.upload.uploadPercentage = 0;
+    state.upload.totalFileSize = 0;
+    state.upload.totalUploadedSize = 0;
   },
 };
 

--- a/frontend/src/store/mutations.js
+++ b/frontend/src/store/mutations.js
@@ -105,7 +105,7 @@ const mutations = {
     state.upload.eta = value;
   },
   setUploadPercentage(state, value) {
-    state.upload.percentage = value;
+    state.upload.uploadPercentage = value;
   },
   resetUpload(state) {
     state.upload.uploads = {};
@@ -115,7 +115,7 @@ const mutations = {
     state.upload.id = 0;
     state.upload.speedMbyte = 0;
     state.upload.eta = 0;
-    state.upload.percentage = 0;
+    state.upload.uploadPercentage = 0;
   },
 };
 


### PR DESCRIPTION
**Description**
![image](https://github.com/filebrowser/filebrowser/assets/5464404/e73aa3fd-f1b3-4663-8f38-fa01ebb501ca)

EDIT: Closing this PR out for [https://github.com/filebrowser/filebrowser/pull/3111](3111), which takes advantage of Vue 3 and is a bit more simple in implementation. )

Uploads will now show progress as percentage and file size /total file size of all files being uploaded.

I noticed this was missing when I was uploading files to my server. Figured it would be useful for determining how much is left beyond just an ETA.

Didn't see any issues related to this however.

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.

