### PR TITLE
fix: download path encoding file paths

### DIFF
--- a/frontend/src/api/pub.ts
+++ b/frontend/src/api/pub.ts
@@ -41,12 +41,12 @@ export function download(
   let url = `${baseURL}/api/public/dl/${hash}`;
 
   if (files.length === 1) {
-    url += encodeURIComponent(files[0]) + "?";
+    url += files[0] + "?";
   } else {
     let arg = "";
 
     for (const file of files) {
-      arg += encodeURIComponent(file) + ",";
+      arg += file + ",";
     }
 
     arg = arg.substring(0, arg.length - 1);


### PR DESCRIPTION
## Description

in download function we are encoding file paths and double encoding files query params value.
Apache HTTP server by default doesn't allow encoded slashes in path and throws 404 error. Nginx by default sends the request to server.

this PR fixes the encoding so the filebrowser works seamlessly with Apache HTTP server and Nginx server without any manual configuration.

## Additional Information
I have tested this change locally with NGINX and Apache server 

closes #5651 

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
