### PR TITLE
fix(upload): don't mark every folder-upload file as conflicting

### DIFF
--- a/frontend/src/utils/upload.ts
+++ b/frontend/src/utils/upload.ts
@@ -25,7 +25,7 @@ export function checkConflict(
     const file = files[i];
     let name = file.name;
 
-    if (folder_upload) {
+    if (folder_upload && file.isDir) {
       const dirs = file.fullPath?.split("/");
       if (dirs && dirs.length > 1) {
         name = dirs[0];


### PR DESCRIPTION
## Description

Fixes the conflict pre-check for folder uploads so selecting **Skip all conflicting files** can still continue with non-conflicting files.

When uploading a folder, `checkConflict` was treating every nested file as a conflict whenever the top-level folder already existed (because all nested paths were collapsed to the root folder name). That made the skip action remove the full upload queue.

This change keeps the folder-root conflict mapping only for directory entries, and leaves nested files to be handled individually during upload.

## Additional Information

- Scope is intentionally minimal: one conditional in `frontend/src/utils/upload.ts`.
- Repro from #5798: after an interrupted folder upload, re-uploading and choosing "Skip all conflicting files" now proceeds with remaining files instead of doing nothing.

## Checklist

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [ ] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).

Build note: not run locally in this environment because frontend dependencies are not installed and the repo requires Node >=24 (runner has Node 22), so `pnpm run typecheck` cannot complete here.

Fixes #5798
