### PR TITLE
fix: shell command not found

### DIFF
--- a/runner/parser.go
+++ b/runner/parser.go
@@ -12,7 +12,7 @@ import (
 func ParseCommand(s *settings.Settings, raw string) ([]string, error) {
 	var command []string
 
-	if len(s.Shell) == 0 {
+	if len(s.Shell) == 0 || s.Shell[0] == "" {
 		cmd, args, err := SplitCommandAndArgs(raw)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes #3349

When settings are updated, s.Shell[0] ends up with "" when there is no shell defined in the settings. This fixes the parser to set the command properly when that happens.
