### PR TITLE
fix: Update search hotkey in help prompt to CTRL+SHIFT+F

### DIFF
--- a/frontend/src/components/prompts/Help.vue
+++ b/frontend/src/components/prompts/Help.vue
@@ -11,7 +11,7 @@
         <li><strong>DEL</strong> - {{ $t("help.del") }}</li>
         <li><strong>ESC</strong> - {{ $t("help.esc") }}</li>
         <li><strong>CTRL + S</strong> - {{ $t("help.ctrl.s") }}</li>
-        <li><strong>CTRL + F</strong> - {{ $t("help.ctrl.f") }}</li>
+        <li><strong>CTRL + SHIFT + F</strong> - {{ $t("help.ctrl.f") }}</li>
         <li><strong>CTRL + Click</strong> - {{ $t("help.ctrl.click") }}</li>
         <li><strong>Click</strong> - {{ $t("help.click") }}</li>
         <li><strong>Double click</strong> - {{ $t("help.doubleClick") }}</li>


### PR DESCRIPTION
## Description

Since #4638 changed the hotkey for searching from Ctrl+F to Ctrl+Shift+F, it would make sense to also change this in the help pop-up.

![image](https://github.com/user-attachments/assets/1158ef48-097f-4fc4-b566-4e1c46b2374e)

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
