### PR TITLE
fix: Only left click should drag the image in extended image view

### DIFF
--- a/frontend/src/components/files/ExtendedImage.vue
+++ b/frontend/src/components/files/ExtendedImage.vue
@@ -172,7 +172,8 @@ const setCenter = () => {
   imgex.value.style.top = position.value.center.y + "px";
 };
 
-const mousedownStart = (event: Event) => {
+const mousedownStart = (event: MouseEvent) => {
+  if (event.button !== 0) return;
   lastX.value = null;
   lastY.value = null;
   inDrag.value = true;
@@ -184,8 +185,10 @@ const mouseMove = (event: MouseEvent) => {
   event.preventDefault();
 };
 const mouseUp = (event: Event) => {
+  if (inDrag.value) {
+    event.preventDefault();
+  }
   inDrag.value = false;
-  event.preventDefault();
 };
 const touchStart = (event: TouchEvent) => {
   lastX.value = null;


### PR DESCRIPTION
## Description

This PR introduces a fix where in extended image view only left click should drag the image. without this fix all the button including the thumb keys are draging the image.

## Additional Information

Closes #5248

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
