### PR TITLE
fix: allow moving and copying files to root directory

### DIFF
--- a/fileutils/copy.go
+++ b/fileutils/copy.go
@@ -18,8 +18,8 @@ func Copy(afs afero.Fs, src, dst string, fileMode, dirMode fs.FileMode) error {
 		return os.ErrNotExist
 	}
 
-	if src == "/" || dst == "/" {
-		// Prohibit copying from or to the virtual root directory.
+	if src == "/" {
+		// Prohibit copying from the virtual root directory.
 		return os.ErrInvalid
 	}
 

--- a/http/resource.go
+++ b/http/resource.go
@@ -197,7 +197,7 @@ func resourcePatchHandler(fileCache FileCache) handleFunc {
 		if err != nil {
 			return errToStatus(err), err
 		}
-		if dst == "/" || src == "/" {
+		if src == "/" {
 			return http.StatusForbidden, nil
 		}
 


### PR DESCRIPTION
fixes issue where users got 403 forbidden when trying to move or copy files to the configured root, even though uploads and renames worked fine there

Fixes #5683

This PR allows files and folders to be moved/copied to the root directory.

Previously, users received a 403 Forbidden error when trying to move or copy files to the configured FileBrowser root, even though uploads and renames worked fine there.

Changes:
- Removed the `dst == "/"` restriction in `fileutils/copy.go`
- Removed the `dst == "/"` check in `http/resource.go`
- Still prevents moving/copying FROM root for safety

The fix makes move/copy operations consistent with other file operations like upload and rename.
