### PR TITLE
fix: the copy method in clipboard.ts

### DIFF
--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -33,29 +33,18 @@ export function copy(text: string) {
       document.queryCommandSupported &&
       document.queryCommandSupported("copy")
     ) {
-      const textarea = document.createElement("textarea");
-      textarea.textContent = text;
-      textarea.setAttribute("readonly", "");
-      textarea.style.fontSize = "12pt";
-      textarea.style.position = "fixed";
-      textarea.style.width = "2em";
-      textarea.style.height = "2em";
-      textarea.style.padding = "0";
-      textarea.style.margin = "0";
-      textarea.style.border = "none";
-      textarea.style.outline = "none";
-      textarea.style.boxShadow = "none";
-      textarea.style.background = "transparent";
-      document.body.appendChild(textarea);
-      textarea.focus();
-      textarea.select();
+      const textarea = createTemporaryTextarea(text);
+      const body = document.activeElement || document.body;
       try {
+        body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
         document.execCommand("copy");
-        document.body.removeChild(textarea);
         resolve();
       } catch (e) {
-        document.body.removeChild(textarea);
         reject(e);
+      } finally {
+        body.removeChild(textarea);
       }
     } else {
       reject(
@@ -64,3 +53,26 @@ export function copy(text: string) {
     }
   });
 }
+
+const styles = {
+  fontSize: "12pt",
+  position: "fixed",
+  top: 0,
+  left: 0,
+  width: "2em",
+  height: "2em",
+  padding: 0,
+  margin: 0,
+  border: "none",
+  outline: "none",
+  boxShadow: "none",
+  background: "transparent"
+};
+
+const createTemporaryTextarea = (text:string) => {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  Object.assign(textarea.style, styles);
+  return textarea;
+};


### PR DESCRIPTION
Fix the copy method in clipboard.ts to address the issue of text copying failure when accessing it from the internet and when a modal dialog is open.

When accessing FileBrowser with a non-local host (127.0.0.1/localhost), such as the internal IP 192.168.31.131, the copy function at this location is not functioning as expected (even though clicking the button shows it as copied).

![QQ截图20240429092055](https://github.com/filebrowser/filebrowser/assets/2849711/c2b2c29b-b56a-48d1-90b1-382e99d899ac)


![QQ截图20240429113107](https://github.com/filebrowser/filebrowser/assets/2849711/94187cff-98ed-48e4-bb14-ed83c28301c0)
