### PR TITLE
fix: Graceful shutdown

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,8 +77,12 @@ linters:
         - "1"
         - "2"
         - "3"
+        - "0666"
+        - "0700"
+        - "0700"
       ignored-functions:
         - strings.SplitN
+        - make
     nolintlint:
       allow-unused: false # report any unused nolint directives
       require-explanation: false # require an explanation for nolint directives

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -73,7 +73,7 @@ func dbExists(path string) (bool, error) {
 		d := filepath.Dir(path)
 		_, err = os.Stat(d)
 		if os.IsNotExist(err) {
-			if err := os.MkdirAll(d, 0700); err != nil { //nolint:govet,mnd
+			if err := os.MkdirAll(d, 0700); err != nil { //nolint:govet
 				return false, err
 			}
 			return false, nil

--- a/diskcache/file_cache.go
+++ b/diskcache/file_cache.go
@@ -37,11 +37,11 @@ func (f *FileCache) Store(_ context.Context, key string, value []byte) error {
 	defer mu.Unlock()
 
 	fileName := f.getFileName(key)
-	if err := f.fs.MkdirAll(filepath.Dir(fileName), 0700); err != nil { //nolint:mnd
+	if err := f.fs.MkdirAll(filepath.Dir(fileName), 0700); err != nil {
 		return err
 	}
 
-	if err := afero.WriteFile(f.fs, fileName, value, 0700); err != nil { //nolint:mnd
+	if err := afero.WriteFile(f.fs, fileName, value, 0700); err != nil {
 		return err
 	}
 

--- a/files/file.go
+++ b/files/file.go
@@ -313,7 +313,7 @@ func (i *FileInfo) readFirstBytes() []byte {
 	}
 	defer reader.Close()
 
-	buffer := make([]byte, 512) //nolint:mnd
+	buffer := make([]byte, 512)
 	n, err := reader.Read(buffer)
 	if err != nil && !errors.Is(err, io.EOF) {
 		log.Print(err)

--- a/http/share.go
+++ b/http/share.go
@@ -91,7 +91,7 @@ var sharePostHandler = withPermShare(func(w http.ResponseWriter, r *http.Request
 		defer r.Body.Close()
 	}
 
-	bytes := make([]byte, 6) //nolint:mnd
+	bytes := make([]byte, 6)
 	_, err := rand.Read(bytes)
 	if err != nil {
 		return http.StatusInternalServerError, err
@@ -130,7 +130,7 @@ var sharePostHandler = withPermShare(func(w http.ResponseWriter, r *http.Request
 
 	var token string
 	if len(hash) > 0 {
-		tokenBuffer := make([]byte, 96) //nolint:mnd
+		tokenBuffer := make([]byte, 96)
 		if _, err := rand.Read(tokenBuffer); err != nil {
 			return http.StatusInternalServerError, err
 		}

--- a/img/service.go
+++ b/img/service.go
@@ -207,7 +207,7 @@ func getEmbeddedThumbnail(in io.Reader) ([]byte, io.Reader, error) {
 
 	offset := 0
 	offsets := []int{12, 30}
-	head := make([]byte, 0xffff) //nolint:mnd
+	head := make([]byte, 0xffff)
 
 	_, err := r.Read(head)
 	if err != nil {

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -72,7 +72,7 @@ func (s *Server) GetTokenExpirationTime(fallback time.Duration) time.Duration {
 
 // GenerateKey generates a key of 512 bits.
 func GenerateKey() ([]byte, error) {
-	b := make([]byte, 64) //nolint:mnd
+	b := make([]byte, 64)
 	_, err := rand.Read(b)
 	// Note that err == nil only if we read len(b) bytes.
 	if err != nil {


### PR DESCRIPTION
**Description**

Hello,

I’ve noticed that the process always exits with a non-zero code because of the use of `log.Fatal` in the error block for `http.ListenAndServe` (which always returns a non-nil error). In my installation, it causes systemd to believe that the process failed even during routine restarts, which triggers alerts in my monitoring.

Additionally, because the `listener` is closed before the server, sometimes there is an additional error: 

```
2025/04/14 15:09:39 Using database: PATH/filebrowser.db
2025/04/14 15:09:39 No config file used
2025/04/14 15:09:39 Listening on 127.0.0.1:8080
^C2025/04/14 15:09:41 Caught signal interrupt: shutting down.
2025/04/14 15:09:41 accept tcp 127.0.0.1:8080: use of closed network connection
```

Using the code from https://dev.to/mokiat/proper-http-shutdown-in-go-3fji, I’ve fixed the graceful shutdown mechanism for the HTTP server to ensure a non-zero exit code.

Let me know what you think!

