### PR TITLE
feat: prevent page change if there are outstanding edits

### DIFF
--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -53,7 +53,7 @@ import { getTheme } from "@/utils/theme";
 import { marked } from "marked";
 import { inject, onBeforeUnmount, onMounted, ref, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
-import { useRoute, useRouter } from "vue-router";
+import { onBeforeRouteUpdate, useRoute, useRouter } from "vue-router";
 
 const $showError = inject<IToastError>("$showError")!;
 
@@ -129,6 +129,15 @@ onBeforeUnmount(() => {
   window.removeEventListener("wheel", handleScroll);
   window.removeEventListener("beforeunload", handlePageChange);
   editor.value?.destroy();
+});
+
+onBeforeRouteUpdate((to, from, next) => {
+  if (!editor.value?.session.getUndoManager().isClean()) {
+    layoutStore.showHover("discardEditorChanges");
+    next(false);
+  } else {
+    next();
+  }
 });
 
 const keyEvent = (event: KeyboardEvent) => {

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -39,21 +39,21 @@ import { files as api } from "@/api";
 import buttons from "@/utils/buttons";
 import url from "@/utils/url";
 import ace, { Ace, version as ace_version } from "ace-builds";
-import modelist from "ace-builds/src-noconflict/ext-modelist";
 import "ace-builds/src-noconflict/ext-language_tools";
+import modelist from "ace-builds/src-noconflict/ext-modelist";
 import DOMPurify from "dompurify";
 
-import HeaderBar from "@/components/header/HeaderBar.vue";
-import Action from "@/components/header/Action.vue";
 import Breadcrumbs from "@/components/Breadcrumbs.vue";
+import Action from "@/components/header/Action.vue";
+import HeaderBar from "@/components/header/HeaderBar.vue";
 import { useAuthStore } from "@/stores/auth";
 import { useFileStore } from "@/stores/file";
 import { useLayoutStore } from "@/stores/layout";
-import { inject, onBeforeUnmount, onMounted, ref, watchEffect } from "vue";
-import { useRoute, useRouter } from "vue-router";
-import { useI18n } from "vue-i18n";
 import { getTheme } from "@/utils/theme";
 import { marked } from "marked";
+import { inject, onBeforeUnmount, onMounted, ref, watchEffect } from "vue";
+import { useI18n } from "vue-i18n";
+import { useRoute, useRouter } from "vue-router";
 
 const $showError = inject<IToastError>("$showError")!;
 
@@ -77,6 +77,7 @@ const isMarkdownFile =
 onMounted(() => {
   window.addEventListener("keydown", keyEvent);
   window.addEventListener("wheel", handleScroll);
+  window.addEventListener("beforeunload", handlePageChange);
 
   const fileContent = fileStore.req?.content || "";
 
@@ -126,6 +127,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
   window.removeEventListener("keydown", keyEvent);
   window.removeEventListener("wheel", handleScroll);
+  window.removeEventListener("beforeunload", handlePageChange);
   editor.value?.destroy();
 });
 
@@ -150,6 +152,15 @@ const handleScroll = (event: WheelEvent) => {
   const editorContainer = document.getElementById("preview-container");
   if (editorContainer) {
     editorContainer.scrollTop += event.deltaY;
+  }
+};
+
+const handlePageChange = (event: BeforeUnloadEvent) => {
+  if (!editor.value?.session.getUndoManager().isClean()) {
+    event.preventDefault();
+    // returnValue is now depecrated, though keeping in for legacy browser support
+    // https://developer.mozilla.org/en-US/docs/Web/API/BeforeUnloadEvent/returnValue
+    event.returnValue = true;
   }
 };
 


### PR DESCRIPTION
## Description

Addresses the linked issue - adds an event listener on the file editor that triggers the browser default "unsaved changes" confirmation dialog if the user tries to exit or refresh the page while there are outstanding unsaved changes to a file.

`event.returnValue` is now deprecated, though kept to ensure legacy browser support.  Inline comment and link to documentation included.  

## Checklist

closes #2038

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
