### PR TITLE
fix: properly surface config parse errors

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -118,7 +118,9 @@ func initViper(cmd *cobra.Command) (*viper.Viper, error) {
 
 	// Read in configuration
 	if err := v.ReadInConfig(); err != nil {
-		if errors.Is(err, viper.ConfigParseError{}) {
+
+		var parseErr viper.ConfigParseError
+		if errors.As(err, &parseErr) {
 			return nil, err
 		}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -119,8 +119,7 @@ func initViper(cmd *cobra.Command) (*viper.Viper, error) {
 	// Read in configuration
 	if err := v.ReadInConfig(); err != nil {
 
-		var parseErr viper.ConfigParseError
-		if errors.As(err, &parseErr) {
+		if errors.As(err, &viper.ConfigParseError{}) {
 			return nil, err
 		}
 


### PR DESCRIPTION
## Description

When the configuration file was malformed, the application would incorrectly report that no configuration was being used.

This happened because the error check used `errors.Is` instead of `errors.As`, which prevented `viper.ConfigParseError` from being properly detected.

This change fixes the error detection so configuration parsing errors are correctly surfaced to the user.

## Additional Information

Closes https://github.com/filebrowser/filebrowser/issues/5821

## Checklist

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
