### PR TITLE
fix: wrong url on settings branding link

### DIFF
--- a/frontend/src/views/settings/Global.vue
+++ b/frontend/src/views/settings/Global.vue
@@ -65,7 +65,7 @@
             <a
               class="link"
               target="_blank"
-              href="https://filebrowser.org/configuration.html#command-runner"
+              href="https://filebrowser.org/configuration.html#custom-branding"
               >{{ t("settings.documentation") }}</a
             >
           </i18n-t>


### PR DESCRIPTION
## Description

Was working on a migration of an outdated fork of Filebrowser to the latest version and noticed the following link typo during code review.  This typo was introduced by https://github.com/filebrowser/filebrowser/commit/38d0366acf88352b5a9a97c45837b0f865efae0b

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
