### PR TITLE
fix: properly set video control bar properties #3882

### DIFF
--- a/frontend/src/components/files/VideoPlayer.vue
+++ b/frontend/src/components/files/VideoPlayer.vue
@@ -93,10 +93,17 @@ const initVideoPlayer = async () => {
 const getOptions = (...srcOpt: any[]) => {
   const options = {
     controlBar: {
-      skipButtons: {
-        forward: 5,
-        backward: 5,
-      },
+      volumePanel: {},
+      playbackRateButton: {},
+      currentTimeDisplay: {},
+      timeDivider: {},
+      durationDisplay: {},
+      remainingTimeDisplay: {},
+      progressControl: {},
+      liveDisplay: {},
+      customControlSpacer: {},
+      playToggle: {},
+      fullscreenToggle: {},
     },
     html5: {
       nativeTextTracks: false,


### PR DESCRIPTION
**Description**

Adds proper video control bar properties in order to fix missing control bar when playing videos.
This is the solution proposed by @niubility000 on the issue #3882. I tested it locally and it worked.

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [x] AVOID breaking the continuous integration build.
