### PR TITLE
fix: pdf preview header

### DIFF
--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -269,7 +269,7 @@ main .spinner .bounce2 {
 #previewer .pdf {
   width: 100%;
   height: 100%;
-  margin-top: 4em;
+  padding-top: 4em;
 }
 
 #previewer h2.message {

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -6,7 +6,7 @@
     @mousemove="toggleNavigation"
     @touchstart="toggleNavigation"
   >
-    <header-bar v-if="showNav">
+    <header-bar v-if="isPdf || showNav">
       <action icon="close" :label="$t('buttons.close')" @action="close()" />
       <title>{{ name }}</title>
       <action
@@ -74,11 +74,7 @@
           :options="videoOptions"
         >
         </VideoPlayer>
-        <object
-          v-else-if="fileStore.req?.extension.toLowerCase() == '.pdf'"
-          class="pdf"
-          :data="raw"
-        ></object>
+        <object v-else-if="isPdf" class="pdf" :data="raw"></object>
         <div v-else-if="fileStore.req?.type == 'blob'" class="info">
           <div class="title">
             <i class="material-icons">feedback</i>
@@ -188,6 +184,8 @@ const raw = computed(() => {
 
   return downloadUrl.value;
 });
+
+const isPdf = computed(() => fileStore.req?.extension.toLowerCase() == ".pdf");
 
 const isResizeEnabled = computed(() => resizePreview);
 


### PR DESCRIPTION
**Description**

This PR fixes these 2 minor bugs:

* The bottom of the pdf cannot be seen, exceeds the window limits.
* There is no need to hide the header now that we are again fixing the space for it.

Follow-up of #3024 and #3163.
Fixes #3086.

---

:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.