### PR TITLE
fix: Implemented saving of token expiration time to the configuration file

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -163,6 +163,7 @@ func printSettings(ser *settings.Server, set *settings.Settings, auther auth.Aut
 	fmt.Fprintf(w, "\tTLS Cert:\t%s\n", ser.TLSCert)
 	fmt.Fprintf(w, "\tTLS Key:\t%s\n", ser.TLSKey)
 	fmt.Fprintf(w, "\tExec Enabled:\t%t\n", ser.EnableExec)
+	fmt.Fprintf(w, "\tToken Expiration Time:\t%s\n", ser.TokenExpirationTime)
 	fmt.Fprintln(w, "\nDefaults:")
 	fmt.Fprintf(w, "\tScope:\t%s\n", set.Defaults.Scope)
 	fmt.Fprintf(w, "\tLocale:\t%s\n", set.Defaults.Locale)

--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -45,14 +45,15 @@ override the options.`,
 		}
 
 		ser := &settings.Server{
-			Address: mustGetString(flags, "address"),
-			Socket:  mustGetString(flags, "socket"),
-			Root:    mustGetString(flags, "root"),
-			BaseURL: mustGetString(flags, "baseurl"),
-			TLSKey:  mustGetString(flags, "key"),
-			TLSCert: mustGetString(flags, "cert"),
-			Port:    mustGetString(flags, "port"),
-			Log:     mustGetString(flags, "log"),
+			Address:             mustGetString(flags, "address"),
+			Socket:              mustGetString(flags, "socket"),
+			Root:                mustGetString(flags, "root"),
+			BaseURL:             mustGetString(flags, "baseurl"),
+			TLSKey:              mustGetString(flags, "key"),
+			TLSCert:             mustGetString(flags, "cert"),
+			Port:                mustGetString(flags, "port"),
+			Log:                 mustGetString(flags, "log"),
+			TokenExpirationTime: mustGetString(flags, "token-expiration-time"),
 		}
 
 		err := d.store.Settings.Save(s)

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -63,6 +63,8 @@ you want to change. Other options will remain unchanged.`,
 				set.Branding.DisableUsedPercentage = mustGetBool(flags, flag.Name)
 			case "branding.files":
 				set.Branding.Files = mustGetString(flags, flag.Name)
+			case "token-expiration-time":
+				ser.TokenExpirationTime = mustGetString(flags, flag.Name)
 			}
 		})
 


### PR DESCRIPTION
**Description**
Implemented saving of token expiration time to the configuration file.
Help messages for config init and config set mentioned the --token-expiration-time option, but the value was not being saved at all, which misled users.

Possible related to https://github.com/filebrowser/filebrowser/issues/2917