### PR TITLE
fix: invalid path when uploading files

### DIFF
--- a/frontend/src/api/tus.ts
+++ b/frontend/src/api/tus.ts
@@ -1,5 +1,5 @@
 import * as tus from "tus-js-client";
-import { baseURL, tusEndpoint, tusSettings } from "@/utils/constants";
+import { baseURL, tusEndpoint, tusSettings, origin } from "@/utils/constants";
 import { useAuthStore } from "@/stores/auth";
 import { useUploadStore } from "@/stores/upload";
 import { removePrefix } from "@/api/utils";
@@ -35,7 +35,7 @@ export async function upload(
   }
   return new Promise<void | string>((resolve, reject) => {
     const upload = new tus.Upload(content, {
-      endpoint: `${baseURL}${resourcePath}`,
+      endpoint: `${origin}${baseURL}${resourcePath}`,
       chunkSize: tusSettings.chunkSize,
       retryDelays: computeRetryDelays(tusSettings),
       parallelUploads: 1,

--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -147,7 +147,8 @@ func tusPostHandler() handleFunc {
 		// Enables the user to utilize the PATCH endpoint for uploading file data
 		registerUpload(file.RealPath(), uploadLength)
 
-		w.Header().Set("Location", "/api/tus/"+r.URL.Path)
+		// Signal the frontend to reuse the current request URL
+		w.Header().Set("Location", "")
 
 		return http.StatusCreated, nil
 	})


### PR DESCRIPTION
Trying to upload a file to an instance running on Windows — or when baseurl is configured — results in errors and empty files. This issue stems from the `tusPostHandler`, which uses an absolute path for the Location header. Unfortunately, the `tus-js-client` library doens't handle absolute paths properly and causes the request url to have an additional slash:
```
http://localhost:8080/api/tus//example/file.jpg
```
While Linux handles that without issues, Windows returns an error:
```
404 127.0.0.1 lstat //example/file.jpg: file does not exist
```
Additionally, the baseurl configuration was being ignored, leading to further problems. The introduced changes will ensure that the upload url is now properly constructed and follows the expected format:
```
http://localhost:8080/baseurl/api/tus/example/file.jpg
```