### PR TITLE
feat: Allow file and directory creation modes to be configured

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -49,6 +49,10 @@ func addConfigFlags(flags *pflag.FlagSet) {
 	flags.String("branding.files", "", "path to directory with images and custom styles")
 	flags.Bool("branding.disableExternal", false, "disable external links such as GitHub links")
 	flags.Bool("branding.disableUsedPercentage", false, "disable used disk percentage graph")
+	// NB: these are string so they can be presented as octal in the help text
+	// as that's the conventional representation for modes in Unix.
+	flags.String("file-mode", fmt.Sprintf("%O", settings.DefaultFileMode), "Mode bits that new files are created with")
+	flags.String("dir-mode", fmt.Sprintf("%O", settings.DefaultDirMode), "Mode bits that new directories are created with")
 }
 
 //nolint:gocyclo
@@ -170,6 +174,8 @@ func printSettings(ser *settings.Server, set *settings.Settings, auther auth.Aut
 	fmt.Fprintf(w, "\tLocale:\t%s\n", set.Defaults.Locale)
 	fmt.Fprintf(w, "\tView mode:\t%s\n", set.Defaults.ViewMode)
 	fmt.Fprintf(w, "\tSingle Click:\t%t\n", set.Defaults.SingleClick)
+	fmt.Fprintf(w, "\tFile Creation Mode:\t%O\n", set.FileMode)
+	fmt.Fprintf(w, "\tDirectory Creation Mode:\t%O\n", set.DirMode)
 	fmt.Fprintf(w, "\tCommands:\t%s\n", strings.Join(set.Defaults.Commands, " "))
 	fmt.Fprintf(w, "\tSorting:\n")
 	fmt.Fprintf(w, "\t\tBy:\t%s\n", set.Defaults.Sorting.By)

--- a/cmd/config_init.go
+++ b/cmd/config_init.go
@@ -43,6 +43,8 @@ override the options.`,
 				Theme:                 mustGetString(flags, "branding.theme"),
 				Files:                 mustGetString(flags, "branding.files"),
 			},
+			FileMode: mustGetMode(flags, "file-mode"),
+			DirMode:  mustGetMode(flags, "dir-mode"),
 		}
 
 		ser := &settings.Server{

--- a/cmd/config_set.go
+++ b/cmd/config_set.go
@@ -65,6 +65,10 @@ you want to change. Other options will remain unchanged.`,
 				set.Branding.DisableUsedPercentage = mustGetBool(flags, flag.Name)
 			case "branding.files":
 				set.Branding.Files = mustGetString(flags, flag.Name)
+			case "file-mode":
+				set.FileMode = mustGetMode(flags, flag.Name)
+			case "dir-mode":
+				set.DirMode = mustGetMode(flags, flag.Name)
 			}
 		})
 

--- a/files/file.go
+++ b/files/file.go
@@ -27,9 +27,6 @@ import (
 	"github.com/filebrowser/filebrowser/v2/rules"
 )
 
