### PR TITLE
feat: "save changes" button to discard changes dialog

### DIFF
--- a/frontend/src/components/prompts/DiscardEditorChanges.vue
+++ b/frontend/src/components/prompts/DiscardEditorChanges.vue
@@ -11,9 +11,18 @@
         @click="closeHovers"
         :aria-label="$t('buttons.cancel')"
         :title="$t('buttons.cancel')"
-        tabindex="2"
+        tabindex="3"
       >
         {{ $t("buttons.cancel") }}
+      </button>
+      <button
+        class="button button--flat button--blue"
+        @click="saveAndClose"
+        :aria-label="$t('buttons.saveChanges')"
+        :title="$t('buttons.saveChanges')"
+        tabindex="1"
+      >
+        {{ $t("buttons.saveChanges") }}
       </button>
       <button
         id="focus-prompt"
@@ -21,7 +30,7 @@
         class="button button--flat button--red"
         :aria-label="$t('buttons.discardChanges')"
         :title="$t('buttons.discardChanges')"
-        tabindex="1"
+        tabindex="2"
       >
         {{ $t("buttons.discardChanges") }}
       </button>
@@ -40,6 +49,13 @@ export default {
   },
   methods: {
     ...mapActions(useLayoutStore, ["closeHovers"]),
+    saveAndClose() {
+      // Ejecutar la función de guardado si está disponible
+      if (this.currentPrompt?.saveAction) {
+        this.currentPrompt.saveAction();
+      }
+      this.closeHovers();
+    },
   },
 };
 </script>

--- a/frontend/src/components/prompts/DiscardEditorChanges.vue
+++ b/frontend/src/components/prompts/DiscardEditorChanges.vue
@@ -50,7 +50,6 @@ export default {
   methods: {
     ...mapActions(useLayoutStore, ["closeHovers"]),
     saveAndClose() {
-      // Ejecutar la función de guardado si está disponible
       if (this.currentPrompt?.saveAction) {
         this.currentPrompt.saveAction();
       }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -42,7 +42,8 @@
     "update": "Update",
     "upload": "Upload",
     "openFile": "Open file",
-    "discardChanges": "Discard"
+  "discardChanges": "Discard",
+  "saveChanges": "Save changes"
   },
   "download": {
     "downloadFile": "Download File",

--- a/frontend/src/stores/layout.ts
+++ b/frontend/src/stores/layout.ts
@@ -41,6 +41,7 @@ export const useLayoutStore = defineStore("layout", {
           prompt: value,
           confirm: null,
           action: undefined,
+          saveAction: undefined,
           props: null,
           close: null,
         });
@@ -51,6 +52,7 @@ export const useLayoutStore = defineStore("layout", {
         prompt: value.prompt,
         confirm: value?.confirm,
         action: value?.action,
+        saveAction: value?.saveAction,
         props: value?.props,
         close: value?.close,
       });

--- a/frontend/src/types/layout.d.ts
+++ b/frontend/src/types/layout.d.ts
@@ -2,6 +2,7 @@ interface PopupProps {
   prompt: string;
   confirm?: any;
   action?: PopupAction;
+  saveAction?: () => void;
   props?: any;
   close?: (() => Promise<string>) | null;
 }

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -157,6 +157,10 @@ onBeforeRouteUpdate((to, from, next) => {
       event.preventDefault();
       next();
     },
+    saveAction: async () => {
+      await save();
+      next();
+    },
   });
 });
 


### PR DESCRIPTION
## Description

This PR adds a "Save changes" button to the discard changes dialog that appears when navigating away from the editor with unsaved changes. Users can now save and continue navigation directly from the dialog instead of having to click the save icon in the top-right corner first.

Before:
<img width="525" height="209" alt="Captura de pantalla 2025-09-11 152715" src="https://github.com/user-attachments/assets/c9c9b28f-322e-41f8-ba0b-eebe4b92d47a" />

After:
<img width="511" height="197" alt="Captura de pantalla 2025-09-11 152746" src="https://github.com/user-attachments/assets/444a1d72-fddf-43f3-b8b2-3139270f0428" />

**Changes made:**
- Added a third "Save changes" button to `DiscardEditorChanges.vue` with proper tab ordering
- Extended layout store to support optional `saveAction` property in prompts
- Modified editor route guard to inject save functionality that saves the file and continues navigation
- Added `buttons.saveChanges` key to English locale only (`en.json`) - other language translations will be handled through Transifex after merge

The implementation preserves existing behavior while adding this convenience option. The save action properly marks the undo manager as clean after saving, maintaining editor state consistency.

## Additional Information

This is a minimal UX improvement that addresses a common user friction point. When users have unsaved changes and try to navigate away, they currently must:
1. Click "Cancel" in the dialog
2. Click the save icon in the top-right
3. Navigate again

Now they can simply click "Save changes" directly in the dialog.

**Technical approach:**
- Used existing prompt system architecture without breaking changes
- Made `saveAction` optional to maintain backward compatibility  
- Followed established patterns for button styling and modal interactions
- **Translation approach:** Only added the English source key (`buttons.saveChanges: "Save changes"`) to `en.json`. All other language translations have been submitted to Transifex and will be automatically synchronized after this PR is merged, following the project's established translation workflow.

The change has been manually tested in development mode with both frontend dev server and Go backend running.

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).