### PR TITLE
fix: top margin in preview for pdf and missing video codec message

### DIFF
--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -234,6 +234,10 @@ main .spinner .bounce2 {
   height: 100%;
 }
 
+#previewer .vjs-error-display {
+  margin-top: 40%;
+}
+
 #previewer .preview .info {
   position: absolute;
   top: 50%;
@@ -265,6 +269,7 @@ main .spinner .bounce2 {
 #previewer .pdf {
   width: 100%;
   height: 100%;
+  margin-top: 4em;
 }
 
 #previewer h2.message {


### PR DESCRIPTION
**Fix top margin for PDF preview and for missing video coded error message**

Small CSS fix for two issues:

Before:
![before-video](https://github.com/filebrowser/filebrowser/assets/13764826/096340a1-2881-4644-b168-687e95f167bd)
![before-pdf](https://github.com/filebrowser/filebrowser/assets/13764826/71bc4f55-d660-4bb3-864d-38e1a053fd29)

After
![after-pdf](https://github.com/filebrowser/filebrowser/assets/13764826/77cff4cd-9353-43e4-9eed-a7e0a465090b)
![after-video](https://github.com/filebrowser/filebrowser/assets/13764826/aac8269d-5fd0-455a-b17d-f294002fe784)

this fixes https://github.com/filebrowser/filebrowser/issues/3086

