### PR TITLE
fix: Upload event command runners

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -145,7 +145,7 @@ func printSettings(ser *settings.Server, set *settings.Settings, auther auth.Aut
 	fmt.Fprintf(w, "Sign up:\t%t\n", set.Signup)
 	fmt.Fprintf(w, "Create User Dir:\t%t\n", set.CreateUserDir)
 	fmt.Fprintf(w, "Auth method:\t%s\n", set.AuthMethod)
-	fmt.Fprintf(w, "Shell:\t%s\t\n", strings.Join(set.Shell, " "))
+	fmt.Fprintf(w, "Shell:\t%s\t\n", set.Shell)
 	fmt.Fprintln(w, "\nBranding:")
 	fmt.Fprintf(w, "\tName:\t%s\n", set.Branding.Name)
 	fmt.Fprintf(w, "\tFiles override:\t%s\n", set.Branding.Files)

--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -32,7 +32,7 @@ override the options.`,
 			Key:           generateKey(),
 			Signup:        mustGetBool(flags, "signup"),
 			CreateUserDir: mustGetBool(flags, "create-user-dir"),
-			Shell:         convertCmdStrToCmdArray(mustGetString(flags, "shell")),
+			Shell:         mustGetString(flags, "shell"),
 			AuthMethod:    authMethod,
 			Defaults:      defaults,
 			Branding: settings.Branding{

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -48,7 +48,7 @@ you want to change. Other options will remain unchanged.`,
 			case "auth.method":
 				hasAuth = true
 			case "shell":
-				set.Shell = convertCmdStrToCmdArray(mustGetString(flags, flag.Name))
+				set.Shell = mustGetString(flags, flag.Name)
 			case "create-user-dir":
 				set.CreateUserDir = mustGetBool(flags, flag.Name)
 			case "branding.name":

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -344,7 +344,7 @@ func quickSetup(flags *pflag.FlagSet, d pythonData) {
 			RetryCount: settings.DefaultTusRetryCount,
 		},
 		Commands: nil,
-		Shell:    nil,
+		Shell:    "",
 		Rules:    nil,
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -194,7 +194,7 @@ func convertCmdStrToCmdArray(cmd string) []string {
 	var cmdArray []string
 	trimmedCmdStr := strings.TrimSpace(cmd)
 	if trimmedCmdStr != "" {
-		cmdArray = strings.Split(trimmedCmdStr, " ")
+		cmdArray = strings.Split(trimmedCmdStr, ",")
 	}
 	return cmdArray
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -186,15 +186,3 @@ func cleanUpMapValue(v interface{}) interface{} {
 		return v
 	}
 }
-
-// convertCmdStrToCmdArray checks if cmd string is blank (whitespace included)
-// then returns empty string array, else returns the split word array of cmd.
-// This is to ensure the result will never be []string{""}
-func convertCmdStrToCmdArray(cmd string) []string {
-	var cmdArray []string
-	trimmedCmdStr := strings.TrimSpace(cmd)
-	if trimmedCmdStr != "" {
-		cmdArray = strings.Split(trimmedCmdStr, ",")
-	}
-	return cmdArray
-}

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -6,7 +6,7 @@ interface ISettings {
   rules: any[];
   branding: SettingsBranding;
   tus: SettingsTus;
-  shell: string[];
+  shell: string;
   commands: SettingsCommand;
 }
 

--- a/frontend/src/views/settings/Global.vue
+++ b/frontend/src/views/settings/Global.vue
@@ -296,12 +296,7 @@ const save = async () => {
   if (settings.value === null) return false;
   let newSettings: ISettings = {
     ...settings.value,
-    shell:
-      settings.value?.shell
-        .join(" ")
-        .trim()
-        .split(" ")
-        .filter((s: string) => s !== "") ?? [],
+    shell: settings.value?.shell?.trim() ?? "", // Change this to a string
     commands: {},
   };
 
@@ -309,7 +304,6 @@ const save = async () => {
     keyof SettingsCommand
   >;
   for (const key of keys) {
-    // not sure if we can safely assume non-null
     const newValue = commandObject.value[key];
     if (!newValue) continue;
 
@@ -321,7 +315,9 @@ const save = async () => {
         .filter((cmd: string) => cmd !== "");
     }
   }
-  newSettings.shell = shellValue.value.split("\n");
+
+  // Update this line to assign the string directly, without splitting
+  newSettings.shell = shellValue.value.trim();
 
   if (newSettings.branding.theme !== getTheme()) {
     setTheme(newSettings.branding.theme);
@@ -386,7 +382,7 @@ onMounted(async () => {
 
     originalSettings.value = original;
     settings.value = newSettings;
-    shellValue.value = newSettings.shell.join("\n");
+    shellValue.value = newSettings.shell;
   } catch (err) {
     if (err instanceof Error) {
       error.value = err;

--- a/http/settings.go
+++ b/http/settings.go
@@ -16,7 +16,7 @@ type settingsData struct {
 	Rules            []rules.Rule          `json:"rules"`
 	Branding         settings.Branding     `json:"branding"`
 	Tus              settings.Tus          `json:"tus"`
-	Shell            []string              `json:"shell"`
+	Shell            string                `json:"shell"`
 	Commands         map[string][]string   `json:"commands"`
 }
 

--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -158,7 +158,6 @@ func tusPatchHandler() handleFunc {
 		w.Header().Set("Upload-Offset", strconv.FormatInt(uploadOffset+bytesWritten, 10))
 
 		if bytesWritten < int64(d.Settings.Tus.ChunkSize) {
-			fmt.Printf("Final chunk detected (size: %d). Running after hook\n", bytesWritten)
 			err = d.RunAfterHook("upload", r.URL.Path, "", d.user)
 			if err != nil {
 				return errToStatus(err), err

--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -157,7 +157,7 @@ func tusPatchHandler() handleFunc {
 
 		w.Header().Set("Upload-Offset", strconv.FormatInt(uploadOffset+bytesWritten, 10))
 
-		if bytesWritten < int64(d.Settings.Tus.ChunkSize) {
+		if uint64(bytesWritten) < (d.Settings.Tus.ChunkSize) {
 			err = d.RunAfterHook("upload", r.URL.Path, "", d.user)
 			if err != nil {
 				return errToStatus(err), err

--- a/runner/parser.go
+++ b/runner/parser.go
@@ -12,7 +12,7 @@ import (
 func ParseCommand(s *settings.Settings, raw string) ([]string, error) {
 	var command []string
 
-	if len(s.Shell) == 0 || s.Shell[0] == "" {
+	if s.Shell == "" {
 		cmd, args, err := SplitCommandAndArgs(raw)
 		if err != nil {
 			return nil, err
@@ -26,7 +26,7 @@ func ParseCommand(s *settings.Settings, raw string) ([]string, error) {
 		command = append(command, cmd)
 		command = append(command, args...)
 	} else {
-		cmd, args, err := SplitCommandAndArgs(s.Shell[0])
+		cmd, args, err := SplitCommandAndArgs(s.Shell)
 		if err != nil {
 			return nil, err
 		}

--- a/runner/parser.go
+++ b/runner/parser.go
@@ -8,7 +8,7 @@ import (
 
 // ParseCommand parses the command taking in account if the current
 // instance uses a shell to run the commands or just calls the binary
-// directyly.
+// directly.
 func ParseCommand(s *settings.Settings, raw string) ([]string, error) {
 	var command []string
 
@@ -26,7 +26,19 @@ func ParseCommand(s *settings.Settings, raw string) ([]string, error) {
 		command = append(command, cmd)
 		command = append(command, args...)
 	} else {
-		command = append(s.Shell, raw) //nolint:gocritic
+		cmd, args, err := SplitCommandAndArgs(s.Shell[0])
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = exec.LookPath(cmd)
+		if err != nil {
+			return nil, err
+		}
+
+		command = append(command, cmd)
+		command = append(command, args...)
+		command = append(command, raw)
 	}
 
 	return command, nil

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -17,6 +17,39 @@ type Runner struct {
 	*settings.Settings
 }
 
+// RunBeforeHooks and RunAfterHooks is used for the chunked upload since it cannot use the standard RunHook
+func (r *Runner) RunBeforeHook(evt, path, dst string, user *users.User) error {
+	path = user.FullPath(path)
+	dst = user.FullPath(dst)
+	if r.Enabled {
+		if val, ok := r.Commands["before_"+evt]; ok {
+			for _, command := range val {
+				err := r.exec(command, "before_"+evt, path, dst, user)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (r *Runner) RunAfterHook(evt, path, dst string, user *users.User) error {
+	path = user.FullPath(path)
+	dst = user.FullPath(dst)
+	if r.Enabled {
+		if val, ok := r.Commands["after_"+evt]; ok {
+			for _, command := range val {
+				err := r.exec(command, "after_"+evt, path, dst, user)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // RunHook runs the hooks for the before and after event.
 func (r *Runner) RunHook(fn func() error, evt, path, dst string, user *users.User) error {
 	path = user.FullPath(path)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -17,7 +17,7 @@ type Runner struct {
 	*settings.Settings
 }
 
-// RunBeforeHooks and RunAfterHooks is used for the chunked upload since it cannot use the standard RunHook
+// RunBeforeHook and RunAfterHook are triggering on their respective timings
 func (r *Runner) RunBeforeHook(evt, path, dst string, user *users.User) error {
 	path = user.FullPath(path)
 	dst = user.FullPath(dst)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -17,7 +17,7 @@ type Runner struct {
 	*settings.Settings
 }
 
-// RunBeforeHook and RunAfterHook are triggering on their respective timings
+// RunBeforeHook and RunAfterHook trigger the command runner at their respective times.
 func (r *Runner) RunBeforeHook(evt, path, dst string, user *users.User) error {
 	path = user.FullPath(path)
 	dst = user.FullPath(dst)

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -25,7 +25,7 @@ type Settings struct {
 	Branding         Branding            `json:"branding"`
 	Tus              Tus                 `json:"tus"`
 	Commands         map[string][]string `json:"commands"`
-	Shell            []string            `json:"shell"`
+	Shell            string              `json:"shell"`
 	Rules            []rules.Rule        `json:"rules"`
 }
 

--- a/settings/storage.go
+++ b/settings/storage.go
@@ -72,8 +72,8 @@ func (s *Storage) Save(set *Settings) error {
 		set.Rules = []rules.Rule{}
 	}
 
-	if set.Shell == nil {
-		set.Shell = []string{}
+	if set.Shell == "" {
+		set.Shell = ""
 	}
 
 	if set.Commands == nil {


### PR DESCRIPTION
**Description**
This PR contains changes which add to the TUS uploading that when merged broke command runner triggered on events BEFORE_UPLOAD and AFTER_UPLOAD. This required creating two new hook methods for runner, one for before event and one for after event. These methods were needed because of how the TUS chunks the processed file. 

This PR solves following issues
[#3670]
[#2993]

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.
