### PR TITLE
fix(upload): avoid skipping whole folder upload on conflict modal

### DIFF
--- a/frontend/src/utils/upload.ts
+++ b/frontend/src/utils/upload.ts
@@ -23,12 +23,16 @@ export function checkConflict(
 
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
-    let name = file.name;
+    const name = file.name;
 
     if (folder_upload) {
       const dirs = file.fullPath?.split("/");
+      // For folder uploads, destination listing is flat and only contains
+      // top-level entries. Treating every nested file as a conflict when the
+      // parent folder exists blocks the whole upload (see #5798), so skip
+      // preflight conflict detection for nested files.
       if (dirs && dirs.length > 1) {
-        name = dirs[0];
+        continue;
       }
     }
 


### PR DESCRIPTION
## Description
- fix conflict preflight for folder uploads so nested files are not all marked as conflicting when the top-level folder already exists
- keep file-level conflict detection unchanged for non-folder uploads
- this allows "Skip all conflicting files" to continue uploading non-conflicting files instead of aborting the transfer

## Additional Information
- Repro from #5798: re-uploading a partially uploaded folder surfaced the conflict modal, but selecting skip resulted in no upload starting because every nested file was incorrectly treated as a conflict.
- This patch is intentionally minimal and scoped to the preflight conflict check.

## Checklist
- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).

Fixes #5798

## Testing
- `pnpm -C frontend install --config.engine-strict=false`
- `pnpm -C frontend run typecheck`
