### PR TITLE
fix: allow deleting the user's own account

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -21,7 +21,7 @@ var (
 	ErrPermissionDenied         = errors.New("permission denied")
 	ErrInvalidRequestParams     = errors.New("invalid request params")
 	ErrSourceIsParent           = errors.New("source is parent")
-	ErrRootUserDeletion         = errors.New("user with id 1 can't be deleted")
+	ErrRootUserDeletion         = errors.New("the sole admin can't be deleted")
 	ErrCurrentPasswordIncorrect = errors.New("the current password is incorrect")
 )
 

--- a/frontend/src/views/settings/User.vue
+++ b/frontend/src/views/settings/User.vue
@@ -59,6 +59,7 @@ import { useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { StatusError } from "@/api/utils";
 import { authMethod } from "@/utils/constants";
+import { logout } from "@/utils/auth";
 
 const error = ref<StatusError>();
 const originalUser = ref<IUser>();
@@ -144,7 +145,11 @@ const deleteUser = async (currentPassword: string) => {
   }
   try {
     await api.remove(user.value.id, currentPassword);
-    router.push({ path: "/settings/users" });
+    if (user.value.id == authStore.user?.id) {
+      logout();
+    } else {
+      router.push({ path: "/settings/users" });
+    }
     $showSuccess(t("settings.userDeleted"));
   } catch (err) {
     if (err instanceof StatusError) {

--- a/storage/bolt/users.go
+++ b/storage/bolt/users.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/asdine/storm/v3"
+	bolt "go.etcd.io/bbolt"
 
 	fberrors "github.com/filebrowser/filebrowser/v2/errors"
 	"github.com/filebrowser/filebrowser/v2/users"
@@ -92,4 +93,30 @@ func (st usersBackend) DeleteByUsername(username string) error {
 	}
 
 	return st.db.DeleteStruct(user)
+}
+
+func (st usersBackend) CountAdmins() (int, error) {
+	count := 0
+
+	err := st.db.Bolt.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(reflect.TypeOf(users.User{}).Name()))
+		if bucket == nil {
+			return nil
+		}
+
+		c := bucket.Cursor()
+		for _, v := c.First(); v != nil; _, v = c.Next() {
+			var u users.User
+			if err := st.db.Codec().Unmarshal(v, &u); err != nil {
+				return err
+			}
+			if u.Perm.Admin {
+				count++
+			}
+		}
+
+		return nil
+	})
+
+	return count, err
 }

--- a/users/storage.go
+++ b/users/storage.go
@@ -15,6 +15,7 @@ type StorageBackend interface {
 	Update(u *User, fields ...string) error
 	DeleteByID(uint) error
 	DeleteByUsername(string) error
+	CountAdmins() (int, error)
 }
 
 type Store interface {
@@ -108,14 +109,20 @@ func (s *Storage) Delete(id interface{}) error {
 		if err != nil {
 			return err
 		}
-		if user.ID == 1 {
+		if s.IsUniqueAdmin(user) {
 			return fberrors.ErrRootUserDeletion
 		}
+
 		return s.back.DeleteByUsername(id)
 	case uint:
-		if id == 1 {
+		user, err := s.back.GetBy(id)
+		if err != nil {
+			return err
+		}
+		if s.IsUniqueAdmin(user) {
 			return fberrors.ErrRootUserDeletion
 		}
+
 		return s.back.DeleteByID(id)
 	default:
 		return fberrors.ErrInvalidDataType
@@ -130,4 +137,16 @@ func (s *Storage) LastUpdate(id uint) int64 {
 		return val
 	}
 	return 0
+}
+
+func (s *Storage) IsUniqueAdmin(user *User) bool {
+	if !user.Perm.Admin {
+		return false
+	}
+
+	count, err := s.back.CountAdmins()
+	if err != nil {
+		return true
+	}
+	return count <= 1
 }


### PR DESCRIPTION
## Description
This PR introduces the ability for a user to delete their own account, while ensuring that the system always retains at least one administrator.

Key Changes
1. Admin safety check: The backend now verifies that deleting a user will not result in the system having zero administrators.
If the deletion would remove the last remaining admin, the operation is blocked.
This replaces the previous behavior, which only prevented deletion of the first user (default admin).
2. Frontend session handling: The frontend now detects when a user deletes an account.
If the deleted account ID matches the currently authenticated user, the application automatically terminates the session and logs the user out.

## Additional Information
Closes https://github.com/filebrowser/filebrowser/issues/5792

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
