### PR TITLE
feat: add implement markdown file preview in Ace editor

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "js-base64": "^3.7.7",
         "jwt-decode": "^4.0.0",
         "lodash-es": "^4.17.21",
+        "marked": "^14.1.0",
         "material-icons": "^1.13.12",
         "normalize.css": "^8.0.1",
         "pinia": "^2.1.7",
@@ -5808,6 +5809,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmmirror.com/marked/-/marked-14.1.0.tgz",
+      "integrity": "sha512-P93GikH/Pde0hM5TAXEd8I4JAYi8IB03n8qzW8Bh1BIEFpEyBoYxi/XWZA53LSpTeLBiMQOoSMj0u5E/tiVYTA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/marks-pane": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "jwt-decode": "^4.0.0",
     "lodash-es": "^4.17.21",
     "material-icons": "^1.13.12",
+    "marked": "^14.1.0",
     "normalize.css": "^8.0.1",
     "pinia": "^2.1.7",
     "pretty-bytes": "^6.1.1",

--- a/frontend/src/css/mdPreview.css
+++ b/frontend/src/css/mdPreview.css
@@ -1,5 +1,5 @@
 .md_preview {
-  overflow-y:auto;
+  overflow-y: auto;
   max-height: 80vh;
   padding: 1rem;
   border: 1px solid #000;
@@ -8,6 +8,6 @@
 }
 
 #preview-container {
-   overflow: auto;
-   max-height: 80vh; /* Match the max-height of md_preview for scrolling */
+  overflow: auto;
+  max-height: 80vh; /* Match the max-height of md_preview for scrolling */
 }

--- a/frontend/src/css/mdPreview.css
+++ b/frontend/src/css/mdPreview.css
@@ -1,0 +1,13 @@
+.md_preview {
+  overflow-y:auto;
+  max-height: 80vh;
+  padding: 1rem;
+  border: 1px solid #000;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+#preview-container {
+   overflow: auto;
+   max-height: 80vh; /* Match the max-height of md_preview for scrolling */
+}

--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -16,6 +16,7 @@
 @import "./login.css";
 @import "./mobile.css";
 @import "./epubReader.css";
