### PR TITLE
add button to go up to .. (parent)

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -32,6 +32,7 @@
     "selectMultiple": "Select multiple",
     "share": "Share",
     "shell": "Toggle shell",
+    "gotoParent": "Open parent dir",
     "submit": "Submit",
     "switchView": "Switch view",
     "toggleSidebar": "Toggle sidebar",

--- a/frontend/src/views/files/Listing.vue
+++ b/frontend/src/views/files/Listing.vue
@@ -46,7 +46,12 @@
             show="delete"
           />
         </template>
-
+        <action
+          v-if="headerButtons.gotoParent"
+          icon="arrow_upward"
+          :label="$t('buttons.gotoParent')"
+          @action="gotoParent"
+        />
         <action
           v-if="headerButtons.shell"
           icon="code"
@@ -367,6 +372,7 @@ export default {
     },
     headerButtons() {
       return {
+        gotoParent: true,
         upload: this.user.perm.create,
         download: this.user.perm.download,
         shell: this.user.perm.execute && enableExec,
@@ -852,6 +858,14 @@ export default {
 
       this.setItemWeight();
       this.fillWindow();
+    },
+
+    gotoParent: function() {
+      const url = (window.location.pathname || "")
+      const parts = url.replace(/\/$/, '').split('/');
+      parts.pop();
+      const parentUrl = parts.join('/');
+      this.$router.push({ path: parentUrl });
     },
     upload: function () {
       if (


### PR DESCRIPTION
**Description**

This adds a button to the static set of buttons in the upper-right corner. When clicked, the browser navigates one level up the folder hierarchy. I think this is a crucial input/action to have in a browser.

I would prefer to have it closer to the logo (on the left side), but people probably put branding there, or whatever, so I decided to just stick it with the other buttons.


This is a new feature. No issues exist for this as far as I am aware.

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [?] AVOID breaking the continuous integration build.

```
$make build (…)
found 0 vulnerabilities (…)
✓ 188 modules transformed. (…)
✓ built in 20.20s 
```

**Further comments**

<small>I'm not sure if the last two check can be ticked off, yet. I'll update the PR when I am.</small>

...How do I check the last point? I guess you don't want to use up all the free time on the builder. Not sure how to proceed here.

I have a couple of questions:

- am I supposed to add the new "gettext" localization strings to all the other language file or just the one that I'm using? Is there some automation in place to help updating those files?


And some questions not related to this PR

- do you prefer people ask before adding features or is opening a PR the way to do it?

- how come there is no video preview in the browser? Is that something that you would find useful? (I imagine it could be done with ffmpeg or even directly in go)

- how come the "back" button on the mouse does not work to navigate away from photo preview? `<Esc>` works though, but I think the back button should close the photo preview and navigate back to the file listing just the way `<Esc>` does.