### PR TITLE
fix: Location header on TUS endpoint

### DIFF
--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -147,8 +148,12 @@ func tusPostHandler() handleFunc {
 		// Enables the user to utilize the PATCH endpoint for uploading file data
 		registerUpload(file.RealPath(), uploadLength)
 
-		w.Header().Set("Location", "/api/tus"+r.URL.Path)
+		path, err := url.JoinPath("/", d.server.BaseURL, "/api/tus", r.URL.Path)
+		if err != nil {
+			return http.StatusBadRequest, fmt.Errorf("invalid path: %w", err)
+		}
 
+		w.Header().Set("Location", path)
 		return http.StatusCreated, nil
 	})
 }

--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -147,8 +147,7 @@ func tusPostHandler() handleFunc {
 		// Enables the user to utilize the PATCH endpoint for uploading file data
 		registerUpload(file.RealPath(), uploadLength)
 
-		// Signal the frontend to reuse the current request URL
-		w.Header().Set("Location", "")
+		w.Header().Set("Location", "/api/tus"+r.URL.Path)
 
 		return http.StatusCreated, nil
 	})


### PR DESCRIPTION
I think this should correctly fix the issue with the uploads creating empty files described in https://github.com/filebrowser/filebrowser/discussions/5299.

On https://github.com/filebrowser/filebrowser/pull/5292, we changed the `Location` header to an empty string because there was a double slash in the path. However, that was because we were concatenating `/api/path/` (with slash) with `r.URL.Path` which is prefixed with the slash.