### PR TITLE
fix: "new folder" button not working in the move and copy popup

### DIFF
--- a/frontend/src/components/prompts/FileList.vue
+++ b/frontend/src/components/prompts/FileList.vue
@@ -25,9 +25,10 @@
 </template>
 
 <script>
-import { mapState } from "pinia";
+import { mapState, mapActions } from "pinia";
 import { useAuthStore } from "@/stores/auth";
 import { useFileStore } from "@/stores/file";
+import { useLayoutStore } from "@/stores/layout";
 
 import url from "@/utils/url";
 import { files } from "@/api";
@@ -68,6 +69,7 @@ export default {
     this.abortOngoingNext();
   },
   methods: {
+    ...mapActions(useLayoutStore, ["showHover"]),
     abortOngoingNext() {
       this.nextAbortController.abort();
     },
@@ -163,7 +165,7 @@ export default {
       this.$emit("update:selected", this.selected);
     },
     createDir: async function () {
-      this.$store.commit("showHover", {
+      this.showHover({
         prompt: "newDir",
         action: null,
         confirm: null,


### PR DESCRIPTION
## Description

In the `createDir` method of the FileList component, it's using the old Vuex store syntax (`this.$store.commit`) instead of the new Pinia store syntax that the rest of the application is using.

Looking at the other components, they use Pinia with `mapActions` from `useLayoutStore` to access `showHover`.

This PR introduces the Fix for "New Folder" button not working in the copy / Move Hover


## Additional Information

Closes #5354 

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
