### PR TITLE
fix: always show separators and encoding list in the CSV viewer

### DIFF
--- a/frontend/src/components/files/CsvViewer.vue
+++ b/frontend/src/components/files/CsvViewer.vue
@@ -1,5 +1,41 @@
 <template>
   <div class="csv-viewer">
+    <div class="csv-header">
+      <div class="header-select">
+        <label for="columnSeparator">{{ $t("files.columnSeparator") }}</label>
+        <select
+          id="columnSeparator"
+          class="input input--block"
+          v-model="columnSeparator"
+        >
+          <option :value="[',']">
+            {{ $t("files.csvSeparators.comma") }}
+          </option>
+          <option :value="[';']">
+            {{ $t("files.csvSeparators.semicolon") }}
+          </option>
+          <option :value="[',', ';']">
+            {{ $t("files.csvSeparators.both") }}
+          </option>
+        </select>
+      </div>
+      <div class="header-select" v-if="isEncodedContent">
+        <label for="fileEncoding">{{ $t("files.fileEncoding") }}</label>
+        <select
+          id="fileEncoding"
+          class="input input--block"
+          v-model="selectedEncoding"
+        >
+          <option
+            v-for="encoding in availableEncodings"
+            :value="encoding"
+            :key="encoding"
+          >
+            {{ encoding }}
+          </option>
+        </select>
+      </div>
+    </div>
     <div v-if="displayError" class="csv-error">
       <i class="material-icons">error</i>
       <p>{{ displayError }}</p>
@@ -9,42 +45,6 @@
       <p>{{ $t("files.lonely") }}</p>
     </div>
     <div v-else class="csv-table-container" @wheel.stop @touchmove.stop>
-      <div class="csv-header">
-        <div class="header-select">
-          <label for="columnSeparator">{{ $t("files.columnSeparator") }}</label>
-          <select
-            id="columnSeparator"
-            class="input input--block"
-            v-model="columnSeparator"
-          >
-            <option :value="[',']">
-              {{ $t("files.csvSeparators.comma") }}
-            </option>
-            <option :value="[';']">
-              {{ $t("files.csvSeparators.semicolon") }}
-            </option>
-            <option :value="[',', ';']">
-              {{ $t("files.csvSeparators.both") }}
-            </option>
-          </select>
-        </div>
-        <div class="header-select" v-if="isEncodedContent">
-          <label for="fileEncoding">{{ $t("files.fileEncoding") }}</label>
-          <select
-            id="fileEncoding"
-            class="input input--block"
-            v-model="selectedEncoding"
-          >
-            <option
-              v-for="encoding in availableEncodings"
-              :value="encoding"
-              :key="encoding"
-            >
-              {{ encoding }}
-            </option>
-          </select>
-        </div>
-      </div>
       <table class="csv-table">
         <thead>
           <tr>


### PR DESCRIPTION
## Description
This feature allows the separator and encoding list to always be displayed in the .csv file viewer. This means that if a problem occurs when parsing a CSV file with one separator, you can change it to another separator to allow the content to be parsed correctly. For example, in CSV files where the `semicolon` is used as a separator and there are columns with `commas`, having both `;` and `,` selected as separators will cause an error when parsing the CSV because it will interpret the commas in the column content as separators. With this feature, you can change the separator to just the semicolon, and it will parse correctly.

## Additional Information
Closes https://github.com/filebrowser/filebrowser/issues/5768

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
