### PR TITLE
fix: recursively remove associated shares when folder/file is deleted

### DIFF
--- a/http/resource.go
+++ b/http/resource.go
@@ -73,7 +73,7 @@ func resourceDeleteHandler(fileCache FileCache) handleFunc {
 			return errToStatus(err), err
 		}
 
-		d.store.Share.DeleteWithPath(file.Path)
+		d.store.Share.DeleteWithPathPrefix(file.Path)
 
 		// delete thumbnails
 		err = delThumbs(r.Context(), fileCache, file)

--- a/http/resource.go
+++ b/http/resource.go
@@ -73,10 +73,7 @@ func resourceDeleteHandler(fileCache FileCache) handleFunc {
 			return errToStatus(err), err
 		}
 
-		// delete potential shares for this path
-		for _, path := range flatListFilePaths(file, d) {
-			d.store.Share.DeleteWithPath(path)
-		}
+		d.store.Share.DeleteWithPath(file.Path)
 
 		// delete thumbnails
 		err = delThumbs(r.Context(), fileCache, file)
@@ -335,41 +332,6 @@ func patchAction(ctx context.Context, action, src, dst string, d *data, fileCach
 	default:
 		return fmt.Errorf("unsupported action %s: %w", action, fbErrors.ErrInvalidRequestParams)
 	}
-}
-
-func flatListFilePaths(fileInfo *files.FileInfo, d *data) []string {
-	var paths []string
-
-	paths = append(paths, fileInfo.Path)
-
-	if (!fileInfo.isDir) {
-		return paths
-	}
-
-	for _, item := range fileInfo.Items {
-		// no need to add the directory's path here as it will provide itself in the next recursion
-		if (item.IsDir) {
-			file, err := files.NewFileInfo(&files.FileOptions{
-				Fs:         item.Fs,
-				Path:       item.Path + "/", // ensure we add the suffix "/" for a directory
-				Modify:     false,
-				Expand:     true,
-				ReadHeader: false,
-				Checker: 	d,
-			})
-
-			if (err != nil) {
-				return paths
-			}
-
-			deeperFiles := flatListFilePaths(file, d)
-			paths = append(paths, deeperFiles...)
-		} else {
-			paths = append(paths, item.Path)
-		}
-	}
-
-	return paths
 }
 
 type DiskUsageResponse struct {

--- a/http/resource.go
+++ b/http/resource.go
@@ -65,7 +65,7 @@ func resourceDeleteHandler(fileCache FileCache) handleFunc {
 			Fs:         d.user.Fs,
 			Path:       r.URL.Path,
 			Modify:     d.user.Perm.Modify,
-			Expand:     true,
+			Expand:     false,
 			ReadHeader: d.server.TypeDetectionByHeader,
 			Checker:    d,
 		})

