### PR TITLE
fix: don't redirect to login when no auth

### DIFF
--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,7 +1,7 @@
 import { useAuthStore } from "@/stores/auth";
 import router from "@/router";
 import { JwtPayload, jwtDecode } from "jwt-decode";
-import { baseURL } from "./constants";
+import { baseURL, noAuth } from "./constants";
 import { StatusError } from "@/api/utils";
 
 export function parseToken(token: string) {
@@ -98,5 +98,9 @@ export function logout() {
   authStore.clearUser();
 
   localStorage.setItem("jwt", "");
-  router.push({ path: "/login" });
+  if (noAuth) {
+    window.location.reload();
+  } else {
+    router.push({path: "/login"});
+  }
 }


### PR DESCRIPTION
**Don't redirect to login page when there's no authentication**

Steps to reproduce:
1. Set up NoAuth as login provider, wait till session expires
2. Try to click on any folder/file
3. You'll be redirected to login page

Expected results:
When NoAuth is used as login provider user is not redirected to login page (as simply there is no login/password). Instead refreshing a page is enough to obtain a new token and to continue browsing.

There is no open issue for this.

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x ] AVOID breaking the continuous integration build.

