### PR TITLE
fix: Prevent thumbnail generation for ludicrously large images

### DIFF
--- a/http/utils.go
+++ b/http/utils.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	libErrors "github.com/filebrowser/filebrowser/v2/errors"
+	imgErrors "github.com/filebrowser/filebrowser/v2/img"
 )
 
 func renderJSON(w http.ResponseWriter, _ *http.Request, data interface{}) (int, error) {
@@ -42,6 +43,8 @@ func errToStatus(err error) int {
 		return http.StatusBadRequest
 	case errors.Is(err, libErrors.ErrRootUserDeletion):
 		return http.StatusForbidden
+	case errors.Is(err, imgErrors.ErrImageTooLarge):
+		return http.StatusRequestEntityTooLarge
 	default:
 		return http.StatusInternalServerError
 	}


### PR DESCRIPTION
## Description

When the folders I am opening through filebrowser contains large images the programs tries to create a thumbnail and as the image is very large the server starts using too much resources at best or crashes at worst.

In this PR I am adding a check before creating thumbnail which checks if the size of image is larger than 10000 x 10000 and if its larger than the above config it return 413 error.

if the image contains EXIF thumbnail then EXIF thumbnail is returned.

## Additional Information

I also checked with [govips](https://pkg.go.dev/github.com/davidbyttow/govips/v2@v2.16.0)  ([reference](https://github.com/filebrowser/filebrowser/issues/3888#issuecomment-3043206728)) and this implementation can reduce the resource usage and can return Thumbnails faster than current implementation. But using govips we have to link libvips-dev, which will increase binary size, Docker iamge size.

closes #3888

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
