### PR TITLE
fix: Use layoutStore instead of this.$store

### DIFF
--- a/frontend/src/components/prompts/FileList.vue
+++ b/frontend/src/components/prompts/FileList.vue
@@ -28,6 +28,7 @@
 import { mapState } from "pinia";
 import { useAuthStore } from "@/stores/auth";
 import { useFileStore } from "@/stores/file";
+import { useLayoutStore } from "@/stores/layout";
 
 import url from "@/utils/url";
 import { files } from "@/api";
@@ -49,6 +50,7 @@ export default {
   computed: {
     ...mapState(useAuthStore, ["user"]),
     ...mapState(useFileStore, ["req"]),
+    ...mapState(useLayoutStore, ["showHover"]),
     nav() {
       return decodeURIComponent(this.current);
     },
@@ -139,7 +141,7 @@ export default {
       this.$emit("update:selected", this.selected);
     },
     createDir: async function () {
-      this.$store.commit("showHover", {
+      this.showHover({
         prompt: "newDir",
         action: null,
         confirm: null,


### PR DESCRIPTION
**Description**
Looks like a this.$store was left behind after the switch to Pinia (or that's what I'm assuming right now). This change should fix the new folder button in the Move prompt. Should fix #3621. Not currently able to build locally as I am away from my dev machine so this entire PR was done in the Github web client.

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [ ] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] AVOID breaking the continuous integration build.