-const PermFile = 0640
-const PermDir = 0750
-
 var (
 	reSubDirs = regexp.MustCompile("(?i)^sub(s|titles)$")
 	reSubExts = regexp.MustCompile("(?i)(.vtt|.srt|.ass|.ssa)$")

--- a/fileutils/copy.go
+++ b/fileutils/copy.go
@@ -1,6 +1,7 @@
 package fileutils
 
 import (
+	"io/fs"
 	"os"
 	"path"
 
@@ -8,7 +9,7 @@ import (
 )
 
 // Copy copies a file or folder from one place to another.
-func Copy(fs afero.Fs, src, dst string) error {
+func Copy(afs afero.Fs, src, dst string, fileMode, dirMode fs.FileMode) error {
 	if src = path.Clean("/" + src); src == "" {
 		return os.ErrNotExist
 	}
@@ -26,14 +27,14 @@ func Copy(fs afero.Fs, src, dst string) error {
 		return os.ErrInvalid
 	}
 
-	info, err := fs.Stat(src)
+	info, err := afs.Stat(src)
 	if err != nil {
 		return err
 	}
 
 	if info.IsDir() {
-		return CopyDir(fs, src, dst)
+		return CopyDir(afs, src, dst, fileMode, dirMode)
 	}
 
-	return CopyFile(fs, src, dst)
+	return CopyFile(afs, src, dst, fileMode, dirMode)
 }

--- a/fileutils/dir.go
+++ b/fileutils/dir.go
@@ -2,6 +2,7 @@ package fileutils
 
 import (
 	"errors"
+	"io/fs"
 
 	"github.com/spf13/afero"
 )
@@ -9,20 +10,20 @@ import (
 // CopyDir copies a directory from source to dest and all
 // of its sub-directories. It doesn't stop if it finds an error
 // during the copy. Returns an error if any.
-func CopyDir(fs afero.Fs, source, dest string) error {
+func CopyDir(afs afero.Fs, source, dest string, fileMode, dirMode fs.FileMode) error {
 	// Get properties of source.
-	srcinfo, err := fs.Stat(source)
+	srcinfo, err := afs.Stat(source)
 	if err != nil {
 		return err
 	}
 
 	// Create the destination directory.
-	err = fs.MkdirAll(dest, srcinfo.Mode())
+	err = afs.MkdirAll(dest, srcinfo.Mode())
 	if err != nil {
 		return err
 	}
 
-	dir, _ := fs.Open(source)
+	dir, _ := afs.Open(source)
 	obs, err := dir.Readdir(-1)
 	if err != nil {
 		return err
@@ -36,13 +37,13 @@ func CopyDir(fs afero.Fs, source, dest string) error {
 
 		if obj.IsDir() {
 			// Create sub-directories, recursively.
-			err = CopyDir(fs, fsource, fdest)
+			err = CopyDir(afs, fsource, fdest, fileMode, dirMode)
 			if err != nil {
 				errs = append(errs, err)
 			}
 		} else {
 			// Perform the file copy.
-			err = CopyFile(fs, fsource, fdest)
+			err = CopyFile(afs, fsource, fdest, fileMode, dirMode)
 			if err != nil {
 				errs = append(errs, err)
 			}

--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -92,7 +92,7 @@ func tusPostHandler() handleFunc {
 		case errors.Is(err, afero.ErrFileNotFound):
 			dirPath := filepath.Dir(r.URL.Path)
 			if _, statErr := d.user.Fs.Stat(dirPath); os.IsNotExist(statErr) {
-				if mkdirErr := d.user.Fs.MkdirAll(dirPath, files.PermDir); mkdirErr != nil {
+				if mkdirErr := d.user.Fs.MkdirAll(dirPath, d.settings.DirMode); mkdirErr != nil {
 					return http.StatusInternalServerError, err
 				}
 			}
@@ -121,7 +121,7 @@ func tusPostHandler() handleFunc {
 			fileFlags |= os.O_TRUNC
 		}
 
-		openFile, err := d.user.Fs.OpenFile(r.URL.Path, fileFlags, files.PermFile)
+		openFile, err := d.user.Fs.OpenFile(r.URL.Path, fileFlags, d.settings.FileMode)
 		if err != nil {
 			return errToStatus(err), err
 		}
@@ -239,7 +239,7 @@ func tusPatchHandler() handleFunc {
 			)
 		}
 
-		openFile, err := d.user.Fs.OpenFile(r.URL.Path, os.O_WRONLY|os.O_APPEND, files.PermFile)
+		openFile, err := d.user.Fs.OpenFile(r.URL.Path, os.O_WRONLY|os.O_APPEND, d.settings.FileMode)
 		if err != nil {
 			return http.StatusInternalServerError, fmt.Errorf("could not open file: %w", err)
 		}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"crypto/rand"
+	"io/fs"
 	"log"
 	"strings"
 	"time"
@@ -11,6 +12,8 @@ import (
 
 const DefaultUsersHomeBasePath = "/users"
 const DefaultMinimumPasswordLength = 12
+const DefaultFileMode = 0640
+const DefaultDirMode = 0750
 
 // AuthMethod describes an authentication method.
 type AuthMethod string
@@ -29,6 +32,8 @@ type Settings struct {
 	Shell                 []string            `json:"shell"`
 	Rules                 []rules.Rule        `json:"rules"`
 	MinimumPasswordLength uint                `json:"minimumPasswordLength"`
+	FileMode              fs.FileMode         `json:"fileMode"`
+	DirMode               fs.FileMode         `json:"dirMode"`
 }
 
 // GetRules implements rules.Provider.

--- a/settings/storage.go
+++ b/settings/storage.go
@@ -42,6 +42,12 @@ func (s *Storage) Get() (*Settings, error) {
 			RetryCount: DefaultTusRetryCount,
 		}
 	}
+	if set.FileMode == 0 {
+		set.FileMode = DefaultFileMode
+	}
+	if set.DirMode == 0 {
+		set.DirMode = DefaultDirMode
+	}
 	return set, nil
 }
 


### PR DESCRIPTION

The defaults remain the same as before.
For now, the config options are global instead of per-user.
Note also that the BoltDB creation maintains the old default mode of 0640
since it's not really a user-facing filesystem manipulation.
Fixes #5316, #5200
