### PR TITLE
fix: Revert using modal hook (#2689)

### DIFF
--- a/frontend/src/components/prompts/BaseModal.vue
+++ b/frontend/src/components/prompts/BaseModal.vue
@@ -3,7 +3,6 @@
     class="vfm-modal"
     overlay-transition="vfm-fade"
     content-transition="vfm-fade"
-    @closed="layoutStore.closeHovers"
     :focus-trap="{
       initialFocus: '#focus-prompt',
       fallbackFocus: 'div.vfm__content',
@@ -15,7 +14,4 @@
 
 <script setup lang="ts">
 import { VueFinalModal } from "vue-final-modal";
-import { useLayoutStore } from "@/stores/layout";
-
-const layoutStore = useLayoutStore();
 </script>


### PR DESCRIPTION
`@closed` hook gets called for all actions, whether user initiated or not. This is the source of auto-closing modals without user interaction reported in #3303 and #3519. While testing its effects, I also discovered other little issues but I have no clue how to Vue so I'll leave it to the big bois.

1. Moving a file to the same folder prompts a second modal. If you hit rename it doesn't ask you for the name, it just appends `(1)` and then complains that it cannot find the file if you try move again.
2. Creating a new file with the same name of an existing one does not issue a toast notification. That's because `files.ts` api does not return a properly formatted `StatusError` [here](https://github.com/filebrowser/filebrowser/blob/master/frontend/src/api/files.ts#L139).

**Description**
<!--
Please explain the changes you made here.
If the feature changes current behaviour, explain why your solution is better.
-->

:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
> Cannot check all the builds, but /frontend builds ok with `npm run build`.
- [x] AVOID breaking the continuous integration build.

**Further comments**
I just played around with the thing in my browser and tried to understand where the calls to `closeHovers()` were coming from. Finally figured out it was the BaseModal.vue, because I had already started modifying the function to check for passed events and such. Too complicated for 0 reason. 

There are remaining issues now that you can actually interact with the UI, but this change should not get in the way. Just call the function when appropriate, i.e. after confirming a rename or whatever. `closeHovers()` should not run as a hook in my opinion, because it gets called by the internal vue dom handler on top of the modal's own actual hook code. Which is why the second prompt disappears before the user is even able to read what it asks.

I don't mind if you don't go this route, it's just food for thought.