### PR TITLE
feat: Restore direct download link

### DIFF
--- a/frontend/src/components/prompts/Share.vue
+++ b/frontend/src/components/prompts/Share.vue
@@ -32,7 +32,7 @@
                 <i class="material-icons">content_paste</i>
               </button>
             </td>
-            <td class="small" v-if="hasDownloadLink()">
+            <td class="small" v-if="hasDownloadLink(link)">
               <button
                 class="action copy-clipboard"
                 :aria-label="$t('buttons.copyDownloadLinkToClipboard')"
@@ -257,10 +257,11 @@ export default {
     buildLink(share) {
       return api.getShareURL(share);
     },
-    hasDownloadLink() {
-      return (
-        this.selectedCount === 1 && !this.req.items[this.selected[0]].isDir
-      );
+    hasDownloadLink(link) {
+      // Only show direct download link for single files without password protection
+      const isSingleFile = this.selectedCount === 1 && !this.req.items[this.selected[0]].isDir;
+      const hasNoPassword = !link.password_hash || link.password_hash === "";
+      return isSingleFile && hasNoPassword;
     },
     buildDownloadLink(share) {
       return pubApi.getDownloadURL(share);

--- a/frontend/src/components/prompts/Share.vue
+++ b/frontend/src/components/prompts/Share.vue
@@ -32,6 +32,16 @@
                 <i class="material-icons">content_paste</i>
               </button>
             </td>
+            <td class="small" v-if="hasDownloadLink()">
+              <button
+                class="action copy-clipboard"
+                :aria-label="$t('buttons.copyDownloadLinkToClipboard')"
+                :title="$t('buttons.copyDownloadLinkToClipboard')"
+                @click="copyToClipboard(buildDownloadLink(link))"
+              >
+                <i class="material-icons">content_paste_go</i>
+              </button>
+            </td>
             <td class="small">
               <button
                 class="action"
@@ -132,7 +142,7 @@
 <script>
 import { mapActions, mapState } from "pinia";
 import { useFileStore } from "@/stores/file";
-import { share as api } from "@/api";
+import { share as api, pub as pubApi } from "@/api";
 import dayjs from "dayjs";
 import { useLayoutStore } from "@/stores/layout";
 import { copy } from "@/utils/clipboard";
@@ -246,6 +256,14 @@ export default {
     },
     buildLink(share) {
       return api.getShareURL(share);
+    },
+    hasDownloadLink() {
+      return (
+        this.selectedCount === 1 && !this.req.items[this.selected[0]].isDir
+      );
+    },
+    buildDownloadLink(share) {
+      return pubApi.getDownloadURL(share);
     },
     sort() {
       this.links = this.links.sort((a, b) => {

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -27,6 +27,7 @@ interface Share {
   userID?: number;
   token?: string;
   username?: string;
+  password_hash?: string;
 }
 
 interface SearchParams {


### PR DESCRIPTION
## Description

#5355 
Restore the function of sharing direct links, but retain password protection. Only non-password links will have a public direct link button.

## Checklist
Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
