### PR TITLE
feat: support mime type for epub extension

### DIFF
--- a/files/mime.go
+++ b/files/mime.go
@@ -597,6 +597,7 @@ var types = map[string]string{
 	".m3u8":      "application/x-mpegURL",
 	".mpd":       "application/dash+xml",
 	".webp":      "image/webp",
+	".epub":      "application/epub+zip",
 }
 
 //nolint:gochecknoinits


### PR DESCRIPTION
Epub extension file is not supported and lead to download .zip file. Adding the corresponding mime type should fix that.