### PR TITLE
Handle quotes in healthcheck.sh

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-PORT=${FB_PORT:-$(jq .port /.filebrowser.json)}
-ADDRESS=${FB_ADDRESS:-$(jq .address /.filebrowser.json)}
+PORT=${FB_PORT:-$(jq -r .port /.filebrowser.json)}
+ADDRESS=${FB_ADDRESS:-$(jq -r .address /.filebrowser.json)}
 ADDRESS=${ADDRESS:-localhost}
 curl -f http://$ADDRESS:$PORT/health || exit 1


### PR DESCRIPTION
This file as is makes a value of `"localhost"` as the address in the .filebrowser.json file read in as `"localhost"` instead of `localhost`. These quotes break the curl command. Using `-r` with jq fixes this.



:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [ ] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
