### PR TITLE
fix: Upload progress percentile calculation

### DIFF
--- a/frontend/src/stores/upload.ts
+++ b/frontend/src/stores/upload.ts
@@ -55,8 +55,12 @@ export const useUploadStore = defineStore("upload", {
 
       const totalSize = state.sizes.reduce((a, b) => a + b, 0);
 
-      // TODO: this looks ugly but it works with ts now
-      const sum = state.progress.reduce((acc, val) => +acc + +val) as number;
+      const sum = state.progress.reduce(
+        (sum, p, i) =>
+          (sum as number) +
+          (typeof p === "number" ? p : p ? state.sizes[i] : 0),
+        0
+      ) as number;
       return Math.ceil((sum / totalSize) * 100);
     },
     getProgressDecimal: (state) => {
@@ -66,8 +70,12 @@ export const useUploadStore = defineStore("upload", {
 
       const totalSize = state.sizes.reduce((a, b) => a + b, 0);
 
-      // TODO: this looks ugly but it works with ts now
-      const sum = state.progress.reduce((acc, val) => +acc + +val) as number;
+      const sum = state.progress.reduce(
+        (sum, p, i) =>
+          (sum as number) +
+          (typeof p === "number" ? p : p ? state.sizes[i] : 0),
+        0
+      ) as number;
       return ((sum / totalSize) * 100).toFixed(2);
     },
     getTotalProgressBytes: (state) => {


### PR DESCRIPTION
## Description

PR fixes the logic of `getProgressDecimal` and `getProgress` to consider the completed items which in turn fixes most of the calucations in Progress %. I taught my previous PR #5267 handled this but noticed its not.


## Additional Information

adds fixes on top of #5267 

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
