### PR TITLE
fix: video thumbnail generation issues (#3737, discussions #1486)

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -16,7 +16,7 @@
   >
     <div>
       <img
-        v-if="!readOnly && type === 'image' && isThumbsEnabled"
+       v-if="!readOnly && (type === 'image' || type === 'video') && isThumbsEnabled"
         v-lazy="thumbnailUrl"
       />
       <i v-else class="material-icons"></i>


### PR DESCRIPTION
This PR resolves video thumbnail generation issues as described in:

- Issue: #3737 
- Discussion: #1486 

### 🚀 Main Changes:

- Limited concurrent `ffmpeg` processes using semaphore to prevent high CPU and resource usage.
- Improved `ffmpeg` commands for reliable video thumbnail generation.
- Optimized caching mechanism to reduce redundant thumbnail processing.


### ✅ Pre-built Binaries:

For testing convenience, pre-built binaries from GitHub Actions are available [here](https://github.com/shengj1ang/filebrowser/releases/tag/202502240418).

fix: set videojs locale #3742 is also considered


### 📸 Screenshot:

![video thumbnail preview](https://raw.githubusercontent.com/shengj1ang/filebrowser/refs/heads/master/Screen%20Shot%202025-02-24%20at%203.01.39%20AM.png)

### 🎉 Credits:

Contributions mainly from [@cody82](https://github.com/cody82/filebrowser/tree/videopreview).

---

Closes #3737  
Resolves discussion #1486
