### PR TITLE
fix: ln command fail workaround for read-only container 

### DIFF
--- a/docker/alpine/healthcheck.sh
+++ b/docker/alpine/healthcheck.sh
@@ -2,8 +2,13 @@
 
 set -e
 
-PORT=${FB_PORT:-$(cat /tmp/FB_CONFIG | sh /JSON.sh | grep '\["port"\]' | awk '{print $2}')}
-ADDRESS=${FB_ADDRESS:-$(cat /tmp/FB_CONFIG | sh /JSON.sh | grep '\["address"\]' | awk '{print $2}' | sed 's/"//g')}
+CONFIG_FILE="/tmp/FB_CONFIG"
+if [ ! -f "/tmp/FB_CONFIG" ]; then
+  CONFIG_FILE="/config/settings.json"
+fi
+
+PORT=${FB_PORT:-$(cat $CONFIG_FILE | sh /JSON.sh | grep '\["port"\]' | awk '{print $2}')}
+ADDRESS=${FB_ADDRESS:-$(cat $CONFIG_FILE | sh /JSON.sh | grep '\["address"\]' | awk '{print $2}' | sed 's/"//g')}
 ADDRESS=${ADDRESS:-localhost}
 
 wget -q --spider http://$ADDRESS:$PORT/health || exit 1

--- a/docker/alpine/init.sh
+++ b/docker/alpine/init.sh
@@ -33,6 +33,6 @@ if [ -z "$config_file" ]; then
 fi                                                                                                                                                                                                                                                                                                                                                             
 
 # Create a symlink to the config file for compatibility with the healthcheck script
-ln -s "$config_file" /tmp/FB_CONFIG
+ln -s "$config_file" /tmp/FB_CONFIG || true
 
 exec filebrowser "$@"


### PR DESCRIPTION
## Description

https://github.com/filebrowser/filebrowser/issues/5289

I'm sorry that I overlooked the possibility of read-only container. 
I couldn’t find a way to pass the config argument to the healthcheck script in a read-only container, so I ensure the ln command always exits successfully.

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
