### PR TITLE
feat: Add missing CLI flags for user management

### DIFF
--- a/cmd/users.go
+++ b/cmd/users.go
@@ -77,6 +77,8 @@ func addUserFlags(flags *pflag.FlagSet) {
 	flags.String("locale", "en", "locale for users")
 	flags.String("viewMode", string(users.ListViewMode), "view mode for users")
 	flags.Bool("singleClick", false, "use single clicks only")
+	flags.Bool("dateFormat", false, "use date format (true for absolute time, false for relative)")
+	flags.Bool("hideDotfiles", false, "hide dotfiles")
 }
 
 func getViewMode(flags *pflag.FlagSet) (users.ViewMode, error) {

--- a/cmd/users_add.go
+++ b/cmd/users_add.go
@@ -36,10 +36,22 @@ var usersAddCmd = &cobra.Command{
 			return err
 		}
 
+		dateFormat, err := getBool(cmd.Flags(), "dateFormat")
+		if err != nil {
+			return err
+		}
+
+		hideDotfiles, err := getBool(cmd.Flags(), "hideDotfiles")
+		if err != nil {
+			return err
+		}
+
 		user := &users.User{
 			Username:     args[0],
 			Password:     password,
 			LockPassword: lockPassword,
+			DateFormat:   dateFormat,
+			HideDotfiles: hideDotfiles,
 		}
 
 		s.Defaults.Apply(user)

--- a/cmd/users_update.go
+++ b/cmd/users_update.go
@@ -76,6 +76,14 @@ options you want to change.`,
 		if err != nil {
 			return err
 		}
+		user.DateFormat, err = getBool(flags, "dateFormat")
+		if err != nil {
+			return err
+		}
+		user.HideDotfiles, err = getBool(flags, "hideDotfiles")
+		if err != nil {
+			return err
+		}
 
 		if newUsername != "" {
 			user.Username = newUsername


### PR DESCRIPTION
Add support for --dateFormat and --hideDotfiles flags in user management commands.

These fields already exist in the User struct but were not exposed via CLI:
- --dateFormat: Controls time display format (absolute vs relative)
- --hideDotfiles: Controls visibility of dotfiles

This allows administrators to set these preferences directly via CLI when creating or updating users, instead of requiring manual database manipulation.

fix #5355 