### PR TITLE
ci: Change stale days from 30 to 90

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,12 +13,12 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity.'
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
-          days-before-stale: 30
-          days-before-close: 5
+          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 7 days with no activity.'
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          days-before-stale: 90
+          days-before-close: 7
           exempt-issue-labels: 'feature ☘,enhancement ⚙,bug 🐞'
           exempt-pr-labels: 'need-help,wip'
           operations-per-run: 100


### PR DESCRIPTION
**Description**

30 days before stale issues are closed is too short for a slow-moving project like Filebrowser. for example:

- https://github.com/filebrowser/filebrowser/issues/3007
- https://github.com/filebrowser/filebrowser/issues/3213
- https://github.com/filebrowser/filebrowser/issues/3230
- https://github.com/filebrowser/filebrowser/issues/3237
- https://github.com/filebrowser/filebrowser/issues/3242

These are just ~30s of looking. [They are >700 issues closed because of staleness.](https://github.com/filebrowser/filebrowser/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aclosed+%22This+issue+was+closed+because+it+has+been+stalled+for+5+days+with+no+activity.%22)

I would even encourage to increase this to 180 or 365, or even remove completely. Issues should ideally be closed by a human when they are completed.