### PR TITLE
fix: display the directory name in the shared folder view

### DIFF
--- a/http/public.go
+++ b/http/public.go
@@ -74,6 +74,12 @@ var withHashFile = func(fn handleFunc) handleFunc {
 			return errToStatus(err), err
 		}
 
+		if file.IsDir {
+			// extract name from the last directory in the path
+			name := filepath.Base(strings.TrimRight(link.Path, string(filepath.Separator)))
+			file.Name = name
+		}
+
 		d.raw = file
 		return fn(w, r, d)
 	}


### PR DESCRIPTION
## Description
When sharing a directory, the directory name is displayed in the "Display Name" field; previously, that field was empty.
When sharing a file, the file name continues to be displayed in this "Display name" field.

## Additional Information
Closes https://github.com/filebrowser/filebrowser/issues/5614

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
