### PR TITLE
feat: allow multi-select with SHIFT key in singleClick mode

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -209,8 +209,10 @@ const drop = async (event: Event) => {
 
 const itemClick = (event: Event | KeyboardEvent) => {
   if (
-    !((event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) &&
     singleClick.value &&
+    !(event as KeyboardEvent).ctrlKey &&
+    !(event as KeyboardEvent).metaKey &&
+    !(event as KeyboardEvent).shiftKey &&
     !fileStore.multiple
   )
     open();


### PR DESCRIPTION
**Description**

This is a follow-up of #2953 to also take into account the <kbd>SHIFT</kbd> key for selecting multiple files when `singleClick` mode is active.

:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->

n/a