### PR TITLE
ci: Bump 'actions/stale' to latest version

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v9
         with:
           stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity.'


### PR DESCRIPTION
This PR fixes a [warning](https://github.com/filebrowser/filebrowser/actions/runs/10867237798) printed out when running 'Close stale issues' workflow.
