### PR TITLE
fix: validate current password with a modal

### DIFF
--- a/frontend/src/components/prompts/CurrentPassword.vue
+++ b/frontend/src/components/prompts/CurrentPassword.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="card floating">
+    <div class="card-title">
+      <h2>{{ $t("prompts.currentPassword") }}</h2>
+    </div>
+
+    <div class="card-content">
+      <p>
+        {{ $t("prompts.currentPasswordMessage") }}
+      </p>
+      <input
+        id="focus-prompt"
+        class="input input--block"
+        type="text"
+        @keyup.enter="submit"
+        v-model="password"
+      />
+    </div>
+
+    <div class="card-action">
+      <button
+        class="button button--flat button--grey"
+        @click="cancel"
+        :aria-label="$t('buttons.cancel')"
+        :title="$t('buttons.cancel')"
+      >
+        {{ $t("buttons.cancel") }}
+      </button>
+      <button
+        @click="submit"
+        class="button button--flat"
+        type="submit"
+        :aria-label="$t('buttons.ok')"
+        :title="$t('buttons.ok')"
+      >
+        {{ $t("buttons.ok") }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { useLayoutStore } from "@/stores/layout";
+const layoutStore = useLayoutStore();
+
+const { currentPrompt } = layoutStore;
+
+const password = ref("");
+
+const submit = (event: Event) => {
+  currentPrompt?.confirm(event, password.value);
+};
+
+const cancel = () => {
+  layoutStore.closeHovers();
+};
+</script>

--- a/frontend/src/components/prompts/Prompts.vue
+++ b/frontend/src/components/prompts/Prompts.vue
@@ -28,6 +28,7 @@ import ShareDelete from "./ShareDelete.vue";
 import Upload from "./Upload.vue";
 import DiscardEditorChanges from "./DiscardEditorChanges.vue";
 import ResolveConflict from "./ResolveConflict.vue";
+import CurrentPassword from "./CurrentPassword.vue";
 
 const layoutStore = useLayoutStore();
 
@@ -50,6 +51,7 @@ const components = new Map<string, any>([
   ["deleteUser", DeleteUser],
   ["discardEditorChanges", DiscardEditorChanges],
   ["resolve-conflict", ResolveConflict],
+  ["current-password", CurrentPassword],
 ]);
 
 const modal = computed(() => {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -175,7 +175,9 @@
     "filesInDest": "Files in destination",
     "override": "Overwrite",
     "skip": "Skip",
-    "forbiddenError": "Forbidden Error"
+    "forbiddenError": "Forbidden Error",
+    "currentPassword": "Your password",
+    "currentPasswordMessage": "Enter your password to validate this action."
   },
   "search": {
     "images": "Images",

--- a/frontend/src/views/settings/User.vue
+++ b/frontend/src/views/settings/User.vue
@@ -15,19 +15,6 @@
             :isDefault="false"
             :isNew="isNew"
           />
-
-          <p v-if="isCurrentPasswordRequired">
-            <label for="currentPassword">{{
-              t("settings.currentPassword")
-            }}</label>
-            <input
-              class="input input--block"
-              type="password"
-              v-model="currentPassword"
-              id="currentPassword"
-              autocomplete="current-password"
-            />
-          </p>
         </div>
 
         <div class="card-action">
@@ -77,7 +64,6 @@ const error = ref<StatusError>();
 const originalUser = ref<IUser>();
 const user = ref<IUser>();
 const createUserDir = ref<boolean>(false);
-const currentPassword = ref<string>("");
 const isCurrentPasswordRequired = ref<boolean>(false);
 
 const $showError = inject<IToastError>("$showError")!;
@@ -134,16 +120,30 @@ const fetchData = async () => {
   }
 };
 
-const deletePrompt = () =>
-  layoutStore.showHover({ prompt: "deleteUser", confirm: deleteUser });
+const deletePrompt = () => {
+  if (isCurrentPasswordRequired.value) {
+    layoutStore.showHover({
+      prompt: "current-password",
+      confirm: (event: Event, currentPassword: string) => {
+        event.preventDefault();
+        layoutStore.closeHovers();
+        deleteUser(currentPassword);
+      },
+    });
+  } else {
+    layoutStore.showHover({
+      prompt: "deleteUser",
+      confirm: () => deleteUser(""),
+    });
+  }
+};
 
-const deleteUser = async (e: Event) => {
-  e.preventDefault();
+const deleteUser = async (currentPassword: string) => {
   if (!user.value) {
     return false;
   }
   try {
-    await api.remove(user.value.id, currentPassword.value);
+    await api.remove(user.value.id, currentPassword);
     router.push({ path: "/settings/users" });
     $showSuccess(t("settings.userDeleted"));
   } catch (err) {
@@ -157,8 +157,25 @@ const deleteUser = async (e: Event) => {
   return true;
 };
 
-const save = async (event: Event) => {
+const save = (event: Event) => {
   event.preventDefault();
+  if (isCurrentPasswordRequired.value) {
+    layoutStore.showHover({
+      prompt: "current-password",
+      confirm: (event: Event, currentPassword: string) => {
+        event.preventDefault();
+        layoutStore.closeHovers();
+        send(currentPassword);
+      },
+    });
+  } else {
+    send("");
+  }
+
+  return true;
+};
+
+const send = async (currentPassword: string) => {
   if (!user.value) {
     return false;
   }
@@ -170,11 +187,11 @@ const save = async (event: Event) => {
         ...user.value,
       };
 
-      const loc = await api.create(newUser, currentPassword.value);
+      const loc = await api.create(newUser, currentPassword);
       router.push({ path: loc || "/settings/users" });
       $showSuccess(t("settings.userCreated"));
     } else {
-      await api.update(user.value, ["all"], currentPassword.value);
+      await api.update(user.value, ["all"], currentPassword);
 
       if (user.value.id === authStore.user?.id) {
         authStore.updateUser(user.value);
@@ -185,7 +202,5 @@ const save = async (event: Event) => {
   } catch (e: any) {
     $showError(e);
   }
-
-  return true;
 };
 </script>


### PR DESCRIPTION
## Description
When validating sensitive actions such as creating/updating users and deleting existing users, the password of the logged-in user is requested through a modal window with a clear message to make this process more intuitive.

## Additional Information
Closes https://github.com/filebrowser/filebrowser/issues/5797
<img width="1349" height="629" alt="127 0 0 1_8080_settings_users_new" src="https://github.com/user-attachments/assets/41598a48-5476-41d6-958e-d2331d4b315b" />

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
