### PR TITLE
fix: editor discard prompt doesn't save nor discard

### DIFF
--- a/frontend/src/components/prompts/DiscardEditorChanges.vue
+++ b/frontend/src/components/prompts/DiscardEditorChanges.vue
@@ -17,7 +17,7 @@
       </button>
       <button
         class="button button--flat button--blue"
-        @click="saveAndClose"
+        @click="currentPrompt.saveAction"
         :aria-label="$t('buttons.saveChanges')"
         :title="$t('buttons.saveChanges')"
         tabindex="1"
@@ -39,8 +39,8 @@
 </template>
 
 <script>
-import { mapState, mapActions } from "pinia";
 import { useLayoutStore } from "@/stores/layout";
+import { mapActions, mapState } from "pinia";
 
 export default {
   name: "discardEditorChanges",
@@ -49,12 +49,6 @@ export default {
   },
   methods: {
     ...mapActions(useLayoutStore, ["closeHovers"]),
-    saveAndClose() {
-      if (this.currentPrompt?.saveAction) {
-        this.currentPrompt.saveAction();
-      }
-      this.closeHovers();
-    },
   },
 };
 </script>

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -216,12 +216,24 @@ const decreaseFontSize = () => {
 
 const close = () => {
   if (!editor.value?.session.getUndoManager().isClean()) {
-    layoutStore.showHover("discardEditorChanges");
+    layoutStore.showHover({
+      prompt: "discardEditorChanges",
+      confirm: (event: Event) => {
+        event.preventDefault();
+        finishClose();
+      },
+      saveAction: async () => {
+        await save();
+        finishClose();
+      },
+    });
     return;
   }
+  finishClose();
+};
 
+const finishClose = () => {
   fileStore.updateRequest(null);
-
   const uri = url.removeLastDir(route.path) + "/";
   router.push({ path: uri });
 };


### PR DESCRIPTION
## Description

I noticed the "DiscardEditorChanges" prompt didn't work at all.  Cancel was the only working option.  "Save" would just exit the hover without doing anything, and "Discard" would give no feedback at all, also doing nothing.  After digging into this, I found that the Prompt was attempting to use the "saveAction" and "confirm" functions attached to the prompt, though this prompt was created without either of these functions being set.  The additional "finishClose" method for the editor view isn't the _cleanest_ solution, though wanted to minimize the code duplication across these 3 scenarios. 

## Additional Information

Introduced by both https://github.com/filebrowser/filebrowser/pull/5430 and https://github.com/filebrowser/filebrowser/pull/5329

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
