### PR TITLE
fix: close copy dialog after successful copy operation

### DIFF
--- a/frontend/src/components/prompts/Copy.vue
+++ b/frontend/src/components/prompts/Copy.vue
@@ -106,10 +106,10 @@ export default {
           .then(() => {
             buttons.success("copy");
             this.preselect = removePrefix(items[0].to);
+            this.closeHovers();
 
             if (this.$route.path === this.dest) {
               this.reload = true;
-
               return;
             }
 


### PR DESCRIPTION
## Bug
https://github.com/filebrowser/filebrowser/issues/5840 — Copy dialog remains open after directory copy completion, causing '404 not found' errors and UI state issues.

## Fix
Ensures the copy dialog is properly closed in all success paths by calling closeHovers() immediately after the copy operation succeeds, before any navigation or reload operations.

## Testing
Verified the fix addresses the issue where:
- Copy dialog would remain displayed during copy operations
- 404 errors would appear after copy completion
- UI would remain in a dark/background state

The fix ensures consistent dialog cleanup behavior matching the move operation pattern.

Greetings, saschabuehrle