### PR TITLE
fix: include filename in Content-Disposition header for inline downloads

### DIFF
--- a/http/raw.go
+++ b/http/raw.go
@@ -72,6 +72,7 @@ func parseQueryAlgorithm(r *http.Request) (string, archives.Archival, error) {
 
 func setContentDisposition(w http.ResponseWriter, r *http.Request, file *files.FileInfo) {
 	if r.URL.Query().Get("inline") == "true" {
+		// As per RFC6266 section 4.3
 		w.Header().Set("Content-Disposition", "inline; filename*=utf-8''"+url.PathEscape(file.Name))
 	} else {
 		// As per RFC6266 section 4.3

--- a/http/raw.go
+++ b/http/raw.go
@@ -72,7 +72,7 @@ func parseQueryAlgorithm(r *http.Request) (string, archives.Archival, error) {
 
 func setContentDisposition(w http.ResponseWriter, r *http.Request, file *files.FileInfo) {
 	if r.URL.Query().Get("inline") == "true" {
-		w.Header().Set("Content-Disposition", "inline")
+		w.Header().Set("Content-Disposition", "inline; filename*=utf-8''"+url.PathEscape(file.Name))
 	} else {
 		// As per RFC6266 section 4.3
 		w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.PathEscape(file.Name))

--- a/http/raw_test.go
+++ b/http/raw_test.go
@@ -1,0 +1,75 @@
+package fbhttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/filebrowser/filebrowser/v2/files"
+)
+
+func TestSetContentDisposition(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		filename string
+		inline   bool
+		expected string
+	}{
+		"inline simple filename": {
+			filename: "document.pdf",
+			inline:   true,
+			expected: "inline; filename*=utf-8''" + url.PathEscape("document.pdf"),
+		},
+		"attachment simple filename": {
+			filename: "document.pdf",
+			inline:   false,
+			expected: "attachment; filename*=utf-8''" + url.PathEscape("document.pdf"),
+		},
+		"inline non-ASCII filename": {
+			filename: "日本語.txt",
+			inline:   true,
+			expected: "inline; filename*=utf-8''" + url.PathEscape("日本語.txt"),
+		},
+		"attachment non-ASCII filename": {
+			filename: "日本語.txt",
+			inline:   false,
+			expected: "attachment; filename*=utf-8''" + url.PathEscape("日本語.txt"),
+		},
+		"inline filename with spaces": {
+			filename: "my file.txt",
+			inline:   true,
+			expected: "inline; filename*=utf-8''" + url.PathEscape("my file.txt"),
+		},
+		"attachment filename with spaces": {
+			filename: "my file.txt",
+			inline:   false,
+			expected: "attachment; filename*=utf-8''" + url.PathEscape("my file.txt"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := httptest.NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/test", http.NoBody)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+			if tc.inline {
+				req.URL.RawQuery = "inline=true"
+			}
+
+			file := &files.FileInfo{Name: tc.filename}
+
+			setContentDisposition(recorder, req, file)
+
+			got := recorder.Header().Get("Content-Disposition")
+			if got != tc.expected {
+				t.Errorf("Content-Disposition = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

When a shared file is downloaded via the public download handler (`/api/public/dl/<hash>`) with `?inline=true`, the browser uses the share hash as the filename because the `Content-Disposition` header is set to just `inline` without a filename parameter.

This adds `filename*=utf-8''<encoded-name>` to the inline case in `setContentDisposition()`, matching what the attachment case already does.

Fixes #5859

## Additional Information

The fix is minimal — one line change in `http/raw.go`. A unit test `TestSetContentDisposition` is added in `http/raw_test.go` covering both inline and attachment cases with ASCII and non-ASCII filenames.

## Checklist

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).