### PR TITLE
fix:  Current Folder Name in Page Title

### DIFF
--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -45,6 +45,8 @@ import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
 import FileListing from "@/views/files/FileListing.vue";
 import { StatusError } from "@/api/utils";
+import { name } from "../utils/constants";
+
 const Editor = defineAsyncComponent(() => import("@/views/files/Editor.vue"));
 const Preview = defineAsyncComponent(() => import("@/views/files/Preview.vue"));
 
@@ -148,7 +150,8 @@ const fetchData = async () => {
     }
 
     fileStore.updateRequest(res);
-    document.title = `${res.name} - ${t("files.files")} - File Browser`;
+    document.title = `${res.name} - ${t("files.files")} - ${name}`;
+    
   } catch (err) {
     if (err instanceof Error) {
       error.value = err;

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -148,7 +148,7 @@ const fetchData = async () => {
     }
 
     fileStore.updateRequest(res);
-    document.title = `${res.name} - ${document.title}`;
+    document.title = `${res.name} - ${t("files.files")} - File Browser`;
   } catch (err) {
     if (err instanceof Error) {
       error.value = err;


### PR DESCRIPTION
Fix: Avoid Duplicate Display of Current Folder Name in Page Title

When performing multiple uploads/deletions triggering reload at the same path, the current folder name is duplicated in the page title。