### PR TITLE
fix: check download permission when sharing permission is enabled

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -23,6 +23,7 @@ var (
 	ErrSourceIsParent           = errors.New("source is parent")
 	ErrRootUserDeletion         = errors.New("the sole admin can't be deleted")
 	ErrCurrentPasswordIncorrect = errors.New("the current password is incorrect")
+	ErrShareRequiresDownload    = errors.New("permission to share requires permission to download")
 )
 
 type ErrShortPassword struct {

--- a/frontend/src/components/settings/Permissions.vue
+++ b/frontend/src/components/settings/Permissions.vue
@@ -19,7 +19,7 @@
     <p>
       <input
         type="checkbox"
-        :disabled="admin || isShareEnabled"
+        :disabled="admin || perm.share"
         v-model="perm.download"
       />
       {{ $t("settings.perm.download") }}
@@ -49,9 +49,6 @@ export default {
   name: "permissions",
   props: ["perm"],
   computed: {
-    isShareEnabled() {
-      return this.perm.share;
-    },
     admin: {
       get() {
         return this.perm.admin;

--- a/frontend/src/components/settings/Permissions.vue
+++ b/frontend/src/components/settings/Permissions.vue
@@ -17,7 +17,11 @@
       {{ $t("settings.perm.delete") }}
     </p>
     <p>
-      <input type="checkbox" :disabled="admin" v-model="perm.download" />
+      <input
+        type="checkbox"
+        :disabled="admin || isShareEnabled"
+        v-model="perm.download"
+      />
       {{ $t("settings.perm.download") }}
     </p>
     <p>
@@ -45,6 +49,9 @@ export default {
   name: "permissions",
   props: ["perm"],
   computed: {
+    isShareEnabled() {
+      return this.perm.share;
+    },
     admin: {
       get() {
         return this.perm.admin;
@@ -60,6 +67,16 @@ export default {
       },
     },
     isExecEnabled: () => enableExec,
+  },
+  watch: {
+    perm: {
+      deep: true,
+      handler() {
+        if (this.perm.share === true) {
+          this.perm.download = true;
+        }
+      },
+    },
   },
 };
 </script>

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -245,7 +245,7 @@
       "execute": "Execute commands",
       "modify": "Edit files",
       "rename": "Rename or move files and directories",
-      "share": "Share files"
+      "share": "Share files (require download permission)"
     },
     "permissions": "Permissions",
     "permissionsHelp": "You can set the user to be an administrator or choose the permissions individually. If you select \"Administrator\", all of the other options will be automatically checked. The management of users remains a privilege of an administrator.\n",

--- a/http/users.go
+++ b/http/users.go
@@ -156,6 +156,10 @@ var userPostHandler = withAdmin(func(w http.ResponseWriter, r *http.Request, d *
 		return http.StatusBadRequest, err
 	}
 
+	if req.Data.Perm.Share && !req.Data.Perm.Download {
+		return http.StatusBadRequest, fberrors.ErrShareRequiresDownload
+	}
+
 	userHome, err := d.settings.MakeUserDir(req.Data.Username, req.Data.Scope, d.server.Root)
 	if err != nil {
 		log.Printf("create user: failed to mkdir user home dir: [%s]", userHome)
@@ -202,6 +206,14 @@ var userPutHandler = withSelfOrAdmin(func(w http.ResponseWriter, r *http.Request
 
 	if req.Data.ID != d.raw.(uint) {
 		return http.StatusBadRequest, nil
+	}
+
+	for _, field := range req.Which {
+		if strings.ToLower(field) == "perm" || strings.ToLower(field) == "all" {
+			if req.Data.Perm.Share && !req.Data.Perm.Download {
+				return http.StatusBadRequest, fberrors.ErrShareRequiresDownload
+			}
+		}
 	}
 
 	if len(req.Which) == 0 || (len(req.Which) == 1 && req.Which[0] == "all") {


### PR DESCRIPTION
## Description
This PR verifies that the download permission is active when a user with the sharing permission enabled is created/updated
1. Add a visual indicator to the interface making it clear that sharing permission requires download permission to be enabled.
2. Automatically activates and locks the download permission checkbox when the sharing permission is enabled.
3. It applies a backend check to detect if an attempt is made to create/update a user with sharing permission without download permission enabled.

## Additional Information
Closes https://github.com/filebrowser/filebrowser/issues/5835

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
