### PR TITLE
fix(frontend): N files selected hint use i18n

### DIFF
--- a/frontend/src/views/files/FileListing.vue
+++ b/frontend/src/views/files/FileListing.vue
@@ -82,9 +82,9 @@
     </header-bar>
 
     <div v-if="isMobile" id="file-selection">
-      <span v-if="fileStore.selectedCount > 0"
-        >{{ fileStore.selectedCount }} selected</span
-      >
+      <span v-if="fileStore.selectedCount > 0">
+        {{ t("prompts.filesSelected", fileStore.selectedCount) }}
+      </span>
       <action
         v-if="headerButtons.share"
         icon="share"


### PR DESCRIPTION
**Description**
Fix this hint:

![image](https://github.com/user-attachments/assets/7bf107bc-a8bf-4635-a672-c3a130bfb1a0)

:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
