### PR TITLE
docs: clarify scope of config file and environment variables

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -135,6 +135,11 @@ file named .filebrowser.{json, toml, yaml, yml} in the following directories:
 - $HOME/
 - /etc/filebrowser/
 
+**Note:** Only the options listed below can be set via the config file or
+environment variables. Other configuration options live exclusively in the
+database and so they must be set by the "config set" or "config
+import" commands.
+
 The precedence of the configuration values are as follows:
 
 - Flags

--- a/www/docs/cli/filebrowser.md
+++ b/www/docs/cli/filebrowser.md
@@ -26,6 +26,11 @@ file named .filebrowser.{json, toml, yaml, yml} in the following directories:
 - $HOME/
 - /etc/filebrowser/
 
+**Note:** Only the options listed below can be set via the config file or
+environment variables. Other configuration options live exclusively in the
+database and so they must be set by the "config set" or "config
+import" commands.
+
 The precedence of the configuration values are as follows:
 
 - Flags


### PR DESCRIPTION
I got pretty confused about why I can't set auth.method from the config file (and also why there were no docs saying what the JSON/YAML/etc key would even be).

Document that this doesn't work to try to prevent future confusion here.

Caveat: I wrote this documentation by hand, but I did not actually read the code carefully enough to have figured this out myself. I am trusting the claims made by an LLM coding agent (which do at least seem to match empirical evidence).

## Description

... Hopefully docs improvements is compatible with maintenance-only mode?

## Additional Information

<!-- If it is a relatively large or complex change, please add more information to explain what you did, how you did it, if you considered any alternatives, etc. -->

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
