### PR TITLE
fix: prevent context menu clicks from clearing file selection

### DIFF
--- a/frontend/src/views/files/FileListing.vue
+++ b/frontend/src/views/files/FileListing.vue
@@ -1059,6 +1059,9 @@ const handleEmptyAreaClick = (e: MouseEvent) => {
 
   if (target.closest("item") || target.closest(".item")) return;
 
+  // Do not clear selection when clicking on context menu actions
+  if (target.closest(".context-menu")) return;
+
   fileStore.selected = [];
 };
 </script>


### PR DESCRIPTION
## Summary
- Fixes right-click context menu actions (Share, Rename) not working properly
- The click handler was treating context menu clicks as regular clicks, clearing the selection
- Added early return when clicking inside `.context-menu` to preserve file selection

## Test plan
- [ ] Select a file in the file browser
- [ ] Right-click to open the context menu
- [ ] Click "Share" or "Rename" from the context menu
- [ ] Verify the action is performed on the correct file (selection preserved)

Fixes #5680