### PR TITLE
fix: apply proper zindex to modal dialogs

### DIFF
--- a/frontend/src/components/prompts/BaseModal.vue
+++ b/frontend/src/components/prompts/BaseModal.vue
@@ -1,5 +1,6 @@
 <template>
   <VueFinalModal
+    class="vfm-modal"
     overlay-transition="vfm-fade"
     content-transition="vfm-fade"
     @closed="layoutStore.closeHovers"
@@ -7,7 +8,6 @@
       initialFocus: '#focus-prompt',
       fallbackFocus: 'div.vfm__content',
     }"
-    style="z-index: 9999999"
   >
     <slot />
   </VueFinalModal>

--- a/frontend/src/css/base.css
+++ b/frontend/src/css/base.css
@@ -178,3 +178,7 @@ html[dir="rtl"] .breadcrumbs a {
 .vue-number-input__button::after {
   background: var(--textSecondary) !important;
 }
+
+.vfm-modal {
+  z-index: 9999999 !important;
+}


### PR DESCRIPTION
**Description**
Fixes invisible modal dialogs when another overlay is present like preview.

:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.
