### PR TITLE
feat: Add font size botton to text editor

### DIFF
--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -5,6 +5,18 @@
       <title>{{ fileStore.req?.name ?? "" }}</title>
 
       <action
+        icon="add"
+        @action="increaseFontSize"
+        :label="t('buttons.increaseFontSize')"
+      />
+      <span class="editor-font-size">{{ fontSize }}px</span>
+      <action
+        icon="remove"
+        @action="decreaseFontSize"
+        :label="t('buttons.decreaseFontSize')"
+      />
+
+      <action
         v-if="authStore.user?.perm.modify"
         id="save-button"
         icon="save"
@@ -67,6 +79,7 @@ const route = useRoute();
 const router = useRouter();
 
 const editor = ref<Ace.Editor | null>(null);
+const fontSize = ref(parseInt(localStorage.getItem("editorFontSize") || "14"));
 
 const isPreview = ref(false);
 const previewContent = ref("");
@@ -121,6 +134,7 @@ onMounted(() => {
     editor.value!.setTheme("ace/theme/twilight");
   }
 
+  editor.value.setFontSize(fontSize.value);
   editor.value.focus();
 });
 
@@ -186,6 +200,21 @@ const save = async () => {
     $showError(e);
   }
 };
+
+const increaseFontSize = () => {
+  fontSize.value += 1;
+  editor.value?.setFontSize(fontSize.value);
+  localStorage.setItem("editorFontSize", fontSize.value.toString());
+};
+
+const decreaseFontSize = () => {
+  if (fontSize.value > 1) {
+    fontSize.value -= 1;
+    editor.value?.setFontSize(fontSize.value);
+    localStorage.setItem("editorFontSize", fontSize.value.toString());
+  }
+};
+
 const close = () => {
   if (!editor.value?.session.getUndoManager().isClean()) {
     layoutStore.showHover("discardEditorChanges");
@@ -202,3 +231,10 @@ const preview = () => {
   isPreview.value = !isPreview.value;
 };
 </script>
+
+<style scoped>
+.editor-font-size {
+  margin: 0 0.5em;
+  color: var(--fg);
+}
+</style>


### PR DESCRIPTION
## Description

For quickly changing front size in editor.

<img width="1080" height="706" alt="图片" src="https://github.com/user-attachments/assets/22dbbbaa-6aae-4ea3-923a-d7d1711512a5" />

## Additional Information

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
