### PR TITLE
fix: Upload progress size calculation

### DIFF
--- a/frontend/src/stores/upload.ts
+++ b/frontend/src/stores/upload.ts
@@ -74,7 +74,12 @@ export const useUploadStore = defineStore("upload", {
       if (state.progress.length === 0 || state.sizes.length === 0) {
         return "0 Bytes";
       }
-      const sum = state.progress.reduce((acc, val) => +acc + +val, 0) as number;
+      const sum = state.progress.reduce(
+        (sum, p, i) =>
+          (sum as number) +
+          (typeof p === "number" ? p : p ? state.sizes[i] : 0),
+        0
+      ) as number;
       return formatSize(sum);
     },
     getTotalSize: (state) => {


### PR DESCRIPTION
## Description
PR fixes the logic of `getTotalProgressBytes` to consider the completed items which in turn fixes most of the calucations in upload dialog like ETA, Progress % and So on.

## Proof of Testing 
https://github.com/user-attachments/assets/92677639-5a96-4173-b7b6-ea733bf6ac93

 
## Additional Information
closes #5262 

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
