### PR TITLE
chore: add openbsd, remove windows arm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
       - linux
       - windows
       - freebsd
+      - openbsd
     goarch:
       - amd64
       - "386"
@@ -30,6 +31,12 @@ builds:
     ignore:
       - goos: darwin
         goarch: "386"
+      # Experimental, may not work properly
+      - goos: openbsd
+        goarch: riscv64
+      # Broken as of Go 1.24, deprecated as of Go 1.26
+      - goos: windows
+        goarch: arm
       - goos: freebsd
         goarch: arm
 


### PR DESCRIPTION
- Adds OpenBSD target (fixes #5687)
- Removes Windows ARM targets, which have been broken since Go 1.24 and are deprecated from Go 1.26 on (https://github.com/golang/build/commit/07b2dfd321e02bb5e7d3c04d643de19f3e254655)