### PR TITLE
fix: Fix nil deref in config set command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -99,7 +99,7 @@ func getProxyAuth(flags *pflag.FlagSet, defaultAuther map[string]interface{}) (a
 		return nil, err
 	}
 
-	if header == ""  && defaultAuther != nil{
+	if header == ""  && defaultAuther != nil {
 		header = defaultAuther["header"].(string)
 	}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -99,7 +99,7 @@ func getProxyAuth(flags *pflag.FlagSet, defaultAuther map[string]interface{}) (a
 		return nil, err
 	}
 
-	if header == "" {
+	if header == ""  && defaultAuther != nil{
 		header = defaultAuther["header"].(string)
 	}
 


### PR DESCRIPTION
Currently if the user sets --auth.method without --auth.header, if defaultAuther isn't defined then there is a nil deref.

Check for nil directly so we can give a helpeful error message instead.

## Description

<!-- Please explain the changes you made here. -->

## Additional Information

<!-- If it is a relatively large or complex change, please add more information to explain what you did, how you did it, if you considered any alternatives, etc. -->

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
