### PR TITLE
feat: Improved path display in new file and directory modals

### DIFF
--- a/frontend/src/components/prompts/CreateFilePath.vue
+++ b/frontend/src/components/prompts/CreateFilePath.vue
@@ -1,0 +1,87 @@
+<template>
+  <div>
+    <div class="path-container" ref="container">
+      <template v-for="(item, index) in path" :key="index">
+        /
+        <span class="path-item">
+          <span
+            v-if="isDir === true || index < path.length - 1"
+            class="material-icons"
+            >folder
+          </span>
+          <span v-else class="material-icons">insert_drive_file</span>
+          {{ item }}
+        </span>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, nextTick, defineProps } from "vue";
+import { useRoute } from "vue-router";
+import { useFileStore } from "@/stores/file";
+import url from "@/utils/url";
+
+const fileStore = useFileStore();
+const route = useRoute();
+
+const props = defineProps({
+  name: {
+    type: String,
+    required: true,
+  },
+  isDir: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const container = ref<HTMLElement | null>(null);
+
+const path = computed(() => {
+  let basePath = fileStore.isFiles ? route.path : url.removeLastDir(route.path);
+  basePath += props.name;
+
+  return basePath
+    .replace(/^\/[^\/]+/, "")
+    .split("/")
+    .filter(Boolean);
+});
+
+watch(path, () => {
+  nextTick(() => {
+    const lastItem = container.value?.lastElementChild;
+    lastItem?.scrollIntoView({ behavior: "auto", inline: "end" });
+  });
+});
+</script>
+
+<style scoped>
+.path-container {
+  display: flex;
+  align-items: center;
+  margin: 0.2em 0;
+  gap: 0.25em;
+  overflow-x: auto;
+  max-width: 100%;
+  scrollbar-width: none;
+  opacity: 0.5;
+}
+
+.path-container::-webkit-scrollbar {
+  display: none;
+}
+
+.path-item {
+  display: flex;
+  align-items: center;
+  margin: 0.2em 0;
+  gap: 0.25em;
+  white-space: nowrap;
+}
+
+.path-item > span {
+  font-size: 0.9em;
+}
+</style>

--- a/frontend/src/components/prompts/NewDir.vue
+++ b/frontend/src/components/prompts/NewDir.vue
@@ -14,6 +14,7 @@
         v-model.trim="name"
         tabindex="1"
       />
+      <CreateFilePath :name="name" :is-dir="true" />
     </div>
 
     <div class="card-action">
@@ -48,6 +49,7 @@ import { files as api } from "@/api";
 import url from "@/utils/url";
 import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
+import CreateFilePath from "@/components/prompts/CreateFilePath.vue";
 
 const $showError = inject<IToastError>("$showError")!;
 

--- a/frontend/src/components/prompts/NewFile.vue
+++ b/frontend/src/components/prompts/NewFile.vue
@@ -13,6 +13,7 @@
         @keyup.enter="submit"
         v-model.trim="name"
       />
+      <CreateFilePath :name="name" />
     </div>
 
     <div class="card-action">
@@ -42,6 +43,7 @@ import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 import { useFileStore } from "@/stores/file";
 import { useLayoutStore } from "@/stores/layout";
+import CreateFilePath from "@/components/prompts/CreateFilePath.vue";
 
 import { files as api } from "@/api";
 import url from "@/utils/url";


### PR DESCRIPTION
## Description
I added a container below the file name input field that draws the actual path where the file or directory will be created.

## Additional Information
This is an improvement in understanding file and directory creation that was discussed in https://github.com/filebrowser/filebrowser/issues/5306
<img width="1234" height="556" alt="482087188-0f136ad3-49f0-4a29-bef8-450b57f13501" src="https://github.com/user-attachments/assets/8c7bedb2-29b1-4137-987f-041ebd52e0a1" />

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
