### PR TITLE
fix: add jq raw output flag (#3085)

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 PORT=${FB_PORT:-$(jq .port /.filebrowser.json)}
-ADDRESS=${FB_ADDRESS:-$(jq .address /.filebrowser.json)}
+ADDRESS=${FB_ADDRESS:-$(jq -r .address /.filebrowser.json)}
 ADDRESS=${ADDRESS:-localhost}
 curl -f http://$ADDRESS:$PORT/health || exit 1

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-PORT=${FB_PORT:-$(jq .port /.filebrowser.json)}
+PORT=${FB_PORT:-$(jq -r .port /.filebrowser.json)}
 ADDRESS=${FB_ADDRESS:-$(jq -r .address /.filebrowser.json)}
 ADDRESS=${ADDRESS:-localhost}
 curl -f http://$ADDRESS:$PORT/health || exit 1


### PR DESCRIPTION
**Description**
Use jq's "raw output" flag so it doesn't introduce unwanted double quotes in its output.

Closes #3085, Closes #3092, Closes #3139

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] AVOID breaking the continuous integration build.
