### PR TITLE
fix: language change issue

### DIFF
--- a/frontend/src/views/settings/Global.vue
+++ b/frontend/src/views/settings/Global.vue
@@ -251,6 +251,7 @@ import { StatusError } from "@/api/utils";
 import Rules from "@/components/settings/Rules.vue";
 import Themes from "@/components/settings/Themes.vue";
 import UserForm from "@/components/settings/UserForm.vue";
+import { setHtmlLocale, setLocale } from "@/i18n";
 import { useLayoutStore } from "@/stores/layout";
 import { enableExec } from "@/utils/constants";
 import { getTheme, setTheme } from "@/utils/theme";
@@ -349,6 +350,8 @@ const save = async () => {
 
   try {
     await api.update(newSettings);
+    setLocale(newSettings.defaults.locale); // change language
+    setHtmlLocale(newSettings.defaults.locale); // change language
     $showSuccess(t("settings.settingsUpdated"));
   } catch (e: any) {
     $showError(e);
@@ -397,6 +400,7 @@ onMounted(async () => {
     layoutStore.loading = true;
     const original: ISettings = await api.get();
     const newSettings: ISettings = { ...original, commands: {} };
+    setLocale(original.defaults.locale);
 
     const keys = Object.keys(original.commands) as Array<keyof SettingsCommand>;
     for (const key of keys) {

--- a/http/auth.go
+++ b/http/auth.go
@@ -133,6 +133,8 @@ func loginHandler(tokenExpireTime time.Duration) handleFunc {
 			return http.StatusInternalServerError, err
 		}
 
+		user.Locale = d.settings.Defaults.Locale // set language
+
 		return printToken(w, r, d, user, tokenExpireTime)
 	}
 }


### PR DESCRIPTION
## fix: language change issue

When the user changes the language on the frontend, the interface language does not change.

## Checklist

1. fixed: When the user changes the language on the frontend, the interface language does not change.
    now it can be changed when user click the Update Button in setting page.
2. fixed: Every time the user login, the interface language is English, not the language previously set by the user.
    I found out that the reason is that when the user login, the locale field in the data passed from the backend to the frontend is null, so the frontend uses the default locale field: English. Now I have changed it so that the locale field in the settings is passed from the backend to the frontend every time the user logs in.
    
## Additional Information

there is a same parblem in theme change：when use click the Update Button to change page theme, the theme will indeed be changed. But if user reflesh the page or relogin, the theme will revert to the default setting (Dark).

<mark>**I didn't fix the issue of theme changes, but only fixed the problem of language changes. **</mark>

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
