### PR TITLE
fix: Move folder can be moved into itself causing an error

### DIFF
--- a/frontend/src/components/prompts/FileList.vue
+++ b/frontend/src/components/prompts/FileList.vue
@@ -35,6 +35,12 @@ import { StatusError } from "@/api/utils.js";
 
 export default {
   name: "file-list",
+  props: {
+    exclude: {
+      type: Array,
+      default: () => [],
+    },
+  },
   data: function () {
     return {
       items: [],
@@ -90,6 +96,7 @@ export default {
       // move options.
       for (const item of req.items) {
         if (!item.isDir) continue;
+        if (this.exclude?.includes(item.url)) continue;
 
         this.items.push({
           name: item.name,

--- a/frontend/src/components/prompts/Move.vue
+++ b/frontend/src/components/prompts/Move.vue
@@ -8,6 +8,7 @@
       <file-list
         ref="fileList"
         @update:selected="(val) => (dest = val)"
+        :exclude="excludedFolders"
         tabindex="1"
       />
     </div>
@@ -76,6 +77,11 @@ export default {
   computed: {
     ...mapState(useFileStore, ["req", "selected"]),
     ...mapState(useAuthStore, ["user"]),
+    excludedFolders() {
+      return this.selected
+        .filter((idx) => this.req.items[idx].isDir)
+        .map((idx) => this.req.items[idx].url);
+    },
   },
   methods: {
     ...mapActions(useLayoutStore, ["showHover", "closeHovers"]),


### PR DESCRIPTION
## Description

Exclude the to-be-moved folder from the move dialog.

fixes #3892 

## Checklist

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