--- a/http/resource.go
+++ b/http/resource.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -75,7 +76,7 @@ func resourceDeleteHandler(fileCache FileCache) handleFunc {
 
 		err = d.store.Share.DeleteWithPathPrefix(file.Path)
 		if err != nil {
-			fmt.Println("Warning: Error(s) occurred while deleting associated shares with file:" + err.Error())
+			log.Printf("WARNING: Error(s) occurred while deleting associated shares with file: %s", err)
 		}
 
 		// delete thumbnails

--- a/http/resource.go
+++ b/http/resource.go
@@ -73,7 +73,10 @@ func resourceDeleteHandler(fileCache FileCache) handleFunc {
 			return errToStatus(err), err
 		}
 
-		d.store.Share.DeleteWithPathPrefix(file.Path)
+		err = d.store.Share.DeleteWithPathPrefix(file.Path)
+		if err != nil {
+			fmt.Println("Warning: Error(s) occurred while deleting associated shares with file:" + err.Error())
+		}
 
 		// delete thumbnails
 		err = delThumbs(r.Context(), fileCache, file)

--- a/share/storage.go
+++ b/share/storage.go
@@ -15,7 +15,7 @@ type StorageBackend interface {
 	Gets(path string, id uint) ([]*Link, error)
 	Save(s *Link) error
 	Delete(hash string) error
-	DeleteWithPathPrefix(path string)
+	DeleteWithPathPrefix(path string) error
 }
 
 // Storage is a storage.
@@ -120,6 +120,6 @@ func (s *Storage) Delete(hash string) error {
 	return s.back.Delete(hash)
 }
 
-func (s *Storage) DeleteWithPathPrefix(path string) {
-	s.back.DeleteWithPathPrefix(path)
+func (s *Storage) DeleteWithPathPrefix(path string) error {
+	return s.back.DeleteWithPathPrefix(path)
 }

--- a/share/storage.go
+++ b/share/storage.go
@@ -15,6 +15,7 @@ type StorageBackend interface {
 	Gets(path string, id uint) ([]*Link, error)
 	Save(s *Link) error
 	Delete(hash string) error
+	DeleteWithPath(path string) error
 }
 
 // Storage is a storage.
@@ -117,4 +118,8 @@ func (s *Storage) Save(l *Link) error {
 // Delete wraps a StorageBackend.Delete
 func (s *Storage) Delete(hash string) error {
 	return s.back.Delete(hash)
+}
+
+func (s *Storage) DeleteWithPath(path string) error {
+	return s.back.DeleteWithPath(path)
 }

--- a/share/storage.go
+++ b/share/storage.go
@@ -15,7 +15,7 @@ type StorageBackend interface {
 	Gets(path string, id uint) ([]*Link, error)
 	Save(s *Link) error
 	Delete(hash string) error
-	DeleteWithPath(path string) error
+	DeleteWithPath(path string)
 }
 
 // Storage is a storage.
@@ -120,6 +120,6 @@ func (s *Storage) Delete(hash string) error {
 	return s.back.Delete(hash)
 }
 
-func (s *Storage) DeleteWithPath(path string) error {
-	return s.back.DeleteWithPath(path)
+func (s *Storage) DeleteWithPath(path string) {
+	s.back.DeleteWithPath(path)
 }

--- a/share/storage.go
+++ b/share/storage.go
@@ -15,7 +15,7 @@ type StorageBackend interface {
 	Gets(path string, id uint) ([]*Link, error)
 	Save(s *Link) error
 	Delete(hash string) error
-	DeleteWithPath(path string)
+	DeleteWithPathPrefix(path string)
 }
 
 // Storage is a storage.
@@ -120,6 +120,6 @@ func (s *Storage) Delete(hash string) error {
 	return s.back.Delete(hash)
 }
 
-func (s *Storage) DeleteWithPath(path string) {
-	s.back.DeleteWithPath(path)
+func (s *Storage) DeleteWithPathPrefix(path string) {
+	s.back.DeleteWithPathPrefix(path)
 }

--- a/storage/bolt/share.go
+++ b/storage/bolt/share.go
@@ -76,10 +76,10 @@ func (s shareBackend) Delete(hash string) error {
 	return err
 }
 
-func (s shareBackend) DeleteWithPath(path string) error {
-	err := s.db.Select(q.Eq("Path", path)).Delete(&share.Link{})
-	if errors.Is(err, storm.ErrNotFound) {
-		return nil
+func (s shareBackend) DeleteWithPath(pathPrefix string) {
+	var links []share.Link
+	s.db.Prefix("Path", pathPrefix, &links)
+	for _, link :=range links {
+		s.db.DeleteStruct(&share.Link{Hash: link.Hash})
 	}
-	return err
 }

--- a/storage/bolt/share.go
+++ b/storage/bolt/share.go
@@ -76,10 +76,16 @@ func (s shareBackend) Delete(hash string) error {
 	return err
 }
 
-func (s shareBackend) DeleteWithPathPrefix(pathPrefix string) {
+func (s shareBackend) DeleteWithPathPrefix(pathPrefix string) error {
 	var links []share.Link
 	s.db.Prefix("Path", pathPrefix, &links)
-	for _, link := range links {
-		s.db.DeleteStruct(&share.Link{Hash: link.Hash})
+	if err := s.db.Prefix("Path", pathPrefix, &links); err != nil {
+		return err
 	}
+
+	var err error
+	for _, link := range links {
+		err = errors.Join(err, s.db.DeleteStruct(&share.Link{Hash: link.Hash}))
+	}
+	return err
 }

--- a/storage/bolt/share.go
+++ b/storage/bolt/share.go
@@ -75,3 +75,11 @@ func (s shareBackend) Delete(hash string) error {
 	}
 	return err
 }
+
+func (s shareBackend) DeleteWithPath(path string) error {
+	err := s.db.Select(q.Eq("Path", path)).Delete(&share.Link{})
+	if errors.Is(err, storm.ErrNotFound) {
+		return nil
+	}
+	return err
+}

--- a/storage/bolt/share.go
+++ b/storage/bolt/share.go
@@ -78,7 +78,6 @@ func (s shareBackend) Delete(hash string) error {
 
 func (s shareBackend) DeleteWithPathPrefix(pathPrefix string) error {
 	var links []share.Link
-	s.db.Prefix("Path", pathPrefix, &links)
 	if err := s.db.Prefix("Path", pathPrefix, &links); err != nil {
 		return err
 	}

--- a/storage/bolt/share.go
+++ b/storage/bolt/share.go
@@ -76,10 +76,10 @@ func (s shareBackend) Delete(hash string) error {
 	return err
 }
 
-func (s shareBackend) DeleteWithPath(pathPrefix string) {
+func (s shareBackend) DeleteWithPathPrefix(pathPrefix string) {
 	var links []share.Link
 	s.db.Prefix("Path", pathPrefix, &links)
-	for _, link :=range links {
+	for _, link := range links {
 		s.db.DeleteStruct(&share.Link{Hash: link.Hash})
 	}
 }


### PR DESCRIPTION
**Description**
When deleting a folder or a file, remove all shares associated with the file, or, if it is a folder, every file and folder beneath it.

:rotating_light: Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] DO make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] DO make sure you are making a pull request against the **master branch** (left side). Also you should start *your branch* off *our master*.
- [x] DO make sure that File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
- [ ] AVOID breaking the continuous integration build.

**Further comments**
This is my first time writing go code so please let me know if I did something wrong!
