### PR TITLE
feat: Add home url option to branding settings

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -48,6 +48,7 @@ func addConfigFlags(flags *pflag.FlagSet) {
 	flags.String("branding.files", "", "path to directory with images and custom styles")
 	flags.Bool("branding.disableExternal", false, "disable external links such as GitHub links")
 	flags.Bool("branding.disableUsedPercentage", false, "disable used disk percentage graph")
+	flags.String("branding.homeURL", "", "URL to the home website (use in case you have filebrowser embedded in another system)")
 }
 
 //nolint:gocyclo
@@ -153,6 +154,7 @@ func printSettings(ser *settings.Server, set *settings.Settings, auther auth.Aut
 	fmt.Fprintf(w, "\tDisable used disk percentage graph:\t%t\n", set.Branding.DisableUsedPercentage)
 	fmt.Fprintf(w, "\tColor:\t%s\n", set.Branding.Color)
 	fmt.Fprintf(w, "\tTheme:\t%s\n", set.Branding.Theme)
+	fmt.Fprintf(w, "\tHome URL:\t%s\n", set.Branding.HomeURL)
 	fmt.Fprintln(w, "\nServer:")
 	fmt.Fprintf(w, "\tLog:\t%s\n", ser.Log)
 	fmt.Fprintf(w, "\tPort:\t%s\n", ser.Port)

--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -41,6 +41,7 @@ override the options.`,
 				DisableUsedPercentage: mustGetBool(flags, "branding.disableUsedPercentage"),
 				Theme:                 mustGetString(flags, "branding.theme"),
 				Files:                 mustGetString(flags, "branding.files"),
+				HomeURL:               mustGetString(flags, "branding.homeURL"),
 			},
 		}
 

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -63,6 +63,8 @@ you want to change. Other options will remain unchanged.`,
 				set.Branding.DisableUsedPercentage = mustGetBool(flags, flag.Name)
 			case "branding.files":
 				set.Branding.Files = mustGetString(flags, flag.Name)
+			case "branding.homeURL":
+				set.Branding.HomeURL = mustGetString(flags, flag.Name)
 			}
 		})
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -64,6 +64,7 @@
         Signup: false,
         StaticURL: "",
         Theme: "",
+        HomeURL: "",
         TusSettings: { chunkSize: 10485760, retryCount: 5 },
         Version: "(untracked)",
       };

--- a/frontend/src/components/header/HeaderBar.vue
+++ b/frontend/src/components/header/HeaderBar.vue
@@ -1,6 +1,6 @@
 <template>
   <header>
-    <img v-if="showLogo" :src="logoURL" />
+    <a :href="homeURL"> <img v-if="showLogo" :src="logoURL" /> </a>
     <Action
       v-if="showMenu"
       class="menu-button"
@@ -37,7 +37,7 @@
 <script setup lang="ts">
 import { useLayoutStore } from "@/stores/layout";
 
-import { logoURL } from "@/utils/constants";
+import { logoURL, homeURL } from "@/utils/constants";
 
 import Action from "@/components/header/Action.vue";
 import { computed, useSlots } from "vue";

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -29,6 +29,7 @@ interface SettingsBranding {
   files: string;
   theme: UserTheme;
   color: string;
+  homeURL: string;
 }
 
 interface SettingsTus {

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -2,6 +2,7 @@ const name: string = window.FileBrowser.Name || "File Browser";
 const disableExternal: boolean = window.FileBrowser.DisableExternal;
 const disableUsedPercentage: boolean = window.FileBrowser.DisableUsedPercentage;
 const baseURL: string = window.FileBrowser.BaseURL;
+const homeURL: string = window.FileBrowser.HomeURL || baseURL;
 const staticURL: string = window.FileBrowser.StaticURL;
 const recaptcha: string = window.FileBrowser.ReCaptcha;
 const recaptchaKey: string = window.FileBrowser.ReCaptchaKey;
@@ -24,6 +25,7 @@ export {
   disableExternal,
   disableUsedPercentage,
   baseURL,
+  homeURL,
   logoURL,
   recaptcha,
   recaptchaKey,

--- a/frontend/src/views/settings/Global.vue
+++ b/frontend/src/views/settings/Global.vue
@@ -96,6 +96,16 @@
           </p>
 
           <p>
+            <label for="branding-name">{{ t("settings.homeURL") }}</label>
+            <input
+              class="input input--block"
+              type="text"
+              v-model="settings.branding.homeURL"
+              id="branding-home-url"
+            />
+          </p>
+
+          <p>
             <label for="branding-files">{{
               t("settings.brandingDirectoryPath")
             }}</label>

--- a/http/static.go
+++ b/http/static.go
@@ -32,6 +32,7 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, fSys 
 		"DisableExternal":       d.settings.Branding.DisableExternal,
 		"DisableUsedPercentage": d.settings.Branding.DisableUsedPercentage,
 		"Color":                 d.settings.Branding.Color,
+		"HomeURL":               d.settings.Branding.HomeURL,
 		"BaseURL":               d.server.BaseURL,
 		"Version":               version.Version,
 		"StaticURL":             path.Join(d.server.BaseURL, "/static"),

--- a/settings/branding.go
+++ b/settings/branding.go
@@ -8,4 +8,5 @@ type Branding struct {
 	Files                 string `json:"files"`
 	Theme                 string `json:"theme"`
 	Color                 string `json:"color"`
+	HomeURL               string `json:"homeURL"`
 }


### PR DESCRIPTION
**Description**
Add an option to set a home url to the branding settings. This way if filebrowser is used as a part of another system we can have the logo point to the home page of the system to provide a more seamless integration. If no home url is set, then the url will point to the base url instead.

:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.
