### PR TITLE
feat: enable copy operation on drag‑and‑drop with ctrl key

### DIFF
--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -194,8 +194,11 @@ const drop = async (event: Event) => {
   const baseItems = (await api.fetch(path)).items;
 
   const action = (overwrite?: boolean, rename?: boolean) => {
-    api
-      .move(items, overwrite, rename)
+    const action =
+      (event as KeyboardEvent).ctrlKey || (event as KeyboardEvent).metaKey
+        ? api.copy
+        : api.move;
+    action(items, overwrite, rename)
       .then(() => {
         fileStore.reload = true;
       })


### PR DESCRIPTION
## Description
This PR updates drag‑and‑drop so it no longer always moves items.
If the user holds Ctrl (Windows/Linux) or Command (macOS), the operation now performs a copy instead of a move.
This brings the behavior in line with common OS conventions and avoids accidental moves.

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in maintenance-only mode. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
