### PR TITLE
fix: adjust yaml config decodification to yaml.v3

### DIFF
--- a/cmd/config_import.go
+++ b/cmd/config_import.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
-	"path/filepath"
 	"reflect"
 
 	"github.com/spf13/cobra"
@@ -68,12 +67,7 @@ The path must be for a json or yaml file.`,
 			return err
 		}
 
-		var rawAuther interface{}
-		if filepath.Ext(args[0]) != ".json" {
-			rawAuther = cleanUpInterfaceMap(file.Auther.(map[interface{}]interface{}))
-		} else {
-			rawAuther = file.Auther
-		}
+		var rawAuther = file.Auther
 
 		var auther auth.Auther
 		var autherErr error

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/fs"
 	"log"
 	"os"
@@ -246,33 +245,6 @@ func jsonYamlArg(cmd *cobra.Command, args []string) error {
 		return nil
 	default:
 		return errors.New("invalid format: " + ext)
-	}
-}
-
-func cleanUpInterfaceMap(in map[interface{}]interface{}) map[string]interface{} {
-	result := make(map[string]interface{})
-	for k, v := range in {
-		result[fmt.Sprintf("%v", k)] = cleanUpMapValue(v)
-	}
-	return result
-}
-
-func cleanUpInterfaceArray(in []interface{}) []interface{} {
-	result := make([]interface{}, len(in))
-	for i, v := range in {
-		result[i] = cleanUpMapValue(v)
-	}
-	return result
-}
-
-func cleanUpMapValue(v interface{}) interface{} {
-	switch v := v.(type) {
-	case []interface{}:
-		return cleanUpInterfaceArray(v)
-	case map[interface{}]interface{}:
-		return cleanUpInterfaceMap(v)
-	default:
-		return v
 	}
 }
 


### PR DESCRIPTION
## Description
In this pull request (https://github.com/filebrowser/filebrowser/pull/5537), the YAML decoder was updated to yaml.v3. This update caused an error when decoding the YAML file in this line: https://github.com/filebrowser/filebrowser/blob/1053aace8c9a63ded3780f44b18f724cd5602e65/cmd/config_import.go#L73 Because `yaml.v2` decodes to `map[interface{}]interface{}`, but `yaml.v3` decodes to `map[string]interface{}`.

1. The configuration decoding was adjusted to YAML format.
2. The functions previously used for map normalization were removed (since they are no longer needed with `yaml.v3`).

## Additional Information
Closes https://github.com/filebrowser/filebrowser/issues/5705

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
