### PR TITLE
fix: avoid sending the same name in the file/folder rename modal

### DIFF
--- a/frontend/src/components/prompts/Rename.vue
+++ b/frontend/src/components/prompts/Rename.vue
@@ -6,7 +6,7 @@
 
     <div class="card-content">
       <p>
-        {{ $t("prompts.renameMessage") }} <code>{{ oldName() }}</code
+        {{ $t("prompts.renameMessage") }} <code>{{ oldName }}</code
         >:
       </p>
       <input
@@ -33,6 +33,7 @@
         type="submit"
         :aria-label="$t('buttons.rename')"
         :title="$t('buttons.rename')"
+        :disabled="name === '' || name === oldName"
       >
         {{ $t("buttons.rename") }}
       </button>
@@ -56,7 +57,7 @@ export default {
     };
   },
   created() {
-    this.name = this.oldName();
+    this.name = this.oldName;
   },
   inject: ["$showError"],
   computed: {
@@ -67,25 +68,28 @@ export default {
       "isListing",
     ]),
     ...mapWritableState(useFileStore, ["reload", "preselect"]),
-  },
-  methods: {
-    ...mapActions(useLayoutStore, ["closeHovers"]),
-    cancel: function () {
-      this.closeHovers();
-    },
-    oldName: function () {
+    oldName() {
       if (!this.isListing) {
         return this.req.name;
       }
 
       if (this.selectedCount === 0 || this.selectedCount > 1) {
         // This shouldn't happen.
-        return;
+        return "";
       }
 
       return this.req.items[this.selected[0]].name;
     },
+  },
+  methods: {
+    ...mapActions(useLayoutStore, ["closeHovers"]),
+    cancel: function () {
+      this.closeHovers();
+    },
     submit: async function () {
+      if (this.name === "" || this.name === this.oldName) {
+        return;
+      }
       let oldLink = "";
       let newLink = "";
 


### PR DESCRIPTION
## Description
This PR disables the "Rename" button when the "new" and "old" names are the same.
It also prevents data from being sent when the "enter" key is pressed if the names are the same.

## Additional Information
Closes https://github.com/filebrowser/filebrowser/issues/5793

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
