### PR TITLE
fix: display friendly error message for password validation on signup

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -102,6 +102,7 @@
     "username": "Username",
     "usernameTaken": "Username already taken",
     "wrongCredentials": "Wrong credentials",
+    "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
     }

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -101,7 +101,11 @@ export async function signup(username: string, password: string) {
   });
 
   if (res.status !== 200) {
-    throw new StatusError(`${res.status} ${res.statusText}`, res.status);
+    const body = await res.text();
+    throw new StatusError(
+      body || `${res.status} ${res.statusText}`,
+      res.status
+    );
   }
 }
 

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -112,6 +112,13 @@ const submit = async (event: Event) => {
         error.value = t("login.usernameTaken");
       } else if (e.status === 403) {
         error.value = t("login.wrongCredentials");
+      } else if (e.status === 400) {
+        const match = e.message.match(/minimum length is (\d+)/);
+        if (match) {
+          error.value = t("login.passwordTooShort", { min: match[1] });
+        } else {
+          error.value = e.message;
+        }
       } else {
         $showError(e);
       }


### PR DESCRIPTION
## Summary

- Fixes #5499
- The `signup()` function in `auth.ts` was not reading the response body before throwing a StatusError, causing password validation errors to display as "404 error not found" instead of the actual error message
- Added parsing of 400 errors to display a user-friendly "Password must be at least X characters" message instead of the raw API error

## Changes

1. **frontend/src/utils/auth.ts** - Read response body in `signup()` to match the pattern used in `login()`
2. **frontend/src/views/Login.vue** - Added handler for 400 status that parses the password length from the error and displays a translated friendly message
3. **frontend/src/i18n/en.json** - Added `passwordTooShort` translation string

## Alternative Approach
If you prefer a simpler implementation, the fix to `auth.ts` alone (reading the response body) would display the backend's error message directly: "400 Bad Request (password is too short, minimum length is 12)". The additional changes in this PR parse the error to show a cleaner message without the HTTP status prefix.

## Screenshots

### Current behavior (bug)
<img width="1840" height="1138" alt="current-behavior" src="https://github.com/user-attachments/assets/139bd4d8-1834-44fa-bcea-32d191360fb7" />

### With passthrough fix only
<img width="1840" height="1138" alt="with-default-message" src="https://github.com/user-attachments/assets/8eb6cfc8-97ab-4e5b-a8f3-c8a285e8ba10" />

### With this PR (friendly message)
<img width="1840" height="1138" alt="with-custom-message" src="https://github.com/user-attachments/assets/2ae03b81-25aa-4a38-a422-310eb44c963f" />

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).