### PR TITLE
refactor: upload progress calculation

### DIFF
--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -13,7 +13,7 @@ export default async function search(base: string, query: string) {
 
   let data = await res.json();
 
-  data = data.map((item: UploadItem) => {
+  data = data.map((item: ResourceItem & { dir: boolean }) => {
     item.url = `/files${base}` + url.encodePath(item.path);
 
     if (item.dir) {

--- a/frontend/src/api/tus.ts
+++ b/frontend/src/api/tus.ts
@@ -1,17 +1,11 @@
 import * as tus from "tus-js-client";
 import { baseURL, tusEndpoint, tusSettings, origin } from "@/utils/constants";
 import { useAuthStore } from "@/stores/auth";
-import { useUploadStore } from "@/stores/upload";
 import { removePrefix } from "@/api/utils";
 
 const RETRY_BASE_DELAY = 1000;
 const RETRY_MAX_DELAY = 20000;
-const SPEED_UPDATE_INTERVAL = 1000;
-const ALPHA = 0.2;
-const ONE_MINUS_ALPHA = 1 - ALPHA;
-const RECENT_SPEEDS_LIMIT = 5;
-const MB_DIVISOR = 1024 * 1024;
-const CURRENT_UPLOAD_LIST: CurrentUploadList = {};
+const CURRENT_UPLOAD_LIST: { [key: string]: tus.Upload } = {};
 
 export async function upload(
   filePath: string,
@@ -56,9 +50,6 @@ export async function upload(
         return true;
       },
       onError: function (error: Error | tus.DetailedError) {
-        if (CURRENT_UPLOAD_LIST[filePath].interval) {
-          clearInterval(CURRENT_UPLOAD_LIST[filePath].interval);
-        }
         delete CURRENT_UPLOAD_LIST[filePath];
 
         const message =
@@ -73,40 +64,16 @@ export async function upload(
         reject(new Error(message));
       },
       onProgress: function (bytesUploaded) {
-        const fileData = CURRENT_UPLOAD_LIST[filePath];
-        fileData.currentBytesUploaded = bytesUploaded;
-
-        if (!fileData.hasStarted) {
-          fileData.hasStarted = true;
-          fileData.lastProgressTimestamp = Date.now();
-
-          fileData.interval = window.setInterval(() => {
-            calcProgress(filePath);
-          }, SPEED_UPDATE_INTERVAL);
-        }
         if (typeof onupload === "function") {
           onupload({ loaded: bytesUploaded });
         }
       },
       onSuccess: function () {
-        if (CURRENT_UPLOAD_LIST[filePath].interval) {
-          clearInterval(CURRENT_UPLOAD_LIST[filePath].interval);
-        }
         delete CURRENT_UPLOAD_LIST[filePath];
         resolve();
       },
     });
-    CURRENT_UPLOAD_LIST[filePath] = {
-      upload: upload,
-      recentSpeeds: [],
-      initialBytesUploaded: 0,
-      currentBytesUploaded: 0,
-      currentAverageSpeed: 0,
-      lastProgressTimestamp: null,
-      sumOfRecentSpeeds: 0,
-      hasStarted: false,
-      interval: undefined,
-    };
+    CURRENT_UPLOAD_LIST[filePath] = upload;
     upload.start();
   });
 }
@@ -138,76 +105,11 @@ function isTusSupported() {
   return tus.isSupported === true;
 }
 
-function computeETA(speed?: number) {
-  const state = useUploadStore();
-  if (state.speedMbyte === 0) {
-    return Infinity;
-  }
-  const totalSize = state.sizes.reduce(
-    (acc: number, size: number) => acc + size,
-    0
-  );
-  const uploadedSize = state.progress.reduce((a, b) => a + b, 0);
-  const remainingSize = totalSize - uploadedSize;
-  const speedBytesPerSecond = (speed ?? state.speedMbyte) * 1024 * 1024;
-  return remainingSize / speedBytesPerSecond;
-}
-
-function computeGlobalSpeedAndETA() {
-  let totalSpeed = 0;
-  let totalCount = 0;
-
-  for (const filePath in CURRENT_UPLOAD_LIST) {
-    totalSpeed += CURRENT_UPLOAD_LIST[filePath].currentAverageSpeed;
-    totalCount++;
-  }
-
-  if (totalCount === 0) return { speed: 0, eta: Infinity };
-
-  const averageSpeed = totalSpeed / totalCount;
-  const averageETA = computeETA(averageSpeed);
-
-  return { speed: averageSpeed, eta: averageETA };
-}
-
-function calcProgress(filePath: string) {
-  const uploadStore = useUploadStore();
-  const fileData = CURRENT_UPLOAD_LIST[filePath];
-
-  const elapsedTime =
-    (Date.now() - (fileData.lastProgressTimestamp ?? 0)) / 1000;
-  const bytesSinceLastUpdate =
-    fileData.currentBytesUploaded - fileData.initialBytesUploaded;
-  const currentSpeed = bytesSinceLastUpdate / MB_DIVISOR / elapsedTime;
-
-  if (fileData.recentSpeeds.length >= RECENT_SPEEDS_LIMIT) {
-    fileData.sumOfRecentSpeeds -= fileData.recentSpeeds.shift() ?? 0;
-  }
-
-  fileData.recentSpeeds.push(currentSpeed);
-  fileData.sumOfRecentSpeeds += currentSpeed;
-
-  const avgRecentSpeed =
-    fileData.sumOfRecentSpeeds / fileData.recentSpeeds.length;
-  fileData.currentAverageSpeed =
-    ALPHA * avgRecentSpeed + ONE_MINUS_ALPHA * fileData.currentAverageSpeed;
-
-  const { speed, eta } = computeGlobalSpeedAndETA();
-  uploadStore.setUploadSpeed(speed);
-  uploadStore.setETA(eta);
-
-  fileData.initialBytesUploaded = fileData.currentBytesUploaded;
-  fileData.lastProgressTimestamp = Date.now();
-}
-
 export function abortAllUploads() {
   for (const filePath in CURRENT_UPLOAD_LIST) {
-    if (CURRENT_UPLOAD_LIST[filePath].interval) {
-      clearInterval(CURRENT_UPLOAD_LIST[filePath].interval);
-    }
-    if (CURRENT_UPLOAD_LIST[filePath].upload) {
-      CURRENT_UPLOAD_LIST[filePath].upload.abort(true);
-      CURRENT_UPLOAD_LIST[filePath].upload.options!.onError!(
+    if (CURRENT_UPLOAD_LIST[filePath]) {
+      CURRENT_UPLOAD_LIST[filePath].abort(true);
+      CURRENT_UPLOAD_LIST[filePath].options!.onError!(
         new Error("Upload aborted")
       );
     }

--- a/frontend/src/api/tus.ts
+++ b/frontend/src/api/tus.ts
@@ -52,6 +52,10 @@ export async function upload(
       onError: function (error: Error | tus.DetailedError) {
         delete CURRENT_UPLOAD_LIST[filePath];
 
+        if (error.message === "Upload aborted") {
+          return reject(error);
+        }
+
         const message =
           error instanceof tus.DetailedError
             ? error.originalResponse === null

--- a/frontend/src/components/prompts/UploadFiles.vue
+++ b/frontend/src/components/prompts/UploadFiles.vue
@@ -14,12 +14,10 @@
         <div class="upload-info">
           <div class="upload-speed">{{ speed.toFixed(2) }} MB/s</div>
           <div class="upload-eta">{{ formattedETA }} remaining</div>
-          <div class="upload-percentage">
-            {{ uploadStore.getProgressDecimal }}% Completed
-          </div>
+          <div class="upload-percentage">{{ sentPercent }}% Completed</div>
           <div class="upload-fraction">
-            {{ uploadStore.getTotalProgressBytes }} /
-            {{ uploadStore.getTotalSize }}
+            {{ sentMbytes }} /
+            {{ totalMbytes }}
           </div>
         </div>
         <button
@@ -75,6 +73,7 @@ import { computed, ref, watch } from "vue";
 import { abortAllUploads } from "@/api/tus";
 import buttons from "@/utils/buttons";
 import { useI18n } from "vue-i18n";
+import { partial } from "filesize";
 
 const { t } = useI18n({});
 
@@ -86,6 +85,16 @@ const fileStore = useFileStore();
 const uploadStore = useUploadStore();
 
 const { sentBytes } = storeToRefs(uploadStore);
+
+const byteToMbyte = partial({ exponent: 2 });
+
+const sentPercent = computed(() =>
+  ((uploadStore.sentBytes / uploadStore.totalBytes) * 100).toFixed(2)
+);
+
+const sentMbytes = computed(() => byteToMbyte(uploadStore.sentBytes));
+
+const totalMbytes = computed(() => byteToMbyte(uploadStore.totalBytes));
 
 let lastSpeedUpdate: number = 0;
 const recentSpeeds: number[] = [];

--- a/frontend/src/components/prompts/UploadFiles.vue
+++ b/frontend/src/components/prompts/UploadFiles.vue
@@ -93,15 +93,14 @@ const sentPercent = computed(() =>
 );
 
 const sentMbytes = computed(() => byteToMbyte(uploadStore.sentBytes));
-
 const totalMbytes = computed(() => byteToMbyte(uploadStore.totalBytes));
-
 const speedMbytes = computed(() => byteToMbyte(speed.value));
 
 let lastSpeedUpdate: number = 0;
 let recentSpeeds: number[] = [];
 
 const calculateSpeed = (sentBytes: number, oldSentBytes: number) => {
+  // Reset the state when the uploads batch is complete
   if (sentBytes === 0) {
     lastSpeedUpdate = 0;
     recentSpeeds = [];
@@ -124,11 +123,12 @@ const calculateSpeed = (sentBytes: number, oldSentBytes: number) => {
   const recentSpeedsAverage =
     recentSpeeds.reduce((acc, curr) => acc + curr) / recentSpeeds.length;
 
+  // Use the current speed for the first update to avoid smoothing lag
   if (recentSpeeds.length === 1) {
-    speed.value = recentSpeedsAverage;
-  } else {
-    speed.value = recentSpeedsAverage * 0.2 + speed.value * 0.8;
+    speed.value = currentSpeed;
   }
+
+  speed.value = recentSpeedsAverage * 0.2 + speed.value * 0.8;
 
   lastSpeedUpdate = Date.now();
 
@@ -151,10 +151,11 @@ const calculateEta = () => {
 watch(sentBytes, calculateSpeed);
 
 watch(totalBytes, (totalBytes, oldTotalBytes) => {
-  if (oldTotalBytes > 0) {
+  if (oldTotalBytes !== 0) {
     return;
   }
 
+  // Mark the start time of a new upload batch
   lastSpeedUpdate = Date.now();
 });
 

--- a/frontend/src/components/prompts/UploadFiles.vue
+++ b/frontend/src/components/prompts/UploadFiles.vue
@@ -12,7 +12,7 @@
           }}
         </h2>
         <div class="upload-info">
-          <div class="upload-speed">{{ speed.toFixed(2) }} MB/s</div>
+          <div class="upload-speed">{{ speedMbytes }}/s</div>
           <div class="upload-eta">{{ formattedETA }} remaining</div>
           <div class="upload-percentage">{{ sentPercent }}% Completed</div>
           <div class="upload-fraction">
@@ -96,13 +96,15 @@ const sentMbytes = computed(() => byteToMbyte(uploadStore.sentBytes));
 
 const totalMbytes = computed(() => byteToMbyte(uploadStore.totalBytes));
 
+const speedMbytes = computed(() => byteToMbyte(speed.value));
+
 let lastSpeedUpdate: number = 0;
 const recentSpeeds: number[] = [];
 
 const calculateSpeed = (sentBytes: number, oldSentBytes: number) => {
   const elapsedTime = (Date.now() - (lastSpeedUpdate ?? 0)) / 1000;
   const bytesSinceLastUpdate = sentBytes - oldSentBytes;
-  const currentSpeed = bytesSinceLastUpdate / (1024 * 1024) / elapsedTime;
+  const currentSpeed = bytesSinceLastUpdate / elapsedTime;
 
   recentSpeeds.push(currentSpeed);
   if (recentSpeeds.length > 5) {
@@ -126,7 +128,7 @@ const calculateEta = () => {
   }
 
   const remainingSize = uploadStore.totalBytes - uploadStore.sentBytes;
-  const speedBytesPerSecond = speed.value * 1024 * 1024;
+  const speedBytesPerSecond = speed.value;
 
   eta.value = remainingSize / speedBytesPerSecond;
 };

--- a/frontend/src/components/prompts/UploadFiles.vue
+++ b/frontend/src/components/prompts/UploadFiles.vue
@@ -8,7 +8,9 @@
       <div class="card-title">
         <h2>
           {{
-            $t("prompts.uploadFiles", { files: uploadStore.activeUploads.size })
+            $t("prompts.uploadFiles", {
+              files: uploadStore.pendingUploadCount,
+            })
           }}
         </h2>
         <div class="upload-info">

--- a/frontend/src/components/prompts/UploadFiles.vue
+++ b/frontend/src/components/prompts/UploadFiles.vue
@@ -70,7 +70,6 @@ import { useFileStore } from "@/stores/file";
 import { useUploadStore } from "@/stores/upload";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
-import { abortAllUploads } from "@/api/tus";
 import buttons from "@/utils/buttons";
 import { useI18n } from "vue-i18n";
 import { partial } from "filesize";
@@ -181,10 +180,9 @@ const toggle = () => {
 
 const abortAll = () => {
   if (confirm(t("upload.abortUpload"))) {
-    abortAllUploads();
     buttons.done("upload");
     open.value = false;
-    uploadStore.reset(); // Resetting the upload store state
+    uploadStore.abort();
     fileStore.reload = true; // Trigger reload in the file store
   }
 };

--- a/frontend/src/stores/upload.ts
+++ b/frontend/src/stores/upload.ts
@@ -51,7 +51,7 @@ export const useUploadStore = defineStore("upload", () => {
       file,
       overwrite,
       type,
-      totalBytes: file?.size ?? 0,
+      totalBytes: file?.size || 1,
       sentBytes: 0,
       // Stores rapidly changing sent bytes value without causing component re-renders
       rawProgress: markRaw({

--- a/frontend/src/stores/upload.ts
+++ b/frontend/src/stores/upload.ts
@@ -33,8 +33,6 @@ export const useUploadStore = defineStore("upload", {
     progress: number[];
     queue: UploadItem[];
     uploads: Uploads;
-    speedMbyte: number;
-    eta: number;
     error: Error | null;
   } => ({
     id: 0,
@@ -42,8 +40,6 @@ export const useUploadStore = defineStore("upload", {
     progress: [],
     queue: [],
     uploads: {},
-    speedMbyte: 0,
-    eta: 0,
     error: null,
   }),
   getters: {
@@ -73,12 +69,18 @@ export const useUploadStore = defineStore("upload", {
       const sum = state.progress.reduce((a, b) => a + b, 0);
       return formatSize(sum);
     },
+    getTotalProgress: (state) => {
+      return state.progress.reduce((a, b) => a + b, 0);
+    },
     getTotalSize: (state) => {
       if (state.sizes.length === 0) {
         return "0 Bytes";
       }
       const totalSize = state.sizes.reduce((a, b) => a + b, 0);
       return formatSize(totalSize);
+    },
+    getTotalBytes: (state) => {
+      return state.sizes.reduce((a, b) => a + b, 0);
     },
     filesInUploadCount: (state) => {
       return Object.keys(state.uploads).length + state.queue.length;
@@ -108,10 +110,6 @@ export const useUploadStore = defineStore("upload", {
 
       return files.sort((a, b) => a.progress - b.progress);
     },
-    uploadSpeed: (state) => {
-      return state.speedMbyte;
-    },
-    getETA: (state) => state.eta,
   },
   actions: {
     // no context as first argument, use `this` instead
@@ -127,8 +125,6 @@ export const useUploadStore = defineStore("upload", {
       this.progress = [];
       this.queue = [];
       this.uploads = {};
-      this.speedMbyte = 0;
-      this.eta = 0;
       this.error = null;
     },
     addJob(item: UploadItem) {
@@ -205,12 +201,6 @@ export const useUploadStore = defineStore("upload", {
 
         this.finishUpload(item);
       }
-    },
-    setUploadSpeed(value: number) {
-      this.speedMbyte = value;
-    },
-    setETA(value: number) {
-      this.eta = value;
     },
     // easily reset state using `$reset`
     clearUpload() {

--- a/frontend/src/stores/upload.ts
+++ b/frontend/src/stores/upload.ts
@@ -3,7 +3,7 @@ import { useFileStore } from "./file";
 import { files as api } from "@/api";
 import { throttle } from "lodash-es";
 import buttons from "@/utils/buttons";
-import { computed, inject, ref } from "vue";
+import { inject, ref } from "vue";
 
 // TODO: make this into a user setting
 const UPLOADS_LIMIT = 5;
@@ -13,18 +13,6 @@ const beforeUnload = (event: Event) => {
   // To remove >> is deprecated
   // event.returnValue = "";
 };
-
-// Utility function to format bytes into a readable string
-function formatSize(bytes: number): string {
-  if (bytes === 0) return "0.00 Bytes";
-
-  const k = 1024;
-  const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-
-  // Return the rounded size with two decimal places
-  return (bytes / k ** i).toFixed(2) + " " + sizes[i];
-}
 
 export const useUploadStore = defineStore("upload", () => {
   const $showError = inject<IToastError>("$showError")!;
@@ -38,26 +26,6 @@ export const useUploadStore = defineStore("upload", () => {
   const lastUpload = ref<number>(-1);
   const totalBytes = ref<number>(0);
   const sentBytes = ref<number>(0);
-
-  //
-  // GETTERS
-  //
-
-  const getProgress = computed(() => {
-    return Math.ceil((sentBytes.value / totalBytes.value) * 100);
-  });
-
-  const getProgressDecimal = computed(() => {
-    return ((sentBytes.value / totalBytes.value) * 100).toFixed(2);
-  });
-
-  const getTotalProgressBytes = computed(() => {
-    return formatSize(sentBytes.value);
-  });
-
-  const getTotalSize = computed(() => {
-    return formatSize(totalBytes.value);
-  });
 
   //
   // ACTIONS
@@ -165,12 +133,6 @@ export const useUploadStore = defineStore("upload", () => {
     lastUpload,
     totalBytes,
     sentBytes,
-
-    // GETTERS
-    getProgress,
-    getProgressDecimal,
-    getTotalProgressBytes,
-    getTotalSize,
 
     // ACTIONS
     reset,

--- a/frontend/src/stores/upload.ts
+++ b/frontend/src/stores/upload.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import { useFileStore } from "./file";
 import { files as api } from "@/api";
 import buttons from "@/utils/buttons";
-import { inject, markRaw, ref } from "vue";
+import { computed, inject, markRaw, ref } from "vue";
 import * as tus from "@/api/tus";
 
 // TODO: make this into a user setting
@@ -70,6 +70,17 @@ export const useUploadStore = defineStore("upload", () => {
     lastUpload.value = Infinity;
     tus.abortAllUploads();
   };
+
+  //
+  // GETTERS
+  //
+
+  const pendingUploadCount = computed(
+    () =>
+      allUploads.value.length -
+      (lastUpload.value + 1) +
+      activeUploads.value.size
+  );
 
   //
   // PRIVATE FUNCTIONS
@@ -162,5 +173,8 @@ export const useUploadStore = defineStore("upload", () => {
     // ACTIONS
     upload,
     abort,
+
+    // GETTERS
+    pendingUploadCount,
   };
 });

--- a/frontend/src/stores/upload.ts
+++ b/frontend/src/stores/upload.ts
@@ -3,6 +3,7 @@ import { useFileStore } from "./file";
 import { files as api } from "@/api";
 import buttons from "@/utils/buttons";
 import { inject, markRaw, ref } from "vue";
+import * as tus from "@/api/tus";
 
 // TODO: make this into a user setting
 const UPLOADS_LIMIT = 5;
@@ -64,6 +65,12 @@ export const useUploadStore = defineStore("upload", () => {
     processUploads();
   };
 
+  const abort = () => {
+    // Resets the state by preventing the processing of the remaning uploads
+    lastUpload.value = Infinity;
+    tus.abortAllUploads();
+  };
+
   //
   // PRIVATE FUNCTIONS
   //
@@ -101,7 +108,7 @@ export const useUploadStore = defineStore("upload", () => {
 
         await api
           .post(upload.path, upload.file!, upload.overwrite, onUpload)
-          .catch($showError);
+          .catch((err) => err.message !== "Upload aborted" && $showError(err));
       }
 
       finishUpload(upload);
@@ -154,5 +161,6 @@ export const useUploadStore = defineStore("upload", () => {
 
     // ACTIONS
     upload,
+    abort,
   };
 });

--- a/frontend/src/types/file.d.ts
+++ b/frontend/src/types/file.d.ts
@@ -29,6 +29,7 @@ interface ResourceItem extends ResourceBase {
 }
 
 type ResourceType =
+  | "dir"
   | "video"
   | "audio"
   | "image"

--- a/frontend/src/types/upload.d.ts
+++ b/frontend/src/types/upload.d.ts
@@ -27,17 +27,3 @@ interface UploadEntry {
 }
 
 type UploadList = UploadEntry[];
-
-type CurrentUploadList = {
-  [key: string]: {
-    upload: import("tus-js-client").Upload;
-    recentSpeeds: number[];
-    initialBytesUploaded: number;
-    currentBytesUploaded: number;
-    currentAverageSpeed: number;
-    lastProgressTimestamp: number | null;
-    sumOfRecentSpeeds: number;
-    hasStarted: boolean;
-    interval: number | undefined;
-  };
-};

--- a/frontend/src/types/upload.d.ts
+++ b/frontend/src/types/upload.d.ts
@@ -6,6 +6,9 @@ type Upload = {
   overwrite: boolean;
   totalBytes: number;
   sentBytes: number;
+  rawProgress: {
+    sentBytes: number;
+  };
 };
 
 interface UploadEntry {

--- a/frontend/src/types/upload.d.ts
+++ b/frontend/src/types/upload.d.ts
@@ -1,22 +1,12 @@
-interface Uploads {
-  [key: number]: Upload;
-}
-
-interface Upload {
-  id: number;
-  file: UploadEntry;
-  type?: ResourceType;
-}
-
-interface UploadItem {
-  id: number;
-  url?: string;
+type Upload = {
   path: string;
-  file: UploadEntry;
-  dir?: boolean;
-  overwrite?: boolean;
-  type?: ResourceType;
-}
+  name: string;
+  file: File | null;
+  type: ResourceType;
+  overwrite: boolean;
+  totalBytes: number;
+  sentBytes: number;
+};
 
 interface UploadEntry {
   name: string;

--- a/frontend/src/utils/upload.ts
+++ b/frontend/src/utils/upload.ts
@@ -132,7 +132,6 @@ export function handleFiles(
   layoutStore.closeHovers();
 
   for (const file of files) {
-    const id = uploadStore.id;
     let path = base;
 
     if (file.fullPath !== undefined) {
@@ -145,14 +144,8 @@ export function handleFiles(
       path += "/";
     }
 
-    const item: UploadItem = {
-      id,
-      path,
-      file,
-      overwrite,
-      ...(!file.isDir && { type: detectType((file.file as File).type) }),
-    };
+    const type = file.isDir ? "dir" : detectType((file.file as File).type);
 
-    uploadStore.upload(item);
+    uploadStore.upload(path, file.name, file.file ?? null, overwrite, type);
   }
 }

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -26,7 +26,6 @@
 import {
   computed,
   defineAsyncComponent,
-  inject,
   onBeforeUnmount,
   onMounted,
   onUnmounted,
@@ -37,7 +36,6 @@ import { files as api } from "@/api";
 import { storeToRefs } from "pinia";
 import { useFileStore } from "@/stores/file";
 import { useLayoutStore } from "@/stores/layout";
-import { useUploadStore } from "@/stores/upload";
 
 import HeaderBar from "@/components/header/HeaderBar.vue";
 import Breadcrumbs from "@/components/Breadcrumbs.vue";
@@ -51,14 +49,10 @@ import { name } from "../utils/constants";
 const Editor = defineAsyncComponent(() => import("@/views/files/Editor.vue"));
 const Preview = defineAsyncComponent(() => import("@/views/files/Preview.vue"));
 
-const $showError = inject<IToastError>("$showError")!;
-
 const layoutStore = useLayoutStore();
 const fileStore = useFileStore();
-const uploadStore = useUploadStore();
 
 const { reload } = storeToRefs(fileStore);
-const { error: uploadError } = storeToRefs(uploadStore);
 
 const route = useRoute();
 
@@ -110,9 +104,6 @@ watch(route, () => {
 });
 watch(reload, (newValue) => {
   newValue && fetchData();
-});
-watch(uploadError, (newValue) => {
-  newValue && $showError(newValue);
 });
 
 // Define functions

--- a/frontend/src/views/Layout.vue
+++ b/frontend/src/views/Layout.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
-    <div v-if="uploadStore.getProgress" class="progress">
-      <div v-bind:style="{ width: uploadStore.getProgress + '%' }"></div>
+    <div v-if="uploadStore.totalBytes" class="progress">
+      <div
+        v-bind:style="{
+          width: sentPercent + '%',
+        }"
+      ></div>
     </div>
     <sidebar></sidebar>
     <main>
@@ -27,7 +31,7 @@ import Prompts from "@/components/prompts/Prompts.vue";
 import Shell from "@/components/Shell.vue";
 import UploadFiles from "@/components/prompts/UploadFiles.vue";
 import { enableExec } from "@/utils/constants";
-import { watch } from "vue";
+import { computed, watch } from "vue";
 import { useRoute } from "vue-router";
 
 const layoutStore = useLayoutStore();
@@ -35,6 +39,10 @@ const authStore = useAuthStore();
 const fileStore = useFileStore();
 const uploadStore = useUploadStore();
 const route = useRoute();
+
+const sentPercent = computed(() =>
+  ((uploadStore.sentBytes / uploadStore.totalBytes) * 100).toFixed(2)
+);
 
 watch(route, () => {
   fileStore.selected = [];

--- a/frontend/tsconfig.tsc.json
+++ b/frontend/tsconfig.tsc.json
@@ -9,7 +9,6 @@
     "src/components/prompts/Delete.vue",
     "src/components/prompts/FileList.vue",
     "src/components/prompts/Rename.vue",
-    "src/components/prompts/Share.vue",
-    "src/components/prompts/UploadFiles.vue"
+    "src/components/prompts/Share.vue"
   ]
 }


### PR DESCRIPTION
## Description

Refactored and simplified the speed calculation logic by calculating speed and ETA once using the total uploaded bytes instead of per file. The upload store was also streamlined into a leaner setup-style implementation with private helpers, a simplified data structure, and a unified TypeScript type for uploads. Some logic was moved to components to keep the store holding only data and logic that is shared. Upload progress updates now occur on a fixed 1-second interval to ensure consistent refresh rates. Additionally, some fixes were addressed: starting speed from the first measured value instead of zero for accurate initial reporting, suppressing error notifications for aborted uploads, and counting empty files or folders as 1 byte so their progress is properly tracked.

fixes #5339

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
