### PR TITLE
fix(auth): prevent integer overflow in logout timer using safeTimeout

### DIFF
--- a/frontend/src/api/utils.ts
+++ b/frontend/src/api/utils.ts
@@ -91,3 +91,23 @@ export function createURL(endpoint: string, searchParams = {}): string {
 
   return url.toString();
 }
+
+export function setSafeTimeout(callback: () => void, delay: number): number {
+  const MAX_DELAY = 86_400_000;
+  let remaining = delay;
+  let timerId: number;
+
+  function scheduleNext() {
+    if (remaining <= MAX_DELAY) {
+      timerId = window.setTimeout(callback, remaining);
+    } else {
+      timerId = window.setTimeout(() => {
+        remaining -= MAX_DELAY;
+        scheduleNext();
+      }, MAX_DELAY);
+    }
+  }
+
+  scheduleNext();
+  return timerId;
+}

--- a/frontend/src/api/utils.ts
+++ b/frontend/src/api/utils.ts
@@ -95,19 +95,17 @@ export function createURL(endpoint: string, searchParams = {}): string {
 export function setSafeTimeout(callback: () => void, delay: number): number {
   const MAX_DELAY = 86_400_000;
   let remaining = delay;
-  let timerId: number;
 
-  function scheduleNext() {
+  function scheduleNext(): number {
     if (remaining <= MAX_DELAY) {
-      timerId = window.setTimeout(callback, remaining);
+      return window.setTimeout(callback, remaining);
     } else {
-      timerId = window.setTimeout(() => {
+      return window.setTimeout(() => {
         remaining -= MAX_DELAY;
         scheduleNext();
       }, MAX_DELAY);
     }
   }
 
-  scheduleNext();
-  return timerId;
+  return scheduleNext();
 }

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -4,6 +4,7 @@ import type { JwtPayload } from "jwt-decode";
 import { jwtDecode } from "jwt-decode";
 import { baseURL, noAuth } from "./constants";
 import { StatusError } from "@/api/utils";
+import { setSafeTimeout } from "@/api/utils";
 
 export function parseToken(token: string) {
   // falsy or malformed jwt will throw InvalidTokenError
@@ -22,10 +23,11 @@ export function parseToken(token: string) {
   }
 
   const expiresAt = new Date(data.exp! * 1000);
+  const timeout = expiresAt.getTime() - Date.now();
   authStore.setLogoutTimer(
-    window.setTimeout(() => {
+    setSafeTimeout(() => {
       logout("inactivity");
-    }, expiresAt.getTime() - Date.now())
+    }, timeout)
   );
 }
 


### PR DESCRIPTION
## Description
Closes https://github.com/filebrowser/filebrowser/issues/5461
This PR introduces a new setSafeTimeout utility to replace the direct use of setTimeout when scheduling automatic user logout based on JWT expiration.

## Additional Information
- Replaced the existing setTimeout call in parseToken() with a safer implementation that avoids integer overflow issues when the delay exceeds the 32-bit limit (~24.8 days).
- The new setSafeTimeout function divides long timeouts into smaller intervals (e.g., 1 day each) and checks the remaining time recursively until the total delay has passed.
- Ensures consistent behavior across browsers, mobile WebViews, and other runtime environments that may impose shorter timeout limits.

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
