### PR TITLE
fix: wrap response text in Error before reject

### DIFF
--- a/frontend/src/api/files.ts
+++ b/frontend/src/api/files.ts
@@ -151,9 +151,9 @@ async function postResources(
       if (request.status === 200) {
         resolve(request.responseText);
       } else if (request.status === 409) {
-        reject(request.status);
+        reject(new Error(request.status));
       } else {
-        reject(request.responseText);
+        reject(new Error(request.responseText));
       }
     };
 

--- a/frontend/src/api/files.ts
+++ b/frontend/src/api/files.ts
@@ -151,7 +151,7 @@ async function postResources(
       if (request.status === 200) {
         resolve(request.responseText);
       } else if (request.status === 409) {
-        reject(new Error(request.status));
+        reject(new Error(request.status.toString()));
       } else {
         reject(new Error(request.responseText));
       }


### PR DESCRIPTION
This was causing the error notification not to appear when failing to create a file (due to permissions) because the result was a string, not an Error

## Description

Fix a place where a string is rejected (thrown) and an Error is expected.

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
