### PR TITLE
feat: add optional directory sizes in listings

### DIFF
--- a/auth/hook.go
+++ b/auth/hook.go
@@ -233,11 +233,12 @@ func (a *HookAuth) GetUser(d *users.User) *users.User {
 			Asc: a.Fields.GetBoolean("user.sorting.asc", d.Sorting.Asc),
 			By:  a.Fields.GetString("user.sorting.by", d.Sorting.By),
 		},
-		Commands:     a.Fields.GetArray("user.commands", d.Commands),
-		DateFormat:   a.Fields.GetBoolean("user.dateFormat", d.DateFormat),
-		HideDotfiles: a.Fields.GetBoolean("user.hideDotfiles", d.HideDotfiles),
-		Perm:         perms,
-		LockPassword: true,
+		Commands:           a.Fields.GetArray("user.commands", d.Commands),
+		DateFormat:         a.Fields.GetBoolean("user.dateFormat", d.DateFormat),
+		HideDotfiles:       a.Fields.GetBoolean("user.hideDotfiles", d.HideDotfiles),
+		ShowDirectorySizes: a.Fields.GetBoolean("user.showDirectorySizes", d.ShowDirectorySizes),
+		Perm:               perms,
+		LockPassword:       true,
 	}
 
 	return &user
@@ -260,6 +261,7 @@ var validHookFields = []string{
 	"user.sorting.asc",
 	"user.commands",
 	"user.hideDotfiles",
+	"user.showDirectorySizes",
 	"user.perm.admin",
 	"user.perm.execute",
 	"user.perm.create",

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -81,6 +81,7 @@ func addUserFlags(flags *pflag.FlagSet) {
 	flags.Bool("redirectAfterCopyMove", false, "redirect to destination after copy/move")
 	flags.Bool("dateFormat", false, "use date format (true for absolute time, false for relative)")
 	flags.Bool("hideDotfiles", false, "hide dotfiles")
+	flags.Bool("showDirectorySizes", false, "show directory sizes in listings")
 	flags.String("aceEditorTheme", "", "ace editor's syntax highlighting theme for users")
 }
 
@@ -142,6 +143,8 @@ func getUserDefaults(flags *pflag.FlagSet, defaults *settings.UserDefaults, all 
 			defaults.DateFormat, err = flags.GetBool(flag.Name)
 		case "hideDotfiles":
 			defaults.HideDotfiles, err = flags.GetBool(flag.Name)
+		case "showDirectorySizes":
+			defaults.ShowDirectorySizes, err = flags.GetBool(flag.Name)
 		}
 
 		if err != nil {

--- a/cmd/users_update.go
+++ b/cmd/users_update.go
@@ -60,6 +60,7 @@ options you want to change.`,
 			Perm:                  user.Perm,
 			Sorting:               user.Sorting,
 			Commands:              user.Commands,
+			ShowDirectorySizes:    user.ShowDirectorySizes,
 		}
 
 		err = getUserDefaults(flags, &defaults, false)
@@ -75,6 +76,7 @@ options you want to change.`,
 		user.Perm = defaults.Perm
 		user.Commands = defaults.Commands
 		user.Sorting = defaults.Sorting
+		user.ShowDirectorySizes = defaults.ShowDirectorySizes
 		user.LockPassword, err = flags.GetBool("lockPassword")
 		if err != nil {
 			return err

--- a/files/file.go
+++ b/files/file.go
@@ -55,15 +55,16 @@ type FileInfo struct {
 
 // FileOptions are the options when getting a file info.
 type FileOptions struct {
-	Fs         afero.Fs
-	Path       string
-	Modify     bool
-	Expand     bool
-	ReadHeader bool
-	CalcImgRes bool
-	Token      string
-	Checker    rules.Checker
-	Content    bool
+	Fs                 afero.Fs
+	Path               string
+	Modify             bool
+	Expand             bool
+	ReadHeader         bool
+	CalcImgRes         bool
+	ShowDirectorySizes bool
+	Token              string
+	Checker            rules.Checker
+	Content            bool
 }
 
 type ImageResolution struct {
@@ -91,7 +92,7 @@ func NewFileInfo(opts *FileOptions) (*FileInfo, error) {
 
 	if opts.Expand {
 		if file.IsDir {
-			if err := file.readListing(opts.Checker, opts.ReadHeader, opts.CalcImgRes); err != nil {
+			if err := file.readListing(opts.Checker, opts.ReadHeader, opts.CalcImgRes, opts.ShowDirectorySizes); err != nil {
 				return nil, err
 			}
 			return file, nil
@@ -390,7 +391,52 @@ func (i *FileInfo) addSubtitle(fPath string) {
 	i.Subtitles = append(i.Subtitles, fPath)
 }
 
-func (i *FileInfo) readListing(checker rules.Checker, readHeader bool, calcImgRes bool) error {
+func calculateDirectorySize(fSys afero.Fs, dirPath string, checker rules.Checker) (int64, error) {
+	dir, err := afero.ReadDir(fSys, dirPath)
+	if err != nil {
+		return 0, err
+	}
+
+	var size int64
+	for _, entry := range dir {
+		entryPath := path.Join(dirPath, entry.Name())
+		if !checker.Check(entryPath) {
+			continue
+		}
+
+		entrySize, err := calculateEntrySize(fSys, entryPath, entry, checker)
+		if err != nil {
+			return 0, err
+		}
+
+		size += entrySize
+	}
+
+	return size, nil
+}
+
+func calculateEntrySize(fSys afero.Fs, filePath string, info os.FileInfo, checker rules.Checker) (int64, error) {
+	if IsSymlink(info.Mode()) {
+		resolved, err := fSys.Stat(filePath)
+		if err != nil {
+			return 0, nil
+		}
+
+		if resolved.IsDir() {
+			return 0, nil
+		}
+
+		return resolved.Size(), nil
+	}
+
+	if !info.IsDir() {
+		return info.Size(), nil
+	}
+
+	return calculateDirectorySize(fSys, filePath, checker)
+}
+
+func (i *FileInfo) readListing(checker rules.Checker, readHeader bool, calcImgRes bool, showDirectorySizes bool) error {
 	afs := &afero.Afero{Fs: i.Fs}
 	dir, err := afs.ReadDir(i.Path)
 	if err != nil {
@@ -402,6 +448,7 @@ func (i *FileInfo) readListing(checker rules.Checker, readHeader bool, calcImgRe
 		NumDirs:  0,
 		NumFiles: 0,
 	}
+	var totalSize int64
 
 	for _, f := range dir {
 		name := f.Name()
@@ -448,6 +495,14 @@ func (i *FileInfo) readListing(checker rules.Checker, readHeader bool, calcImgRe
 
 		if file.IsDir {
 			listing.NumDirs++
+			if showDirectorySizes {
+				dirSize, err := calculateDirectorySize(file.Fs, file.Path, checker)
+				if err != nil {
+					log.Printf("Error calculating directory size for %s: %v", file.Path, err)
+				} else {
+					file.Size = dirSize
+				}
+			}
 		} else {
 			listing.NumFiles++
 
@@ -461,9 +516,13 @@ func (i *FileInfo) readListing(checker rules.Checker, readHeader bool, calcImgRe
 			}
 		}
 
+		totalSize += file.Size
 		listing.Items = append(listing.Items, file)
 	}
 
 	i.Listing = listing
+	if showDirectorySizes {
+		i.Size = totalSize
+	}
 	return nil
 }

--- a/files/file_test.go
+++ b/files/file_test.go
@@ -1,0 +1,129 @@
+package files
+
+import (
+	"path"
+	"testing"
+
+	"github.com/spf13/afero"
+)
+
+type checkerFunc func(string) bool
+
+func (f checkerFunc) Check(filePath string) bool {
+	return f(filePath)
+}
+
+func TestReadListingCalculatesDirectorySizes(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	writeTestFile(t, fs, "/notes.txt", "hi")
+	writeTestFile(t, fs, "/projects/api/main.go", "123")
+	writeTestFile(t, fs, "/projects/web/index.html", "12345")
+
+	file, err := NewFileInfo(&FileOptions{
+		Fs:                 fs,
+		Path:               "/",
+		Expand:             true,
+		ShowDirectorySizes: true,
+		Checker:            checkerFunc(func(string) bool { return true }),
+	})
+	if err != nil {
+		t.Fatalf("NewFileInfo returned error: %v", err)
+	}
+
+	projects := findItemByName(t, file.Items, "projects")
+	if got, want := projects.Size, int64(8); got != want {
+		t.Fatalf("directory size = %d, want %d", got, want)
+	}
+
+	if got, want := file.Size, int64(10); got != want {
+		t.Fatalf("root directory size = %d, want %d", got, want)
+	}
+}
+
+func TestReadListingSkipsHiddenEntriesInDirectorySizes(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	writeTestFile(t, fs, "/visible/report.txt", "123")
+	writeTestFile(t, fs, "/visible/.secret.txt", "12345")
+	writeTestFile(t, fs, "/visible/.private/hidden.txt", "1234567")
+
+	file, err := NewFileInfo(&FileOptions{
+		Fs:                 fs,
+		Path:               "/",
+		Expand:             true,
+		ShowDirectorySizes: true,
+		Checker: checkerFunc(func(filePath string) bool {
+			for current := filePath; current != "/" && current != "."; current = path.Dir(current) {
+				if path.Base(current) != "" && path.Base(current)[0] == '.' {
+					return false
+				}
+			}
+			return true
+		}),
+	})
+	if err != nil {
+		t.Fatalf("NewFileInfo returned error: %v", err)
+	}
+
+	visible := findItemByName(t, file.Items, "visible")
+	if got, want := visible.Size, int64(3); got != want {
+		t.Fatalf("directory size with hidden files filtered = %d, want %d", got, want)
+	}
+}
+
+func TestApplySortUsesCalculatedDirectorySizes(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	writeTestFile(t, fs, "/small/a.txt", "1")
+	writeTestFile(t, fs, "/large/a.txt", "123456")
+
+	file, err := NewFileInfo(&FileOptions{
+		Fs:                 fs,
+		Path:               "/",
+		Expand:             true,
+		ShowDirectorySizes: true,
+		Checker:            checkerFunc(func(string) bool { return true }),
+	})
+	if err != nil {
+		t.Fatalf("NewFileInfo returned error: %v", err)
+	}
+
+	file.Sorting = Sorting{By: "size", Asc: true}
+	file.ApplySort()
+
+	if got, want := file.Items[0].Name, "small"; got != want {
+		t.Fatalf("first item after sort = %q, want %q", got, want)
+	}
+	if got, want := file.Items[1].Name, "large"; got != want {
+		t.Fatalf("second item after sort = %q, want %q", got, want)
+	}
+}
+
+func writeTestFile(t *testing.T, fs afero.Fs, filePath, contents string) {
+	t.Helper()
+
+	if err := fs.MkdirAll(path.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) returned error: %v", path.Dir(filePath), err)
+	}
+
+	if err := afero.WriteFile(fs, filePath, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) returned error: %v", filePath, err)
+	}
+}
+
+func findItemByName(t *testing.T, items []*FileInfo, name string) *FileInfo {
+	t.Helper()
+
+	for _, item := range items {
+		if item.Name == name {
+			return item
+		}
+	}
+
+	t.Fatalf("item %q not found", name)
+	return nil
+}

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -33,7 +33,14 @@
     <div>
       <p class="name">{{ name }}</p>
 
-      <p v-if="isDir" class="size" data-order="-1">&mdash;</p>
+      <p
+        v-if="isDir && showDirectorySizes"
+        class="size"
+        :data-order="humanSize()"
+      >
+        {{ humanSize() }}
+      </p>
+      <p v-else-if="isDir" class="size" data-order="-1">&mdash;</p>
       <p v-else class="size" :data-order="humanSize()">{{ humanSize() }}</p>
 
       <p class="modified">
@@ -116,6 +123,10 @@ const thumbnailUrl = computed(() => {
 
 const isThumbsEnabled = computed(() => {
   return enableThumbs;
+});
+
+const showDirectorySizes = computed(() => {
+  return !props.readOnly && props.isDir && !!authStore.user?.showDirectorySizes;
 });
 
 const humanSize = () => {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -259,6 +259,8 @@
     "shareDuration": "Freigabedauer",
     "shareManagement": "Freigabeverwaltung",
     "shareDeleted": "Freigabe gelöscht!",
+    "showDirectorySizes": "Verzeichnisgrößen in Listen anzeigen",
+    "showDirectorySizesHelp": "Die Berechnung von Verzeichnisgrößen kann große Ordner verlangsamen.",
     "singleClick": "Einfacher Klick zum Öffnen von Dateien und Verzeichnissen",
     "themes": {
       "default": "Systemstandard",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -261,6 +261,8 @@
     "shareDuration": "Share Duration",
     "shareManagement": "Share Management",
     "shareDeleted": "Share deleted!",
+    "showDirectorySizes": "Show directory sizes in listings",
+    "showDirectorySizesHelp": "Calculating directory sizes can slow down large folders.",
     "singleClick": "Use single clicks to open files and directories",
     "themes": {
       "default": "System default",

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -23,6 +23,7 @@ interface SettingsDefaults {
   perm: Permissions;
   commands: any[];
   hideDotfiles: boolean;
+  showDirectorySizes: boolean;
   dateFormat: boolean;
   aceEditorTheme: string;
 }

--- a/frontend/src/types/user.d.ts
+++ b/frontend/src/types/user.d.ts
@@ -9,6 +9,7 @@ interface IUser {
   rules: IRule[];
   lockPassword: boolean;
   hideDotfiles: boolean;
+  showDirectorySizes: boolean;
   singleClick: boolean;
   redirectAfterCopyMove: boolean;
   dateFormat: boolean;
@@ -30,6 +31,7 @@ interface IUserForm {
   rules?: IRule[];
   lockPassword?: boolean;
   hideDotfiles?: boolean;
+  showDirectorySizes?: boolean;
   singleClick?: boolean;
   redirectAfterCopyMove?: boolean;
   dateFormat?: boolean;

--- a/frontend/src/views/settings/Profile.vue
+++ b/frontend/src/views/settings/Profile.vue
@@ -12,6 +12,17 @@
             {{ t("settings.hideDotfiles") }}
           </p>
           <p>
+            <input
+              type="checkbox"
+              name="showDirectorySizes"
+              v-model="showDirectorySizes"
+            />
+            {{ t("settings.showDirectorySizes") }}
+          </p>
+          <p class="small">
+            {{ t("settings.showDirectorySizesHelp") }}
+          </p>
+          <p>
             <input type="checkbox" name="singleClick" v-model="singleClick" />
             {{ t("settings.singleClick") }}
           </p>
@@ -123,6 +134,7 @@ const passwordConf = ref<string>("");
 const currentPassword = ref<string>("");
 const isCurrentPasswordRequired = ref<boolean>(false);
 const hideDotfiles = ref<boolean>(false);
+const showDirectorySizes = ref<boolean>(false);
 const singleClick = ref<boolean>(false);
 const redirectAfterCopyMove = ref<boolean>(false);
 const dateFormat = ref<boolean>(false);
@@ -148,6 +160,7 @@ onMounted(async () => {
   if (authStore.user === null) return false;
   locale.value = authStore.user.locale;
   hideDotfiles.value = authStore.user.hideDotfiles;
+  showDirectorySizes.value = authStore.user.showDirectorySizes;
   singleClick.value = authStore.user.singleClick;
   redirectAfterCopyMove.value = authStore.user.redirectAfterCopyMove;
   dateFormat.value = authStore.user.dateFormat;
@@ -196,6 +209,7 @@ const updateSettings = async (event: Event) => {
       id: authStore.user.id,
       locale: locale.value,
       hideDotfiles: hideDotfiles.value,
+      showDirectorySizes: showDirectorySizes.value,
       singleClick: singleClick.value,
       redirectAfterCopyMove: redirectAfterCopyMove.value,
       dateFormat: dateFormat.value,
@@ -205,6 +219,7 @@ const updateSettings = async (event: Event) => {
     await api.update(data, [
       "locale",
       "hideDotfiles",
+      "showDirectorySizes",
       "singleClick",
       "redirectAfterCopyMove",
       "dateFormat",

--- a/http/auth.go
+++ b/http/auth.go
@@ -32,6 +32,7 @@ type userInfo struct {
 	Commands              []string          `json:"commands"`
 	LockPassword          bool              `json:"lockPassword"`
 	HideDotfiles          bool              `json:"hideDotfiles"`
+	ShowDirectorySizes    bool              `json:"showDirectorySizes"`
 	DateFormat            bool              `json:"dateFormat"`
 	Username              string            `json:"username"`
 	AceEditorTheme        string            `json:"aceEditorTheme"`
@@ -214,6 +215,7 @@ func printToken(w http.ResponseWriter, _ *http.Request, d *data, user *users.Use
 			LockPassword:          user.LockPassword,
 			Commands:              user.Commands,
 			HideDotfiles:          user.HideDotfiles,
+			ShowDirectorySizes:    user.ShowDirectorySizes,
 			DateFormat:            user.DateFormat,
 			Username:              user.Username,
 			AceEditorTheme:        user.AceEditorTheme,

--- a/http/resource.go
+++ b/http/resource.go
@@ -24,13 +24,14 @@ import (
 
 var resourceGetHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
 	file, err := files.NewFileInfo(&files.FileOptions{
-		Fs:         d.user.Fs,
-		Path:       r.URL.Path,
-		Modify:     d.user.Perm.Modify,
-		Expand:     true,
-		ReadHeader: d.server.TypeDetectionByHeader,
-		Checker:    d,
-		Content:    true,
+		Fs:                 d.user.Fs,
+		Path:               r.URL.Path,
+		Modify:             d.user.Perm.Modify,
+		Expand:             true,
+		ReadHeader:         d.server.TypeDetectionByHeader,
+		ShowDirectorySizes: d.user.ShowDirectorySizes,
+		Checker:            d,
+		Content:            true,
 	})
 	if err != nil {
 		return errToStatus(err), err

--- a/settings/defaults.go
+++ b/settings/defaults.go
@@ -17,6 +17,7 @@ type UserDefaults struct {
 	Perm                  users.Permissions `json:"perm"`
 	Commands              []string          `json:"commands"`
 	HideDotfiles          bool              `json:"hideDotfiles"`
+	ShowDirectorySizes    bool              `json:"showDirectorySizes"`
 	DateFormat            bool              `json:"dateFormat"`
 	AceEditorTheme        string            `json:"aceEditorTheme"`
 }
@@ -32,6 +33,7 @@ func (d *UserDefaults) Apply(u *users.User) {
 	u.Sorting = d.Sorting
 	u.Commands = d.Commands
 	u.HideDotfiles = d.HideDotfiles
+	u.ShowDirectorySizes = d.ShowDirectorySizes
 	u.DateFormat = d.DateFormat
 	u.AceEditorTheme = d.AceEditorTheme
 }

--- a/users/users.go
+++ b/users/users.go
@@ -35,6 +35,7 @@ type User struct {
 	Fs                    afero.Fs      `json:"-" yaml:"-"`
 	Rules                 []rules.Rule  `json:"rules"`
 	HideDotfiles          bool          `json:"hideDotfiles"`
+	ShowDirectorySizes    bool          `json:"showDirectorySizes"`
 	DateFormat            bool          `json:"dateFormat"`
 	AceEditorTheme        string        `json:"aceEditorTheme"`
 }

--- a/www/docs/cli/filebrowser-config-init.md
+++ b/www/docs/cli/filebrowser-config-init.md
@@ -66,6 +66,7 @@ filebrowser config init [flags]
       --scope string                     scope for users (default ".")
       --shell string                     shell command to which other commands should be appended
   -s, --signup                           allow users to signup
+      --showDirectorySizes               show directory sizes in listings
       --singleClick                      use single clicks only
       --socket string                    socket to listen to (cannot be used with address, port, cert nor key flags)
       --sorting.asc                      sorting by ascending order
@@ -86,4 +87,3 @@ filebrowser config init [flags]
 ## See Also
 
 * [filebrowser config](filebrowser-config.md)	 - Configuration management utility
-

--- a/www/docs/cli/filebrowser-config-set.md
+++ b/www/docs/cli/filebrowser-config-set.md
@@ -63,6 +63,7 @@ filebrowser config set [flags]
       --scope string                     scope for users (default ".")
       --shell string                     shell command to which other commands should be appended
   -s, --signup                           allow users to signup
+      --showDirectorySizes               show directory sizes in listings
       --singleClick                      use single clicks only
       --socket string                    socket to listen to (cannot be used with address, port, cert nor key flags)
       --sorting.asc                      sorting by ascending order
@@ -83,4 +84,3 @@ filebrowser config set [flags]
 ## See Also
 
 * [filebrowser config](filebrowser-config.md)	 - Configuration management utility
-

--- a/www/docs/cli/filebrowser-users-add.md
+++ b/www/docs/cli/filebrowser-users-add.md
@@ -30,6 +30,7 @@ filebrowser users add <username> <password> [flags]
       --perm.share              share perm for users (default true)
       --redirectAfterCopyMove   redirect to destination after copy/move
       --scope string            scope for users (default ".")
+      --showDirectorySizes      show directory sizes in listings
       --singleClick             use single clicks only
       --sorting.asc             sorting by ascending order
       --sorting.by string       sorting mode (name, size or modified) (default "name")
@@ -46,4 +47,3 @@ filebrowser users add <username> <password> [flags]
 ## See Also
 
 * [filebrowser users](filebrowser-users.md)	 - Users management utility
-

--- a/www/docs/cli/filebrowser-users-update.md
+++ b/www/docs/cli/filebrowser-users-update.md
@@ -32,6 +32,7 @@ filebrowser users update <id|username> [flags]
       --perm.share              share perm for users (default true)
       --redirectAfterCopyMove   redirect to destination after copy/move
       --scope string            scope for users (default ".")
+      --showDirectorySizes      show directory sizes in listings
       --singleClick             use single clicks only
       --sorting.asc             sorting by ascending order
       --sorting.by string       sorting mode (name, size or modified) (default "name")
@@ -49,4 +50,3 @@ filebrowser users update <id|username> [flags]
 ## See Also
 
 * [filebrowser users](filebrowser-users.md)	 - Users management utility
-


### PR DESCRIPTION
## Description

Add an optional per-user setting to calculate and display directory sizes in file listings.

Today File Browser shows file sizes but not useful directory sizes in the listing view. This change adds a new profile setting, `showDirectorySizes`, which is disabled by default. When enabled, directory sizes are calculated recursively in the backend and shown in the UI. The calculated values are also used when sorting by size.

## Additional Information

The implementation was added to the existing backend listing pipeline instead of shelling out to a platform-specific command such as `du`. That keeps the feature portable, testable, and consistent with the current file metadata flow.

The setting is stored on the user model, passed through defaults/auth payloads, exposed in Profile Settings, and consumed by the listing UI. Directory size calculation respects the existing checker/rule filtering so hidden or blocked entries are not counted. Symlinked directories are not traversed.

The feature is intentionally opt-in because recursive size calculation can be expensive on large directory trees.

I also added backend tests for directory size calculation and size-based sorting.

This PR includes minimal UI string additions in `en.json` and `de.json` only because the new setting requires labels in the interface. It is not intended as a translation-focused change.

## Checklist

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
