### PR TITLE
fix: disallow "/" in renamed directory and filenames

### DIFF
--- a/frontend/src/components/prompts/Rename.vue
+++ b/frontend/src/components/prompts/Rename.vue
@@ -16,6 +16,9 @@
         @keyup.enter="submit"
         v-model.trim="name"
       />
+      <p class="invalid-name" v-if="!isValidName">
+        {{ $t("errors.invalidFileName") }}
+      </p>
     </div>
 
     <div class="card-action">
@@ -31,6 +34,7 @@
         @click="submit"
         class="button button--flat"
         type="submit"
+        :disabled="!isValidName"
         :aria-label="$t('buttons.rename')"
         :title="$t('buttons.rename')"
       >
@@ -47,6 +51,8 @@ import { useLayoutStore } from "@/stores/layout";
 import url from "@/utils/url";
 import { files as api } from "@/api";
 import { removePrefix } from "@/api/utils";
+
+const INVALID_CHARACTERS = ["/"];
 
 export default {
   name: "rename",
@@ -67,6 +73,9 @@ export default {
       "isListing",
     ]),
     ...mapWritableState(useFileStore, ["reload", "preselect"]),
+    isValidName() {
+      return !INVALID_CHARACTERS.some((char) => this.name.includes(char));
+    },
   },
   methods: {
     ...mapActions(useLayoutStore, ["closeHovers"]),
@@ -117,3 +126,9 @@ export default {
   },
 };
 </script>
+<style scoped>
+.invalid-name {
+  color: var(--red);
+  font-size: 0.9em;
+}
+</style>

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -57,7 +57,8 @@
     "forbidden": "You don't have permissions to access this.",
     "internal": "Something really went wrong.",
     "notFound": "This location can't be reached.",
-    "connection": "The server can't be reached."
+    "connection": "The server can't be reached.",
+    "invalidFileName": "The file or directory name is not valid."
   },
   "files": {
     "body": "Body",


### PR DESCRIPTION
Closes https://github.com/filebrowser/filebrowser/issues/5306

## Description

This pull request fixes a bug that allowed users to rename files or directories using the / character. Previously, entering / in the new name would unintentionally create a new file or folder in a different path, rather than renaming the original item. This behavior has now been corrected by validating the input and disallowing invalid characters such as /.

## Additional Information

1. Added a validation check to prevent renaming with forbidden characters.
2. The character / is now explicitly blocked to avoid path traversal issues.
3. Ensures that renamed items remain in their original location and do not result in unintended file creation.

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/f397c8a8-c545-43a8-8cd5-85fa46eb4ffb" />

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
