### PR TITLE
fix(tus): reject negative upload-length to prevent inconsistent cache entry

### DIFF
--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -105,7 +105,7 @@ func tusPostHandler(cache UploadCache) handleFunc {
 		}
 
 		uploadLength, err := getUploadLength(r)
-		if err != nil {
+		if err != nil || uploadLength < 0 {
 			return http.StatusBadRequest, fmt.Errorf("invalid upload length: %w", err)
 		}
 


### PR DESCRIPTION
## Description
This PR adds a validation step to reject negative Upload-Length values in TUS upload requests.  
A negative length could create an inconsistent upload cache entry and cause FileBrowser to treat the upload as completed prematurely (Described at https://github.com/filebrowser/filebrowser/security/advisories/GHSA-ffx7-75gc-jg7c). By ensuring the value is non‑negative, we prevent invalid upload sessions and avoid triggering hooks before the file actually exists.

## Additional Information
Closes https://github.com/filebrowser/filebrowser/issues/5834

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
