### PR TITLE
feat: open item in new window when pressing ctrl/meta key

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -211,12 +211,14 @@ const drop = async (event: Event) => {
 const itemClick = (event: Event | KeyboardEvent) => {
   if (
     singleClick.value &&
-    !(event as KeyboardEvent).ctrlKey &&
-    !(event as KeyboardEvent).metaKey &&
+    !(
+      fileStore.selectedCount !== 0 &&
+      ((event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey)
+    ) &&
     !(event as KeyboardEvent).shiftKey &&
     !fileStore.multiple
   )
-    open();
+    open(event);
   else click(event);
 };
 
@@ -230,7 +232,7 @@ const click = (event: Event | KeyboardEvent) => {
 
   touches.value++;
   if (touches.value > 1) {
-    open();
+    open(event);
   }
 
   if (fileStore.selected.indexOf(props.index) !== -1) {
@@ -270,8 +272,13 @@ const click = (event: Event | KeyboardEvent) => {
   fileStore.selected.push(props.index);
 };
 
-const open = () => {
-  router.push({ path: props.url });
+const open = (event: Event | KeyboardEvent) => {
+  if ((event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey) {
+    const route = router.resolve({ path: props.url });
+    window.open(route.href, "_blank");
+  } else {
+    router.push({ path: props.url });
+  }
 };
 
 const getExtension = (fileName: string): string => {


### PR DESCRIPTION
**Description**

Open item in a new window or tab when pressing <kbd>CTRL</kbd> / <kbd>META</kbd> key.

When doing a selection of items, you can still press <kbd>CTRL</kbd> / <kbd>META</kbd> to (de)select single items.

---

:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.

**Further comments**

- ⚠️ I'm not sure if some users can consider this a regression as they may be used to start selecting items pressing  <kbd>CTRL</kbd> / <kbd>META</kbd>. By merging this PR, you would enter "selection mode" with <kbd>SHIFT</kbd> only.