### PR TITLE
fix: make checkbox selectable via adjacent text

### DIFF
--- a/frontend/src/components/settings/Permissions.vue
+++ b/frontend/src/components/settings/Permissions.vue
@@ -4,37 +4,37 @@
     <p class="small">{{ $t("settings.permissionsHelp") }}</p>
 
     <p>
-      <input type="checkbox" v-model="admin" />
-      {{ $t("settings.administrator") }}
+      <input  id="uds-admin" type="checkbox" v-model="admin" />
+      <label for="uds-admin">{{ $t("settings.administrator") }}</label>
     </p>
 
     <p>
-      <input type="checkbox" :disabled="admin" v-model="perm.create" />
-      {{ $t("settings.perm.create") }}
+      <input  id="uds-create" type="checkbox" :disabled="admin" v-model="perm.create" />
+      <label for="uds-create">{{ $t("settings.perm.create") }}</label>
     </p>
     <p>
-      <input type="checkbox" :disabled="admin" v-model="perm.delete" />
-      {{ $t("settings.perm.delete") }}
+      <input  id="uds-delete" type="checkbox" :disabled="admin" v-model="perm.delete" />
+      <label for="uds-delete">{{ $t("settings.perm.delete") }}</label>
     </p>
     <p>
-      <input type="checkbox" :disabled="admin" v-model="perm.download" />
-      {{ $t("settings.perm.download") }}
+      <input  id="uds-download" type="checkbox" :disabled="admin" v-model="perm.download" />
+      <label for="uds-download">{{ $t("settings.perm.download") }}</label>
     </p>
     <p>
-      <input type="checkbox" :disabled="admin" v-model="perm.modify" />
-      {{ $t("settings.perm.modify") }}
+      <input  id="uds-modify" type="checkbox" :disabled="admin" v-model="perm.modify" />
+      <label for="uds-modify">{{ $t("settings.perm.modify") }}</label>
     </p>
     <p v-if="isExecEnabled">
-      <input type="checkbox" :disabled="admin" v-model="perm.execute" />
-      {{ $t("settings.perm.execute") }}
+      <input  id="uds-execute" type="checkbox" :disabled="admin" v-model="perm.execute" />
+      <label for="uds-execute">{{ $t("settings.perm.execute") }}</label>
     </p>
     <p>
-      <input type="checkbox" :disabled="admin" v-model="perm.rename" />
-      {{ $t("settings.perm.rename") }}
+      <input  id="uds-rename" type="checkbox" :disabled="admin" v-model="perm.rename" />
+      <label for="uds-rename">{{ $t("settings.perm.rename") }}</label>
     </p>
     <p>
-      <input type="checkbox" :disabled="admin" v-model="perm.share" />
-      {{ $t("settings.perm.share") }}
+      <input  id="uds-share" type="checkbox" :disabled="admin" v-model="perm.share" />
+      <label for="uds-share">{{ $t("settings.perm.share") }}</label>
     </p>
   </div>
 </template>

--- a/frontend/src/components/settings/Rules.vue
+++ b/frontend/src/components/settings/Rules.vue
@@ -1,8 +1,11 @@
 <template>
   <form class="rules small">
     <div v-for="(rule, index) in rules" :key="index">
-      <input type="checkbox" v-model="rule.regex" /><label>Regex</label>
-      <input type="checkbox" v-model="rule.allow" /><label>Allow</label>
+      <input :id="'regex-'+index" type="checkbox" v-model="rule.regex" />
+      <label :for="'regex-'+index" >Regex</label>
+
+      <input :id="'allow-'+index" type="checkbox" v-model="rule.allow" />
+      <label :for="'allow-'+index">Allow</label>
 
       <input
         @keypress.enter.prevent

--- a/frontend/src/components/settings/UserForm.vue
+++ b/frontend/src/components/settings/UserForm.vue
@@ -51,8 +51,9 @@
         type="checkbox"
         :disabled="user.perm.admin"
         v-model="user.lockPassword"
