### PR TITLE
fix: share page preview items to contain baseUrl

### DIFF
--- a/frontend/src/components/settings/AceEditorTheme.vue
+++ b/frontend/src/components/settings/AceEditorTheme.vue
@@ -1,5 +1,9 @@
 <template>
-  <select name="selectAceEditorTheme" v-on:change="change" :value="aceEditorTheme">
+  <select
+    name="selectAceEditorTheme"
+    v-on:change="change"
+    :value="aceEditorTheme"
+  >
     <option v-for="theme in themes" :value="theme.theme" :key="theme.theme">
       {{ theme.name }}
     </option>

--- a/frontend/src/views/Share.vue
+++ b/frontend/src/views/Share.vue
@@ -301,7 +301,7 @@ import { pub as api } from "@/api";
 import { filesize } from "@/utils";
 import dayjs from "dayjs";
 import { Base64 } from "js-base64";
-
+import { createURL } from "@/api/utils";
 import HeaderBar from "@/components/header/HeaderBar.vue";
 import Action from "@/components/header/Action.vue";
 import Breadcrumbs from "@/components/Breadcrumbs.vue";
@@ -354,14 +354,11 @@ const icon = computed(() => {
 
 const link = computed(() => (req.value ? api.getDownloadURL(req.value) : ""));
 const raw = computed(() => {
-  return req.value
-    ? req.value.items[fileStore.selected[0]].url.replace(
-        /share/,
-        "api/public/dl"
-      ) +
-        "?token=" +
-        token.value
-    : "";
+  if (!req.value || !req.value.items[fileStore.selected[0]]) return "";
+  return createURL(
+    `api/public/dl/${hash.value}${req.value.items[fileStore.selected[0]].path}`,
+    { token: token.value }
+  );
 });
 const inlineLink = computed(() =>
   req.value ? api.getDownloadURL(req.value, true) : ""


### PR DESCRIPTION
## Description

In this PR i have changed the logic of how preview's URL are generated to respect the base URL.

rather than replacing the URL of share which will be regex operation i am building the URL using path and hash.

<img width="1433" height="368" alt="Screenshot_2025-11-11_06-21-22" src="https://github.com/user-attachments/assets/b1005930-60a0-43dc-afc0-31083eed7e8e" />

## Additional Information

Closes #5491

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
