### PR TITLE
fix: remove duplicated 'hide-defaults' flag (is 'hideDefaults')

### DIFF
--- a/cmd/users.go
+++ b/cmd/users.go
@@ -80,7 +80,6 @@ func addUserFlags(flags *pflag.FlagSet) {
 	flags.Bool("dateFormat", false, "use date format (true for absolute time, false for relative)")
 	flags.Bool("hideDotfiles", false, "hide dotfiles")
 	flags.String("aceEditorTheme", "", "ace editor's syntax highlighting theme for users")
-	flags.Bool("hide-dotfiles", false, "Hide dotfiles by default")
 }
 
 func getViewMode(flags *pflag.FlagSet) (users.ViewMode, error) {
@@ -136,7 +135,7 @@ func getUserDefaults(flags *pflag.FlagSet, defaults *settings.UserDefaults, all 
 			defaults.Sorting.By, err = getString(flags, flag.Name)
 		case "sorting.asc":
 			defaults.Sorting.Asc, err = getBool(flags, flag.Name)
-		case "hide-dotfiles":
+		case "hideDotfiles":
 			defaults.HideDotfiles, err = getBool(flags, flag.Name)
 		}
 		if err != nil {


### PR DESCRIPTION
This duplicate flag has been added by mistake in #3802. The flag already existed, but the value handling wasn't there.

A note is that the flags are a mess: some are hyphenated, some are camel case... it's a mess.