### PR TITLE
fix: Enable long press selection on mobile for all modes

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -225,7 +225,10 @@ const itemClick = (event: Event | KeyboardEvent) => {
   // If long press was triggered, prevent normal click behavior
   if (longPressTriggered.value) {
     longPressTriggered.value = false;
-    return;
+    // In non-singleClick mode, long press should only select, not open
+    if (!singleClick.value) {
+      return;
+    }
   }
 
   if (
@@ -318,10 +321,10 @@ const cancelLongPress = () => {
 };
 
 const handleLongPress = () => {
-  if (singleClick.value) {
-    longPressTriggered.value = true;
-    click(new Event("longpress"));
-  }
+  // Allow long press to select items regardless of singleClick mode
+  // This is essential for mobile devices where right-click is not available
+  longPressTriggered.value = true;
+  click(new Event("longpress"));
   cancelLongPress();
 };
 


### PR DESCRIPTION

## Description
Previously, long press to select files only worked in singleClick mode, making it impossible to select files on mobile devices in normal mode where right-click is not available.

This fix enables long press selection regardless of singleClick setting, which is essential for mobile usability.

Changes:
- Remove singleClick condition from handleLongPress
- Properly handle long press in itemClick for both modes

<!-- Please explain the changes you made here. -->

## Additional Information
fix #5355 

<!-- If it is a relatively large or complex change, please add more information to explain what you did, how you did it, if you considered any alternatives, etc. -->

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [ ] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [ ] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [ ] I am making a PR against the `master` branch.
- [ ] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
