### PR TITLE
fix: touch Redis upload cache key on GetLength to prevent TTL expiry

### DIFF
--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -18,8 +18,6 @@ import (
 
 // keepUploadActive periodically touches the cache entry to prevent eviction during transfer
 func keepUploadActive(cache UploadCache, filePath string) func() {
-	cache.Touch(filePath)
-
 	stop := make(chan bool)
 
 	go func() {

--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -18,6 +18,8 @@ import (
 
 // keepUploadActive periodically touches the cache entry to prevent eviction during transfer
 func keepUploadActive(cache UploadCache, filePath string) func() {
+	cache.Touch(filePath)
+
 	stop := make(chan bool)
 
 	go func() {

--- a/http/upload_cache_redis.go
+++ b/http/upload_cache_redis.go
@@ -67,6 +67,8 @@ func (c *redisUploadCache) GetLength(filePath string) (int64, error) {
 		return 0, fmt.Errorf("invalid upload length in cache: %w", err)
 	}
 
+	c.Touch(filePath)
+
 	return size, nil
 }
 


### PR DESCRIPTION
## Description

When using the Redis upload cache, big file uploads (that take longer than 2 minutes in total) fail with a `409 - Conflict`.

On file upload in FileBrowser, the file is registered in an upload cache with a TTL (of 2 minutes) so FileBrowser can track all the in-progress uploads. The TTL is naturally set so that if the upload fails, the file key is eventually removed from the upload cache.

When using the `ttlcache` (in-memory) upload cache, `GetLength` will also automatically touch the key, extending its expiry. However, with Redis, running a `GET` does not automatically extend the TTL. This means `GetLength` was never touching the key with this upload cache.

Additionally, when uploading, FileBrowser uses tus to upload the file in 10MB chunks via a PATCH. When this PATCH is handled, a goroutine is started which will touch the key in the upload cache every two seconds, extending the TTL to ensure the key does not expire while an upload is in progress.

However, because the keep-alive goroutine only touches the key after an initial two-second delay — if a 10MB chunk uploads in under two seconds (e.g. on a fast network and/or fast storage), the goroutine is cancelled before the key is ever touched. This means the TTL is never extended, leading to eventual key expiry after 2 minutes — which causes a `409 - Conflict` error.

## Additional Information

N/A

## Checklist

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).