### PR TITLE
build: bump go version to 1.23.11

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.0
+          go-version: 1.23.11
       - run: make lint-backend
   lint:
     runs-on: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.0
+          go-version: 1.23.11
       - run: make test-backend
   test:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.0
+          go-version: 1.23.11
       - uses: pnpm/action-setup@v4
         with:
           package_json_file: "frontend/package.json"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/filebrowser/filebrowser/v2
 
-go 1.23.0
+go 1.23.11
 
 require (
 	github.com/asdine/storm/v3 v3.2.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/filebrowser/filebrowser/v2/tools
 
-go 1.23.0
+go 1.23.11
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.1.6


### PR DESCRIPTION
## Description

Bump Go version to v1.23.11.

Resolves some CVEs picked up by various security scanners.

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
