### PR TITLE
fix: lookup directory name if blank when downloading shared directory

### DIFF
--- a/http/raw.go
+++ b/http/raw.go
@@ -182,9 +182,10 @@ func rawDirHandler(w http.ResponseWriter, r *http.Request, d *data, file *files.
 			name = file.Name
 		} else {
 			// This should indicate that the fs root is the directory being downloaded, lookup its name
-			actual, err := file.Fs.Stat(".")
-			if err != nil {
-				return http.StatusInternalServerError, err
+
+			actual, statErr := file.Fs.Stat(".")
+			if statErr != nil {
+				return http.StatusInternalServerError, statErr
 			}
 			name = actual.Name()
 		}

--- a/http/raw.go
+++ b/http/raw.go
@@ -177,7 +177,17 @@ func rawDirHandler(w http.ResponseWriter, r *http.Request, d *data, file *files.
 
 	name := filepath.Base(commonDir)
 	if name == "." || name == "" || name == string(filepath.Separator) {
-		name = file.Name
+		// Not sure when/if this will ever be true, though kept incase there is an edge-case where it is
+		if file.Name != "" {
+			name = file.Name
+		} else {
+			// This should indicate that the fs root is the directory being downloaded, lookup its name
+			actual, err := file.Fs.Stat(".")
+			if err != nil {
+				return http.StatusInternalServerError, err
+			}
+			name = actual.Name()
+		}
 	}
 	// Prefix used to distinguish a filelist generated
 	// archive from the full directory archive


### PR DESCRIPTION
## Description

When downloading a shared directory, the fileinfo was being overwritten to where the directory in question would become the new fs root.  This lead to file.Name = "" and file.Path = "/", hence the bug of downloading a file with the name ".zip" ("" + ".zip").  This has been fixed by doing an fs.Stat(".") to get the current directories name under the circumstances where file.Name is empty.  

## Checklist

closes #5255

- [X] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [X] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [X] I am making a PR against the `master` branch.
- [X] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
