### PR TITLE
fix: do not expose the name of the root directory

### DIFF
--- a/files/file.go
+++ b/files/file.go
@@ -88,7 +88,7 @@ func NewFileInfo(opts *FileOptions) (*FileInfo, error) {
 
 	// Do not expose the name of root directory.
 	if file.Path == "/" {
-		file.Name = "/"
+		file.Name = ""
 	}
 
 	if opts.Expand {

--- a/files/file.go
+++ b/files/file.go
@@ -86,6 +86,11 @@ func NewFileInfo(opts *FileOptions) (*FileInfo, error) {
 		return nil, err
 	}
 
+	// Do not expose the name of root directory.
+	if file.Path == "/" {
+		file.Name = "/"
+	}
+
 	if opts.Expand {
 		if file.IsDir {
 			if err := file.readListing(opts.Checker, opts.ReadHeader); err != nil { //nolint:govet

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -150,7 +150,7 @@ const fetchData = async () => {
     }
 
     fileStore.updateRequest(res);
-    document.title = `${res.name} - ${t("files.files")} - ${name}`;
+    document.title = `${res.name || t("sidebar.myFiles")} - ${t("files.files")} - ${name}`;
   } catch (err) {
     if (err instanceof Error) {
       error.value = err;


### PR DESCRIPTION
This fixes #3794, by always setting the name of the "root directory" to "/".