### PR TITLE
feat: force file sync while uploading file

### DIFF
--- a/http/resource.go
+++ b/http/resource.go
@@ -280,6 +280,12 @@ func writeFile(afs afero.Fs, dst string, in io.Reader, fileMode, dirMode fs.File
 		return nil, err
 	}
 
+	// Sync the file to ensure all data is written to storage.
+	// to prevent file corruption.
+	if err := file.Sync(); err != nil {
+		return nil, err
+	}
+
 	// Gets the info about the file.
 	info, err := file.Stat()
 	if err != nil {

--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -256,6 +256,12 @@ func tusPatchHandler() handleFunc {
 			return http.StatusInternalServerError, fmt.Errorf("could not write to file: %w", err)
 		}
 
+		// Sync the file to ensure all data is written to storage
+		// to prevent file corruption.
+		if err := openFile.Sync(); err != nil {
+			return http.StatusInternalServerError, fmt.Errorf("could not sync file: %w", err)
+		}
+
 		newOffset := uploadOffset + bytesWritten
 		w.Header().Set("Upload-Offset", strconv.FormatInt(newOffset, 10))
 


### PR DESCRIPTION
## Description

normally for data critical applications like filebrowser we should ensure the file is fully written to disk before returning 2xx status code.

this PR adds that capability to filebrowser

## Additional Information

Closes #5664 

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
