### PR TITLE
style: Added whitespace before version

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -101,7 +101,7 @@
           href="https://github.com/filebrowser/filebrowser"
           >File Browser</a
         >
-        <span> {{ version }}</span>
+        <span> {{ ' ' }} {{ version }}</span>
       </span>
       <span>
         <a @click="help">{{ $t("sidebar.help") }}</a>


### PR DESCRIPTION
**Description**
I've added a whitespace to separate the GitHub link from the version.
Just a small thing that was bugging me.

**Before:**
![Filebrowser_old](https://github.com/user-attachments/assets/08ebed21-c613-4871-bbee-31580dba0539)

**After:**
![Filebrowser_new](https://github.com/user-attachments/assets/89c520b6-4846-4e18-9b02-f00f02c854a2)
