### PR TITLE
feat: add button to navigate up to .. (parent dir)

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -35,6 +35,7 @@
     "selectMultiple": "Select multiple",
     "share": "Share",
     "shell": "Toggle shell",
+    "gotoParent": "Open parent dir",
     "submit": "Submit",
     "switchView": "Switch view",
     "toggleSidebar": "Toggle sidebar",

--- a/frontend/src/views/files/FileListing.vue
+++ b/frontend/src/views/files/FileListing.vue
@@ -48,6 +48,12 @@
         </template>
 
         <action
+          v-if="headerButtons.gotoParent || true"
+          icon="arrow_upward"
+          :label="t('buttons.gotoParent')"
+          @action="gotoParent"
+        />
+        <action
           v-if="headerButtons.shell"
           icon="code"
           :label="t('buttons.shell')"
@@ -85,6 +91,14 @@
       <span v-if="fileStore.selectedCount > 0"
         >{{ fileStore.selectedCount }} selected</span
       >
+
+      <action
+        v-if="headerButtons.gotoParent || true"
+        icon="arrow_upward"
+        :label="t('buttons.gotoParent')"
+        @action="gotoParent"
+
+      />
       <action
         v-if="headerButtons.share"
         icon="share"
@@ -301,9 +315,10 @@ import {
   ref,
   watch,
 } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { storeToRefs } from "pinia";
+import { useRouterStore } from "@/stores/router";
 
 const showLimit = ref<number>(50);
 const columnWidth = ref<number>(280);
@@ -321,6 +336,7 @@ const layoutStore = useLayoutStore();
 const { req } = storeToRefs(fileStore);
 
 const route = useRoute();
+const router = useRouter();
 
 const { t } = useI18n();
 
@@ -404,6 +420,7 @@ const viewIcon = computed(() => {
 
 const headerButtons = computed(() => {
   return {
+    gotoParent: true,
     upload: authStore.user?.perm.create,
     download: authStore.user?.perm.download,
     shell: authStore.user?.perm.execute && enableExec,
@@ -888,6 +905,15 @@ const download = () => {
       api.download(format, ...files);
     },
   });
+};
+
+const gotoParent = () => {
+  console.log(route.fullPath)
+  const url = (route.fullPath || "")
+  const parts = url.replace(/\/$/, '').split('/');
+  parts.pop();
+  const parentUrl = parts.join('/');
+  router.push({ path: parentUrl });
 };
 
 const switchView = async () => {


### PR DESCRIPTION
**Description**

This adds a button to the static set of buttons in the upper-right corner. When clicked, the browser navigates one level up the folder hierarchy. I think this is a crucial input/action to have in a browser.

I would prefer to have it closer to the logo (on the left side), but people probably put branding there, or whatever, so I decided to just stick it with the other buttons.


This is a new feature. No issues exist for this as far as I am aware.

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [?] AVOID breaking the continuous integration build.

```
$make build (…)
found 0 vulnerabilities (…)
✓ 188 modules transformed. (…)
✓ built in 20.20s 
```

**Further comments**

<small>I'm not sure if the last two check can be ticked off, yet. I'll update the PR when I am.</small>

...How do I check the last point? I guess you don't want to use up all the free time on the builder. Not sure how to proceed here.

I have a couple of questions:

- am I supposed to add the new "gettext" localization strings to all the other language file or just the one that I'm using? Is there some automation in place to help updating those files?


