### PR TITLE
fix: Move and Copy file conflict check race condition

### DIFF
--- a/frontend/src/components/prompts/Copy.vue
+++ b/frontend/src/components/prompts/Copy.vue
@@ -80,7 +80,7 @@ export default {
   },
   methods: {
     ...mapActions(useLayoutStore, ["showHover", "closeHovers"]),
-    copy: async function (event) {
+    copy: function (event) {
       event.preventDefault();
       const items = [];
 
@@ -122,29 +122,29 @@ export default {
         return;
       }
 
-      const dstItems = (await api.fetch(this.dest)).items;
-      const conflict = upload.checkConflict(items, dstItems);
-
       let overwrite = false;
       let rename = false;
 
-      if (conflict) {
-        this.showHover({
-          prompt: "replace-rename",
-          confirm: (event, option) => {
-            overwrite = option == "overwrite";
-            rename = option == "rename";
+      api.fetch(this.dest).then((dst) => {
+        const conflict = upload.checkConflict(items, dst.items);
+        if (conflict) {
+          this.showHover({
+            prompt: "replace-rename",
+            confirm: (event, option) => {
+              overwrite = option == "overwrite";
+              rename = option == "rename";
 
-            event.preventDefault();
-            this.closeHovers();
-            action(overwrite, rename);
-          },
-        });
+              event.preventDefault();
+              this.closeHovers();
+              action(overwrite, rename);
+            },
+          });
 
-        return;
-      }
+          return;
+        }
 
-      action(overwrite, rename);
+        action(overwrite, rename);
+      });
     },
   },
 };

--- a/frontend/src/components/prompts/Move.vue
+++ b/frontend/src/components/prompts/Move.vue
@@ -85,7 +85,7 @@ export default {
   },
   methods: {
     ...mapActions(useLayoutStore, ["showHover", "closeHovers"]),
-    move: async function (event) {
+    move: function (event) {
       event.preventDefault();
       const items = [];
 
@@ -112,29 +112,29 @@ export default {
           });
       };
 
-      const dstItems = (await api.fetch(this.dest)).items;
-      const conflict = upload.checkConflict(items, dstItems);
-
       let overwrite = false;
       let rename = false;
 
-      if (conflict) {
-        this.showHover({
-          prompt: "replace-rename",
-          confirm: (event, option) => {
-            overwrite = option == "overwrite";
-            rename = option == "rename";
+      api.fetch(this.dest).then((dst) => {
+        const conflict = upload.checkConflict(items, dst.items);
+        if (conflict) {
+          this.showHover({
+            prompt: "replace-rename",
+            confirm: (event, option) => {
+              overwrite = option == "overwrite";
+              rename = option == "rename";
 
-            event.preventDefault();
-            this.closeHovers();
-            action(overwrite, rename);
-          },
-        });
+              event.preventDefault();
+              this.closeHovers();
+              action(overwrite, rename);
+            },
+          });
 
-        return;
-      }
+          return;
+        }
 
-      action(overwrite, rename);
+        action(overwrite, rename);
+      });
     },
   },
 };


### PR DESCRIPTION
## Description

This PR introduces a fix for race condition that happens in move or copy file conflict check by converting the check function to promised based. this also makes the async flow more explicit.

##Proof of Testing

https://github.com/user-attachments/assets/bcdc5d0e-b995-44d4-96de-7ceaa5233bcf

## Additional Information
I have tested this by adding console log and the `upload.checkConflict` sometimes returns false. then this conflict popup is not shown and replace method is used to copy / Move the file.

if i add console.log before `upload.checkConflict` then the race condition is not at all reporducible.

Closes #3312 

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
