### PR TITLE
fix: hide "change password form" in noauth setting

### DIFF
--- a/frontend/src/views/settings/Profile.vue
+++ b/frontend/src/views/settings/Profile.vue
@@ -44,7 +44,7 @@
       </form>
     </div>
 
-    <div v-if="!isHidePasswordForm" class="column">
+    <div v-if="!noAuth" class="column">
       <form
         class="card"
         v-if="!authStore.user?.lockPassword"
@@ -96,11 +96,12 @@
 <script setup lang="ts">
 import { useAuthStore } from "@/stores/auth";
 import { useLayoutStore } from "@/stores/layout";
-import { users as api, settings } from "@/api";
+import { users as api } from "@/api";
 import AceEditorTheme from "@/components/settings/AceEditorTheme.vue";
 import Languages from "@/components/settings/Languages.vue";
 import { computed, inject, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
+import { authMethod, noAuth } from "@/utils/constants";
 
 const layoutStore = useLayoutStore();
 const authStore = useAuthStore();
@@ -118,7 +119,6 @@ const singleClick = ref<boolean>(false);
 const dateFormat = ref<boolean>(false);
 const locale = ref<string>("");
 const aceEditorTheme = ref<string>("");
-const isHidePasswordForm = ref<boolean>(false);
 
 const passwordClass = computed(() => {
   const baseClass = "input input--block";
@@ -143,9 +143,7 @@ onMounted(async () => {
   dateFormat.value = authStore.user.dateFormat;
   aceEditorTheme.value = authStore.user.aceEditorTheme;
   layoutStore.loading = false;
-  const { authMethod } = await settings.get();
   isCurrentPasswordRequired.value = authMethod == "json";
-  isHidePasswordForm.value = authMethod == "noauth";
 
   return true;
 });

--- a/frontend/src/views/settings/Profile.vue
+++ b/frontend/src/views/settings/Profile.vue
@@ -44,7 +44,7 @@
       </form>
     </div>
 
-    <div class="column">
+    <div v-if="!isHidePasswordForm" class="column">
       <form
         class="card"
         v-if="!authStore.user?.lockPassword"
@@ -118,6 +118,7 @@ const singleClick = ref<boolean>(false);
 const dateFormat = ref<boolean>(false);
 const locale = ref<string>("");
 const aceEditorTheme = ref<string>("");
+const isHidePasswordForm = ref<boolean>(false);
 
 const passwordClass = computed(() => {
   const baseClass = "input input--block";
@@ -144,6 +145,7 @@ onMounted(async () => {
   layoutStore.loading = false;
   const { authMethod } = await settings.get();
   isCurrentPasswordRequired.value = authMethod == "json";
+  isHidePasswordForm.value = authMethod == "noauth";
 
   return true;
 });


### PR DESCRIPTION
## Description
The form that allows you to change your password in your profile is hidden if the authentication setting is set to "noauth"

## Additional Information
Closes https://github.com/filebrowser/filebrowser/issues/5650

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
