### PR TITLE
fix: Prompts disappearing on copy / move / upload

### DIFF
--- a/frontend/src/api/files.ts
+++ b/frontend/src/api/files.ts
@@ -1,7 +1,8 @@
-import { createURL, fetchURL, removePrefix } from "./utils";
-import { baseURL } from "@/utils/constants";
 import { useAuthStore } from "@/stores/auth";
+import { useLayoutStore } from "@/stores/layout";
+import { baseURL } from "@/utils/constants";
 import { upload as postTus, useTus } from "./tus";
+import { createURL, fetchURL, removePrefix } from "./utils";
 
 export async function fetch(url: string) {
   url = removePrefix(url);
@@ -156,6 +157,7 @@ function moveCopy(
   overwrite = false,
   rename = false
 ) {
+  const layoutStore = useLayoutStore();
   const promises = [];
 
   for (const item of items) {
@@ -166,7 +168,7 @@ function moveCopy(
     }&destination=${to}&override=${overwrite}&rename=${rename}`;
     promises.push(resourceAction(url, "PATCH"));
   }
-
+  layoutStore.closeHovers();
   return Promise.all(promises);
 }
 

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -101,7 +101,7 @@
           href="https://github.com/filebrowser/filebrowser"
           >File Browser</a
         >
-        <span> {{ ' ' }} {{ version }}</span>
+        <span> {{ " " }} {{ version }}</span>
       </span>
       <span>
         <a @click="help">{{ $t("sidebar.help") }}</a>

--- a/frontend/src/components/prompts/Prompts.vue
+++ b/frontend/src/components/prompts/Prompts.vue
@@ -30,8 +30,6 @@ const layoutStore = useLayoutStore();
 
 const { currentPromptName } = storeToRefs(layoutStore);
 
-const closeModal = ref<() => Promise<string>>();
-
 const components = new Map<string, any>([
   ["info", Info],
   ["help", Help],
@@ -52,11 +50,6 @@ const components = new Map<string, any>([
 ]);
 
 watch(currentPromptName, (newValue) => {
-  if (closeModal.value) {
-    closeModal.value();
-    closeModal.value = undefined;
-  }
-
   const modal = components.get(newValue!);
   if (!modal) return;
 
@@ -67,7 +60,7 @@ watch(currentPromptName, (newValue) => {
     },
   });
 
-  closeModal.value = close;
+  layoutStore.setCloseOnPrompt(close, newValue!);
   open();
 });
 

--- a/frontend/src/components/prompts/Prompts.vue
+++ b/frontend/src/components/prompts/Prompts.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { watch } from "vue";
 import { ModalsContainer, useModal } from "vue-final-modal";
 import { storeToRefs } from "pinia";
 import { useLayoutStore } from "@/stores/layout";

--- a/frontend/src/components/prompts/Upload.vue
+++ b/frontend/src/components/prompts/Upload.vue
@@ -48,8 +48,6 @@ const layoutStore = useLayoutStore();
 
 // TODO: this is a copy of the same function in FileListing.vue
 const uploadInput = (event: Event) => {
-  layoutStore.closeHovers();
-
   let files = (event.currentTarget as HTMLInputElement)?.files;
   if (files === null) return;
 

--- a/frontend/src/stores/layout.ts
+++ b/frontend/src/stores/layout.ts
@@ -29,12 +29,11 @@ export const useLayoutStore = defineStore("layout", {
     toggleShell() {
       this.showShell = !this.showShell;
     },
-    setCloseOnPrompt(closeFunction: any, onPrompt: string) {
-      let prompt = this.prompts.find((prompt) => prompt.prompt === onPrompt);
+    setCloseOnPrompt(closeFunction: () => Promise<string>, onPrompt: string) {
+      const prompt = this.prompts.find((prompt) => prompt.prompt === onPrompt);
       if (prompt) {
         prompt.close = closeFunction;
       }
-      return null;
     },
     showHover(value: PopupProps | string) {
       if (typeof value !== "object") {

--- a/frontend/src/stores/layout.ts
+++ b/frontend/src/stores/layout.ts
@@ -75,7 +75,7 @@ export const useLayoutStore = defineStore("layout", {
       });
     },
     closeHovers() {
-      this.prompts.shift()?.close?.();
+      this.prompts.pop()?.close?.();
     },
     // easily reset state using `$reset`
     clearLayout() {

--- a/frontend/src/stores/layout.ts
+++ b/frontend/src/stores/layout.ts
@@ -29,6 +29,13 @@ export const useLayoutStore = defineStore("layout", {
     toggleShell() {
       this.showShell = !this.showShell;
     },
+    setCloseOnPrompt(closeFunction: any, onPrompt: string) {
+      let prompt = this.prompts.find((prompt) => prompt.prompt === onPrompt);
+      if (prompt) {
+        prompt.close = closeFunction;
+      }
+      return null;
+    },
     showHover(value: PopupProps | string) {
       if (typeof value !== "object") {
         this.prompts.push({
@@ -36,6 +43,7 @@ export const useLayoutStore = defineStore("layout", {
           confirm: null,
           action: undefined,
           props: null,
+          close: null,
         });
         return;
       }
@@ -45,6 +53,7 @@ export const useLayoutStore = defineStore("layout", {
         confirm: value?.confirm,
         action: value?.action,
         props: value?.props,
+        close: value?.close,
       });
     },
     showError() {
@@ -53,6 +62,7 @@ export const useLayoutStore = defineStore("layout", {
         confirm: null,
         action: undefined,
         props: null,
+        close: null,
       });
     },
     showSuccess() {
@@ -61,10 +71,11 @@ export const useLayoutStore = defineStore("layout", {
         confirm: null,
         action: undefined,
         props: null,
+        close: null,
       });
     },
     closeHovers() {
-      this.prompts.shift();
+      this.prompts.shift()?.close?.();
     },
     // easily reset state using `$reset`
     clearLayout() {

--- a/frontend/src/stores/layout.ts
+++ b/frontend/src/stores/layout.ts
@@ -64,7 +64,7 @@ export const useLayoutStore = defineStore("layout", {
       });
     },
     closeHovers() {
-      this.prompts.pop();
+      this.prompts.shift();
     },
     // easily reset state using `$reset`
     clearLayout() {

--- a/frontend/src/stores/layout.ts
+++ b/frontend/src/stores/layout.ts
@@ -75,7 +75,7 @@ export const useLayoutStore = defineStore("layout", {
       });
     },
     closeHovers() {
-      this.prompts.pop()?.close?.();
+      this.prompts.shift()?.close?.();
     },
     // easily reset state using `$reset`
     clearLayout() {

--- a/frontend/src/types/layout.d.ts
+++ b/frontend/src/types/layout.d.ts
@@ -3,7 +3,7 @@ interface PopupProps {
   confirm?: any;
   action?: PopupAction;
   props?: any;
-  close?: any;
+  close?: (() => Promise<string>) | null;
 }
 
 type PopupAction = (e: Event) => void;

--- a/frontend/src/types/layout.d.ts
+++ b/frontend/src/types/layout.d.ts
@@ -3,6 +3,7 @@ interface PopupProps {
   confirm?: any;
   action?: PopupAction;
   props?: any;
+  close?: any;
 }
 
 type PopupAction = (e: Event) => void;

--- a/frontend/src/utils/upload.ts
+++ b/frontend/src/utils/upload.ts
@@ -1,3 +1,4 @@
+import { useLayoutStore } from "@/stores/layout";
 import { useUploadStore } from "@/stores/upload";
 import url from "@/utils/url";
 
@@ -126,6 +127,9 @@ export function handleFiles(
   overwrite = false
 ) {
   const uploadStore = useUploadStore();
+  const layoutStore = useLayoutStore();
+
+  layoutStore.closeHovers();
 
   for (const file of files) {
     const id = uploadStore.id;

--- a/frontend/src/views/files/FileListing.vue
+++ b/frontend/src/views/files/FileListing.vue
@@ -753,8 +753,6 @@ const drop = async (event: DragEvent) => {
 };
 
 const uploadInput = (event: Event) => {
-  layoutStore.closeHovers();
-
   let files = (event.currentTarget as HTMLInputElement)?.files;
   if (files === null) return;
 


### PR DESCRIPTION
**Description**
Fixes the bug mentioned in #3519 and #3325 .  

I believe the root of the issues with disappearing modals is in how the `close()` was being handled in Prompts.Vue.  My latest commit removes the `closeModal` reactive var and instead opts for storing the close function directly on the prompt itself.  This now allows for the modals to "stack", and then when `closeHovers` is called, it properly dismisses each one, oldest to newest.  Switching the `closeHovers` array operation from `pop` to `shift` is what ensures all prompts are closed out.  I also removed the `closeHovers` from Upload.vue and FileListing.vue as they would prematurely dismiss any replace/rename prompt if present.  This closeHovers is now in `/utils/upload.ts`, which ensures any prompts are closed only after replace/rename  

:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).
closes #3519 
closes #3325

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.