### PR TITLE
fix: the clipboard.ts for copying failure.

### DIFF
--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -46,16 +46,25 @@ export function copy(text: string) {
       textarea.style.outline = "none";
       textarea.style.boxShadow = "none";
       textarea.style.background = "transparent";
-      document.body.appendChild(textarea);
+
+      let body: Element | null = null;
+      const focusedElement = document.activeElement;
+      if (focusedElement){
+        body = focusedElement
+      }else{
+        body = document.body
+      }
+      body.appendChild(textarea)
+
       textarea.focus();
       textarea.select();
       try {
         document.execCommand("copy");
-        document.body.removeChild(textarea);
         resolve();
       } catch (e) {
-        document.body.removeChild(textarea);
         reject(e);
+      }finally{
+        body.removeChild(textarea)
       }
     } else {
       reject(


### PR DESCRIPTION
Fix the copy method in clipboard.ts to address the issue of text copying failure when accessing it from the internet and when a modal dialog is open.

when accessing FileBrowser with a non-local host (127.0.0.1/localhost), such as the internal IP 192.168.31.1, the copy function at this location is disabled (even though the link is shown as copied).

![QQ截图20240429092055](https://github.com/filebrowser/filebrowser/assets/2849711/1bf2520a-7ff1-4fb6-83a7-06ab2342b162)

![QQ截图20240429113107](https://github.com/filebrowser/filebrowser/assets/2849711/3ec555f2-d204-4616-903a-d6684431ba00)