+        id="user-lock-pass"
       />
-      {{ t("settings.lockPassword") }}
+      <label for="user-lock-pass">{{ t("settings.lockPassword") }}</label>
     </p>
 
     <permissions v-model:perm="user.perm" />

--- a/frontend/src/css/dashboard.css
+++ b/frontend/src/css/dashboard.css
@@ -32,12 +32,16 @@ a {
   color: inherit;
 }
 
-.dashboard p label {
+.dashboard p input[type="checkbox"] {
+  cursor: pointer;
+  vertical-align: middle;
   margin-bottom: 0.2em;
-  display: block;
-  font-size: 0.8em;
-  font-weight: 500;
-  color: var(--textPrimary);
+}
+.dashboard p label {
+  margin-left: 0.35em;
+  vertical-align: bottom;
+  display: inline-block;
+  cursor: pointer;
 }
 
 li code,

--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -417,6 +417,7 @@ html[dir="rtl"] .breadcrumbs .chevron {
 
 .rules input[type="checkbox"] {
   margin-right: 0.2rem;
+  cursor: pointer;
 }
 
 .rules input[type="text"] {
@@ -426,6 +427,7 @@ html[dir="rtl"] .breadcrumbs .chevron {
 
 .rules label {
   margin-right: 0.5rem;
+  cursor: pointer;
 }
 
 .rules button {

--- a/frontend/src/views/settings/Global.vue
+++ b/frontend/src/views/settings/Global.vue
@@ -9,13 +9,14 @@
 
         <div class="card-content">
           <p>
-            <input type="checkbox" v-model="settings.signup" />
-            {{ t("settings.allowSignup") }}
+            <input id="allowSignup" type="checkbox" v-model="settings.signup" />
+            <label for="allowSignup">{{ t("settings.allowSignup") }}</label>
           </p>
 
           <p>
-            <input type="checkbox" v-model="settings.createUserDir" />
-            {{ t("settings.createUserDir") }}
+            <input id="createUserDir" type="checkbox" v-model="settings.createUserDir" />
+            <label for="createUserDir">{{ t("settings.createUserDir") }}</label>
+
           </p>
 
           <div>
@@ -64,7 +65,7 @@
               v-model="settings.branding.disableExternal"
               id="branding-links"
             />
-            {{ t("settings.disableExternalLinks") }}
+            <label for="branding-links">{{ t("settings.disableExternalLinks") }}</label>
           </p>
 
           <p>
@@ -73,7 +74,7 @@
               v-model="settings.branding.disableUsedPercentage"
               id="branding-used-disk"
             />
-            {{ t("settings.disableUsedDiskPercentage") }}
+            <label for="branding-used-disk">{{ t("settings.disableUsedDiskPercentage") }}</label>
           </p>
 
           <p>

--- a/frontend/src/views/settings/Profile.vue
+++ b/frontend/src/views/settings/Profile.vue
@@ -8,16 +8,16 @@
 
         <div class="card-content">
           <p>
-            <input type="checkbox" name="hideDotfiles" v-model="hideDotfiles" />
-            {{ t("settings.hideDotfiles") }}
+            <input id="hideDotfiles" type="checkbox" name="hideDotfiles" v-model="hideDotfiles" />
+            <label for="hideDotfiles">{{ t("settings.hideDotfiles") }}</label>
           </p>
           <p>
-            <input type="checkbox" name="singleClick" v-model="singleClick" />
-            {{ t("settings.singleClick") }}
+            <input id="singleClick" type="checkbox" name="singleClick" v-model="singleClick" />
+            <label for="singleClick">{{ t("settings.singleClick") }}</label>
           </p>
           <p>
-            <input type="checkbox" name="dateFormat" v-model="dateFormat" />
-            {{ t("settings.setDateFormat") }}
+            <input id="dateFormat" type="checkbox" name="dateFormat" v-model="dateFormat" />
+            <label for="dateFormat">{{ t("settings.setDateFormat") }}</label>
           </p>
           <h3>{{ t("settings.language") }}</h3>
           <languages


### PR DESCRIPTION
The the checkbox is not that easy to hit with a mouse. It's much easier to hit the whole description. HTML lets you do that, so why not use it?

The appearance of the font changed slightly but not significantly after the text was moved into a label because other css rules are affecting it now. I don't think it needs adjustment, but I'm not a UI guy or it looks good enough to me before and after.

The app builds.

```
$ make build
npm WARN deprecated noty@3.2.0-beta-deprecated: no longer supported

added 460 packages, and audited 461 packages in 2s

69 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

> filebrowser-frontend@2.0.0 build
> vite build

vite v4.5.2 building for production...
<script src="[{[ .ReCaptchaHost ]}]/recaptcha/api.js?render=explicit"> in "/public/index.html" can't be bundled without type="module" attribute

[{[ .StaticURL ]}]/themes/[{[ .Theme ]}].css doesn't exist at build time, it will remain unchanged to be resolved at runtime

[{[ .StaticURL ]}]/custom.css doesn't exist at build time, it will remain unchanged to be resolved at runtime
transforming (1) public/index.htmlBrowserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
✓ 188 modules transformed.
dist/assets/polyfills-legacy-5429e148.js.gz     55.56 kB
dist/assets/Editor-legacy-5c33137b.js          877.00 kB │ gzip: 237.64 kB
dist/assets/index-legacy-b5f54126.js         1,222.30 kB │ gzip: 374.19 kB

(!) Some chunks are larger than 500 kBs after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
dist/assets/medium-vietnamese-20d9ffa9.woff2        4.78 kB
dist/assets/normal-vietnamese-0af602fe.woff2        4.90 kB
dist/public/index.html                              6.69 kB │ gzip:   2.21 kB
dist/assets/medium-greek-1320e5dd.woff2             7.18 kB
dist/assets/bold-vietnamese-2096d809.woff2          7.20 kB
dist/assets/normal-greek-adc0b6a1.woff2             7.21 kB
dist/assets/bold-greek-20b1d460.woff2               9.49 kB
dist/assets/normal-cyrillic-fb0297aa.woff2         10.00 kB
dist/assets/medium-cyrillic-ef372eb9.woff2         10.06 kB
dist/assets/bold-cyrillic-c72dc79d.woff2           11.68 kB
dist/assets/medium-latin-ext-b4dae108.woff2        11.91 kB
dist/assets/normal-latin-ext-55f25e8b.woff2        12.01 kB
dist/assets/normal-latin-f7bbc846.woff2            14.58 kB
dist/assets/medium-latin-01a44f86.woff2            14.60 kB
dist/assets/bold-latin-ext-2d83ee25.woff2          15.14 kB
dist/assets/medium-cyrillic-ext-2d290fe6.woff2     15.29 kB
dist/assets/normal-cyrillic-ext-457c1e0d.woff2     15.83 kB
dist/assets/bold-cyrillic-ext-d2a7562e.woff2       17.18 kB
dist/assets/bold-latin-827bd1a8.woff2              18.12 kB
dist/assets/material-icons-8265f647.woff2         128.35 kB
dist/assets/material-icons-fd84f88b.woff          164.91 kB
dist/assets/index-14d65c81.css                     58.90 kB │ gzip:  16.89 kB
dist/assets/Editor-58ef5593.js                    871.31 kB │ gzip: 242.99 kB
dist/assets/index-1e0cd658.js                   1,145.68 kB │ gzip: 363.37 kB

(!) Some chunks are larger than 500 kBs after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 20.12s

```

Before and after:

![prefs before](https://github.com/filebrowser/filebrowser/assets/890081/e2a90cd1-e672-4867-badb-c186259b070d)

The texts appears a little bit smaller when wrapped in a label and the collor is gray instead of black.

![prefs after](https://github.com/filebrowser/filebrowser/assets/890081/67e42a29-0d7e-49c1-acc6-05dfcf42f767)
