### PR TITLE
fix: downloadUrl of file preview

### DIFF
--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -253,7 +253,7 @@ const hasPrevious = computed(() => previousLink.value !== "");
 const hasNext = computed(() => nextLink.value !== "");
 
 const downloadUrl = computed(() =>
-  fileStore.req ? api.getDownloadURL(fileStore.req, true) : ""
+  fileStore.req ? api.getDownloadURL(fileStore.req, false) : ""
 );
 
 const raw = computed(() => {


### PR DESCRIPTION
**Description**
#2689 5100e58 did not changed the semantic(definition) of api/files.ts:getDownloadURL(item, inline=undefined).

However, the caller (`frontend/src/views/files/Preview.vue:downloadURL`) is changed from `api.getDownloadURL(this.req)` to `api.getDownloadURL(fileStore.req, true)`
https://github.com/filebrowser/filebrowser/commit/5100e587d73831ecdb5e3bd35a78fef96ad248a4#diff-a8ee9ee497925a6f859b8ba12826e1e5c405f1b39b628140a44421044030c10bL191
https://github.com/filebrowser/filebrowser/commit/5100e587d73831ecdb5e3bd35a78fef96ad248a4#diff-a8ee9ee497925a6f859b8ba12826e1e5c405f1b39b628140a44421044030c10bR181

Thus, the download button which `window.open(downloadUrl)` was changed from `not inline` to `inline` and display the content in browser instead of download it.

:rotating_light: Closes #3611 

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.

**Further comments**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.

:heart: Thank you!
-->
