### PR TITLE
build: improve docker image and binary sizes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -85,6 +85,8 @@ jobs:
           node-version: "22.x"
           cache: "pnpm"
           cache-dependency-path: "frontend/pnpm-lock.yaml"
+      - name: Install upx
+        run: sudo apt-get install -y upx
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,17 @@ archives:
       - goos: windows
         formats: ["zip"]
 
+upx:
+  - enabled: true
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    compress: "best"
+    lzma: true
+
 dockers:
   # Alpine docker images
   - dockerfile: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.22
 
 RUN apk update && \
-  apk --no-cache add ca-certificates mailcap curl jq tini
+  apk --no-cache add ca-certificates mailcap jq tini
 
 # Make user and create necessary directories
 ENV UID=1000

--- a/Dockerfile.s6
+++ b/Dockerfile.s6
@@ -1,7 +1,7 @@
 FROM ghcr.io/linuxserver/baseimage-alpine:3.22
 
 RUN apk update && \
-  apk --no-cache add ca-certificates mailcap curl jq
+  apk --no-cache add ca-certificates mailcap jq
 
 # Make user and create necessary directories
 RUN mkdir -p /config /database /srv && \

--- a/docker/common/healthcheck.sh
+++ b/docker/common/healthcheck.sh
@@ -6,4 +6,4 @@ PORT=${FB_PORT:-$(jq -r .port /config/settings.json)}
 ADDRESS=${FB_ADDRESS:-$(jq -r .address /config/settings.json)}
 ADDRESS=${ADDRESS:-localhost}
 
-curl -f http://$ADDRESS:$PORT/health || exit 1
+wget -q --spider http://$ADDRESS:$PORT/health || exit 1


### PR DESCRIPTION
## Description

This PR introduces improvements to docker release build sizes.
Improvements that help in achieving small docker sizes are
1. using upx to shrink the binary size of filebrowser
2. removing curl command from health check and using wget which is included in alpine image

the final docker build file using these above steps is 27.2 MB compared to initial 69.6MB
<img width="633" height="147" alt="image" src="https://github.com/user-attachments/assets/681ecf5f-439d-4c77-a388-0af50f5f5114" />



## Additional Information

closes #5215 
removing `jq` gives only benifit of 1.3 MB and I felt like its not work the effort to replicate what `jq` is doing with sed or `grep`

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
