### PR TITLE
fix: conversion of backslashes in file paths for archive creation

### DIFF
--- a/http/raw.go
+++ b/http/raw.go
@@ -123,6 +123,7 @@ func getFiles(d *data, path, commonPath string) ([]archives.FileInfo, error) {
 	if path != commonPath {
 		nameInArchive := strings.TrimPrefix(path, commonPath)
 		nameInArchive = strings.TrimPrefix(nameInArchive, string(filepath.Separator))
+		nameInArchive = filepath.ToSlash(nameInArchive)
 
 		archiveFiles = append(archiveFiles, archives.FileInfo{
 			FileInfo:      info,


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Fixes: #3874 
Used `filepath.ToSlash()` to convert all backslashes to slashes in file paths.
Successfully compiled and tested by downloading a file from a Windows machine to a Linux machine using zip as the archive method.
Zip file structure is now correct.

## Additional Information

<!-- If it is a relatively large or complex change, please add more information to explain what you did, how you did it, if you considered any alternatives, etc. -->
To add more context:
- This is my first PR ever, I almost have no idea what I'm doing.
- If I've done something incorrectly, I'm happy to have this reviewed and fixed properly.
- I've been affected by this bug for almost 2 years, so I decided to contribute and help move things forward.

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