+@import "./mdPreview.css";
 
 /* For testing only
  :focus {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -24,6 +24,7 @@
     "ok": "OK",
     "permalink": "Get Permanent Link",
     "previous": "Previous",
+    "preview": "Preview",
     "publish": "Publish",
     "rename": "Rename",
     "replace": "Replace",

--- a/frontend/src/i18n/zh-cn.json
+++ b/frontend/src/i18n/zh-cn.json
@@ -22,6 +22,7 @@
     "ok": "确定",
     "permalink": "获取永久链接",
     "previous": "上一个",
+    "preview": "预览",
     "publish": "发布",
     "rename": "重命名",
     "replace": "替换",

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -11,11 +11,16 @@
         :label="t('buttons.save')"
         @action="save()"
       />
+
+      <action icon="preview" :label="t('buttons.preview')" @action="preview()" />
     </header-bar>
 
     <Breadcrumbs base="/files" noLink />
 
-    <form id="editor"></form>
+    <!-- preview container -->
+    <div v-show="isPreview && isMarkdownFile" id="preview-container" class="md_preview" v-html="previewContent"></div>
+
+    <form v-show="!isPreview || !isMarkdownFile" id="editor"></form>
   </div>
 </template>
 
@@ -33,10 +38,11 @@ import Breadcrumbs from "@/components/Breadcrumbs.vue";
 import { useAuthStore } from "@/stores/auth";
 import { useFileStore } from "@/stores/file";
 import { useLayoutStore } from "@/stores/layout";
-import { inject, onBeforeUnmount, onMounted, ref } from "vue";
+import { inject, onBeforeUnmount, onMounted, ref, watchEffect } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { getTheme } from "@/utils/theme";
+import { marked } from 'marked';
 
 const $showError = inject<IToastError>("$showError")!;
 
@@ -51,10 +57,32 @@ const router = useRouter();
 
 const editor = ref<Ace.Editor | null>(null);
 
+const isPreview = ref(false);
+const previewContent = ref("");
+const isMarkdownFile = fileStore.req?.name.endsWith('.md') || fileStore.req?.name.endsWith('.markdown');
+
 onMounted(() => {
   window.addEventListener("keydown", keyEvent);
+  window.addEventListener("wheel", handleScroll);
 
   const fileContent = fileStore.req?.content || "";
+
+  watchEffect(async () => {
+    if (isMarkdownFile && isPreview.value) {
+      const new_value = editor.value?.getValue() || "";
+      try {
+        previewContent.value = await marked(new_value);
+      } catch (error) {
+        console.error("Failed to convert content to HTML:", error);
+        previewContent.value = "";
+      }
+
+      const previewContainer = document.getElementById('preview-container');
+      if (previewContainer) {
+        previewContainer.addEventListener("wheel", handleScroll, { capture: true });
+      }
+    }
+  });
 
   ace.config.set(
     "basePath",
@@ -82,6 +110,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener("keydown", keyEvent);
+  window.removeEventListener("wheel", handleScroll);
   editor.value?.destroy();
 });
 
@@ -100,6 +129,13 @@ const keyEvent = (event: KeyboardEvent) => {
 
   event.preventDefault();
   save();
+};
+
+const handleScroll = (event: WheelEvent) => {
+  const editorContainer = document.getElementById('preview-container');
+  if (editorContainer) {
+    editorContainer.scrollTop += event.deltaY;
+  }
 };
 
 const save = async () => {
@@ -126,4 +162,9 @@ const close = () => {
   let uri = url.removeLastDir(route.path) + "/";
   router.push({ path: uri });
 };
+
+const preview = () => {
+  isPreview.value = !isPreview.value;
+};
 </script>
+

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -12,13 +12,23 @@
         @action="save()"
       />
 
-      <action icon="preview" :label="t('buttons.preview')" @action="preview()" />
+      <action
+        icon="preview"
+        :label="t('buttons.preview')"
+        @action="preview()"
+        v-show="isMarkdownFile"
+      />
     </header-bar>
 
     <Breadcrumbs base="/files" noLink />
 
     <!-- preview container -->
-    <div v-show="isPreview && isMarkdownFile" id="preview-container" class="md_preview" v-html="previewContent"></div>
+    <div
+      v-show="isPreview && isMarkdownFile"
+      id="preview-container"
+      class="md_preview"
+      v-html="previewContent"
+    ></div>
 
     <form v-show="!isPreview || !isMarkdownFile" id="editor"></form>
   </div>
@@ -42,7 +52,7 @@ import { inject, onBeforeUnmount, onMounted, ref, watchEffect } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { getTheme } from "@/utils/theme";
-import { marked } from 'marked';
+import { marked } from "marked";
 
 const $showError = inject<IToastError>("$showError")!;
 
@@ -59,7 +69,9 @@ const editor = ref<Ace.Editor | null>(null);
 
 const isPreview = ref(false);
 const previewContent = ref("");
-const isMarkdownFile = fileStore.req?.name.endsWith('.md') || fileStore.req?.name.endsWith('.markdown');
+const isMarkdownFile =
+  fileStore.req?.name.endsWith(".md") ||
+  fileStore.req?.name.endsWith(".markdown");
 
 onMounted(() => {
   window.addEventListener("keydown", keyEvent);
@@ -77,9 +89,11 @@ onMounted(() => {
         previewContent.value = "";
       }
 
-      const previewContainer = document.getElementById('preview-container');
+      const previewContainer = document.getElementById("preview-container");
       if (previewContainer) {
-        previewContainer.addEventListener("wheel", handleScroll, { capture: true });
+        previewContainer.addEventListener("wheel", handleScroll, {
+          capture: true,
+        });
       }
     }
   });
@@ -132,7 +146,7 @@ const keyEvent = (event: KeyboardEvent) => {
 };
 
 const handleScroll = (event: WheelEvent) => {
-  const editorContainer = document.getElementById('preview-container');
+  const editorContainer = document.getElementById("preview-container");
   if (editorContainer) {
     editorContainer.scrollTop += event.deltaY;
   }
@@ -167,4 +181,3 @@ const preview = () => {
   isPreview.value = !isPreview.value;
 };
 </script>
-


### PR DESCRIPTION
I like Filebrowser very much. I also deploy it on my server and use it almost every day. I often use Markdown files, 

Reference the following link:
[add mavon-editor for markdown file #1127](https://github.com/filebrowser/filebrowser/pull/1127#issuecomment-729680329)

so I added a Markdown format preview function to it. Use marked to add Markdown support in Ace editor.

I am a novice in Go and JS. I hope you can give me some modification suggestions to verify whether my understanding is correct. Thank you very much.

