### PR TITLE
fix: search uses ctrl+shift+f instead of hijacking browser's ctrl+f

### DIFF
--- a/frontend/src/views/files/FileListing.vue
+++ b/frontend/src/views/files/FileListing.vue
@@ -511,8 +511,11 @@ const keyEvent = (event: KeyboardEvent) => {
 
   switch (event.key) {
     case "f":
-      event.preventDefault();
-      layoutStore.showHover("search");
+    case "F":
+      if (event.shiftKey) {
+        event.preventDefault();
+        layoutStore.showHover("search");
+      }
       break;
     case "c":
     case "x":


### PR DESCRIPTION
fixes issue https://github.com/filebrowser/filebrowser/issues/2850

Since there is no configuration for key bindings, it should be ok just to replace Ctrl+F with Ctrl+Shift+F in code.
The latter doesn't conflict with native browser hot keys