### PR TITLE
fix: avoid clearing selection when clicking elements outside the empty area

### DIFF
--- a/frontend/src/views/files/FileListing.vue
+++ b/frontend/src/views/files/FileListing.vue
@@ -81,7 +81,13 @@
       </template>
     </header-bar>
 
-    <div v-if="isMobile" id="file-selection">
+    <div
+      v-if="isMobile"
+      id="file-selection"
+      :class="{
+        'file-selection-margin-bottom': fileStore.multiple,
+      }"
+    >
       <span v-if="fileStore.selectedCount > 0">
         {{ t("prompts.filesSelected", fileStore.selectedCount) }}
       </span>
@@ -158,6 +164,7 @@
         id="listing"
         ref="listing"
         class="file-icons"
+        data-clear-on-click="true"
         :class="authStore.user?.viewMode ?? ''"
         @click="handleEmptyAreaClick"
       >
@@ -205,11 +212,12 @@
           </div>
         </div>
 
-        <h2 v-if="fileStore.req?.numDirs ?? false">
+        <h2 data-clear-on-click="true" v-if="fileStore.req?.numDirs ?? false">
           {{ t("files.folders") }}
         </h2>
         <div
           v-if="fileStore.req?.numDirs ?? false"
+          data-clear-on-click="true"
           @contextmenu="showContextMenu"
         >
           <item
@@ -227,11 +235,12 @@
           </item>
         </div>
 
-        <h2 v-if="fileStore.req?.numFiles ?? false">
+        <h2 data-clear-on-click="true" v-if="fileStore.req?.numFiles ?? false">
           {{ t("files.files") }}
         </h2>
         <div
           v-if="fileStore.req?.numFiles ?? false"
+          data-clear-on-click="true"
           @contextmenu="showContextMenu"
         >
           <item
@@ -1057,16 +1066,17 @@ const handleEmptyAreaClick = (e: MouseEvent) => {
   const target = e.target;
   if (!(target instanceof HTMLElement)) return;
 
-  if (target.closest("item") || target.closest(".item")) return;
-
-  // Do not clear selection when clicking on context menu actions
-  if (target.closest(".context-menu")) return;
-
-  fileStore.selected = [];
+  if (target.dataset.clearOnClick === "true") {
+    fileStore.selected = [];
+  }
 };
 </script>
 <style scoped>
 #listing {
   min-height: calc(100vh - 8rem);
+}
+
+.file-selection-margin-bottom {
+  margin-bottom: 3.5rem;
 }
 </style>


### PR DESCRIPTION
## Description
Manage interface elements that, when clicked, can clear the selection using the `data-clear-on-click` attribute, to avoid conflicts or unexpected behavior with other elements that, when clicked, should not clear the selection.

In the mobile version, if multi-selection is enabled, the bottom action bar moves upwards to prevent it from being hidden by the multi-selection banner.

## Additional Information
Closes https://github.com/filebrowser/filebrowser/issues/5709
<img width="291" height="519" alt="image" src="https://github.com/user-attachments/assets/b26f2ef2-fdad-4735-8e6c-dc54f02c59b3" />

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
