### PR TITLE
fix: Fix permissions for operating files and directories

### DIFF
--- a/files/file.go
+++ b/files/file.go
@@ -27,8 +27,8 @@ import (
 	"github.com/filebrowser/filebrowser/v2/rules"
 )
 
-const PermFile = 0644
-const PermDir = 0755
+const PermFile = 0666
+const PermDir = 0777
 
 var (
 	reSubDirs = regexp.MustCompile("(?i)^sub(s|titles)$")


### PR DESCRIPTION
**Description**

This PR will fix permission issues (#2535, #3281, #3399) by making permissions as lax as possible when handling files and directories.
However, I know nothing about the possible (and dangerous) side effects of this change.

**Further comments**

Tested on Ubuntu 24.04.2 LTS and Go 1.23.0.
`file0`, `dir0` is the file created before the change, `file1`, `dir1` is the file created by the command line, and `file2`, `dir2` is the file created by the modified filebrowser.

```
ubuntu@8d98ab8f6f40:~/filebrowser/working$ uname -a
Linux 8d98ab8f6f40 6.11.0-21-generic #21-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb 19 16:50:40 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
ubuntu@8d98ab8f6f40:~/filebrowser/working$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu 24.04.2 LTS"
ubuntu@8d98ab8f6f40:~/filebrowser/working$ go version
go version go1.23.0 linux/amd64
ubuntu@8d98ab8f6f40:~/filebrowser/working$ ls -lha
total 64K
drwxrwxr-x 5 ubuntu ubuntu 4.0K Mar 31 19:29 .
drwxrwxr-x 1 ubuntu ubuntu 4.0K Mar 31 19:43 ..
drwxr-xr-x 2 ubuntu ubuntu 4.0K Mar 31 19:25 dir0
drwxrwxr-x 2 ubuntu ubuntu 4.0K Mar 31 19:27 dir1
drwxrwxr-x 2 ubuntu ubuntu 4.0K Mar 31 19:28 dir2
-rw-r--r-- 1 ubuntu ubuntu    0 Mar 31 19:25 file0
-rw-rw-r-- 1 ubuntu ubuntu    0 Mar 31 19:27 file1
-rw-rw-r-- 1 ubuntu ubuntu    0 Mar 31 19:29 file2
-rw------- 1 ubuntu ubuntu  64K Mar 31 19:28 filebrowser.db
```

