### PR TITLE
fix: shell display related

### DIFF
--- a/frontend/src/css/_shell.css
+++ b/frontend/src/css/_shell.css
@@ -6,21 +6,12 @@
   background: var(--surfacePrimary);
   color: var(--textPrimary);
   z-index: 9999;
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--dividerSecondary);
   transition: 0.2s ease background;
   cursor: ns-resize;
   touch-action: none;
   user-select: none;
   width: 100%;
-}
-
-:root.dark {
-  .shell {
-    background: rgba(30, 30, 30, 0.6);
-  }
-  .shell__text {
-    color: white;
-  }
 }
 
 .shell__divider{
@@ -50,7 +41,7 @@
   top: 0px;
   left: 0px;
   z-index: 9998;
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: var(--dividerPrimary);
 }
 
 body.rtl .shell-content {
@@ -78,9 +69,7 @@ body.rtl .shell-content {
   font-size: inherit;
 }
 
-.shell__text{
-  color:black
-}
+
 
 .shell__prompt {
   width: 1.2rem;
@@ -95,4 +84,5 @@ body.rtl .shell-content {
   font-family: inherit;
   white-space: pre-wrap;
   width: 100%;
+  color:var(--textSecondary);
 }

--- a/frontend/src/css/_shell.css
+++ b/frontend/src/css/_shell.css
@@ -6,15 +6,23 @@
   background: var(--surfacePrimary);
   color: var(--textPrimary);
   z-index: 9999;
-  background: rgba(127, 127, 127, 0.1);
+  background: rgba(255, 255, 255, 0.9);
   transition: 0.2s ease background;
   cursor: ns-resize;
   touch-action: none;
   user-select: none;
+  width: 100%;
 }
 
+.shell__divider{
+  background: rgba(127, 127, 127, 0.3);
+  width: 100%;
+  height: 8px;
+}
 .shell__divider:hover {
-  background: rgba(127, 127, 127, 0.4);
+  background: rgba(127, 127, 127, 0.9);
+  
+
 }
 
 .shell__content {
@@ -60,6 +68,10 @@ body.rtl .shell-content {
 .shell__prompt,
 .shell__prompt i {
   font-size: inherit;
+}
+
+.shell__text{
+  color:black
 }
 
 .shell__prompt {

--- a/frontend/src/css/_shell.css
+++ b/frontend/src/css/_shell.css
@@ -14,15 +14,23 @@
   width: 100%;
 }
 
+:root.dark {
+  .shell {
+    background: rgba(30, 30, 30, 0.6);
+  }
+  .shell__text {
+    color: white;
+  }
+}
+
 .shell__divider{
   background: rgba(127, 127, 127, 0.3);
   width: 100%;
   height: 8px;
 }
+
 .shell__divider:hover {
   background: rgba(127, 127, 127, 0.9);
-  
-
 }
 
 .shell__content {

--- a/frontend/src/css/_variables.css
+++ b/frontend/src/css/_variables.css
@@ -31,6 +31,8 @@
   --hover: rgba(0, 0, 0, 0.1);
   --borderPrimary: rgba(0, 0, 0, 0.1);
   --borderSecondary: rgba(0, 0, 0, 0.2);
+  --dividerPrimary: rgba(255, 255, 255, 0.4);
+  --dividerSecondary: rgba(255, 255, 255, 0.9);
 }
 
 :root.dark {
@@ -51,4 +53,6 @@
   --hover: rgba(255, 255, 255, 0.1);
   --borderPrimary: rgba(255, 255, 255, 0.05);
   --borderSecondary: rgba(255, 255, 255, 0.15);
+  --dividerPrimary: rgba(30, 30, 30, 0.4);
+  --dividerSecondary:rgba(30, 30, 30, 0.6);
 }


### PR DESCRIPTION
Fix shell div width display problem
Fixed the issue where shell__divider height is 0, resulting in the inability to drag and drop to change the height of the shell div.
Improve the problem of background color and font conflict making it difficult to see clearly