### PR TITLE
fix: optimize markdown preview height

### DIFF
--- a/frontend/src/css/mdPreview.css
+++ b/frontend/src/css/mdPreview.css
@@ -1,6 +1,4 @@
 .md_preview {
-  overflow-y: auto;
-  max-height: 80vh;
   padding: 1rem;
   border: 1px solid #000;
   font-size: 20px;
@@ -9,6 +7,5 @@
 
 #preview-container {
   overflow: auto;
-  max-height: 100vh;
   flex: 1;
 }

--- a/frontend/src/css/mdPreview.css
+++ b/frontend/src/css/mdPreview.css
@@ -9,5 +9,6 @@
 
 #preview-container {
   overflow: auto;
-  max-height: 80vh; /* Match the max-height of md_preview for scrolling */
+  max-height: 100vh;
+  flex: 1;
 }

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="editor-container" @wheel.prevent.stop>
+  <div id="editor-container">
     <header-bar>
       <action icon="close" :label="t('buttons.close')" @action="close()" />
       <title>{{ fileStore.req?.name ?? "" }}</title>
@@ -97,7 +97,6 @@ const isMarkdownFile =
 
 onMounted(() => {
   window.addEventListener("keydown", keyEvent);
-  window.addEventListener("wheel", handleScroll);
   window.addEventListener("beforeunload", handlePageChange);
 
   const fileContent = fileStore.req?.content || "";
@@ -110,13 +109,6 @@ onMounted(() => {
       } catch (error) {
         console.error("Failed to convert content to HTML:", error);
         previewContent.value = "";
-      }
-
-      const previewContainer = document.getElementById("preview-container");
-      if (previewContainer) {
-        previewContainer.addEventListener("wheel", handleScroll, {
-          capture: true,
-        });
       }
     }
   });
@@ -148,7 +140,6 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   window.removeEventListener("keydown", keyEvent);
-  window.removeEventListener("wheel", handleScroll);
   window.removeEventListener("beforeunload", handlePageChange);
   editor.value?.destroy();
 });
@@ -184,13 +175,6 @@ const keyEvent = (event: KeyboardEvent) => {
 
   event.preventDefault();
   save();
-};
-
-const handleScroll = (event: WheelEvent) => {
-  const editorContainer = document.getElementById("preview-container");
-  if (editorContainer) {
-    editorContainer.scrollTop += event.deltaY;
-  }
 };
 
 const handlePageChange = (event: BeforeUnloadEvent) => {


### PR DESCRIPTION
## Description

**before**
<img width="927" height="821" alt="image" src="https://github.com/user-attachments/assets/e0a3aad4-4e86-4397-97ff-4c5a31bc8655" />

**after**
<img width="927" height="820" alt="image" src="https://github.com/user-attachments/assets/88d4ec25-dfde-48e1-ac9c-6e12c744a11f" />


## Additional Information

<!-- If it is a relatively large or complex change, please add more information to explain what you did, how you did it, if you considered any alternatives, etc. -->

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [ ] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [ ] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [ ] I am making a PR against the `master` branch.
- [ ] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
