### PR TITLE
feat: Improve Docker entrypoint and config handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ VOLUME /srv /config /database
 
 EXPOSE 80
 
-ENTRYPOINT [ "tini", "--", "/init.sh", "filebrowser", "--config", "/config/settings.json" ]
+ENTRYPOINT [ "tini", "--", "/init.sh" ]

--- a/docker/alpine/init.sh
+++ b/docker/alpine/init.sh
@@ -11,7 +11,7 @@ fi
 has_config_arg=0
 for arg in "$@"; do
   case "$arg" in
-  --config=*)
+  --config|--config=*|-c|-c=*)
     has_config_arg=1
     break
     ;;

--- a/docker/alpine/init.sh
+++ b/docker/alpine/init.sh
@@ -7,4 +7,19 @@ if [ ! -f "/config/settings.json" ]; then
   cp -a /defaults/settings.json /config/settings.json
 fi
 
-exec "$@"
+# Deal with the case where user does not provide a config argument
+has_config_arg=0
+for arg in "$@"; do
+  case "$arg" in
+  --config=*)
+    has_config_arg=1
+    break
+    ;;
+  esac
+done
+
+if [ "$has_config_arg" -eq 0 ]; then
+  set -- --config=/config/settings.json "$@"
+fi
+
+exec filebrowser "$@"


### PR DESCRIPTION
## Description

- Simplify Dockerfile ENTRYPOINT to delegate config handling to init.sh.
- Enhance init.sh to automatically add `--config=/config/settings.json` if no config argument is provided.

## Additional Information

This would enable container user to set configfile via --config arg.

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
