### PR TITLE
feat: add native OIDC authentication

### DIFF
--- a/Dockerfile.oidc
+++ b/Dockerfile.oidc
@@ -1,0 +1,59 @@
+## Stage 1: Build frontend
+FROM node:22-alpine AS frontend-builder
+WORKDIR /app/frontend
+RUN npm install -g pnpm@latest
+COPY frontend/package.json frontend/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY frontend/ ./
+RUN pnpm run build
+
+## Stage 2: Build Go backend
+FROM golang:1.25-alpine AS backend-builder
+RUN apk add --no-cache git
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
+RUN go build -ldflags='-s -w -X "github.com/filebrowser/filebrowser/v2/version.Version=oidc-custom"' \
+    -o filebrowser .
+
+## Stage 3: Fetch runtime dependencies
+FROM alpine:3.23 AS fetcher
+RUN apk update && \
+    apk --no-cache add ca-certificates mailcap tini-static wget && \
+    wget -O /JSON.sh https://raw.githubusercontent.com/dominictarr/JSON.sh/0d5e5c77365f63809bf6e77ef44a1f34b0e05840/JSON.sh
+
+## Stage 4: Final runtime image
+FROM busybox:1.37.0-musl
+
+ENV UID=991
+ENV GID=984
+
+RUN addgroup -g $GID share 2>/dev/null || true && \
+    addgroup -g 985 media 2>/dev/null || true && \
+    adduser -D -u $UID -G share user
+
+COPY --chown=user:share --from=backend-builder /app/filebrowser /bin/filebrowser
+COPY --chown=user:share docker/common/ /
+COPY --chown=user:share docker/alpine/ /
+COPY --chown=user:share --from=fetcher /sbin/tini-static /bin/tini
+COPY --from=fetcher /JSON.sh /JSON.sh
+COPY --from=fetcher /etc/ca-certificates.conf /etc/ca-certificates.conf
+COPY --from=fetcher /etc/ca-certificates /etc/ca-certificates
+COPY --from=fetcher /etc/ssl /etc/ssl
+COPY --from=fetcher /etc/mime.types /etc/mime.types
+
+RUN mkdir -p /config /database /srv && \
+    chown -R user:share /config /database /srv && \
+    chmod +x /healthcheck.sh
+
+HEALTHCHECK --start-period=2s --interval=5s --timeout=3s CMD /healthcheck.sh
+
+USER user
+
+VOLUME /srv /config /database
+
+EXPOSE 80
+
+ENTRYPOINT [ "tini", "--", "/init.sh" ]

--- a/auth/oidc.go
+++ b/auth/oidc.go
@@ -1,0 +1,213 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+
+	fberrors "github.com/filebrowser/filebrowser/v2/errors"
+	"github.com/filebrowser/filebrowser/v2/settings"
+	"github.com/filebrowser/filebrowser/v2/users"
+)
+
+// MethodOIDCAuth is used to identify OIDC authentication.
+const MethodOIDCAuth settings.AuthMethod = "oidc"
+
+// OIDCAuth implements OIDC/OAuth2 authentication via an external provider (e.g. Authelia).
+// Config values can be overridden by environment variables:
+//
+//	FB_OIDC_ISSUER, FB_OIDC_CLIENT_ID, FB_OIDC_CLIENT_SECRET, FB_OIDC_USERNAME_CLAIM
+type OIDCAuth struct {
+	IssuerURL     string `json:"issuerUrl"`
+	ClientID      string `json:"clientId"`
+	ClientSecret  string `json:"clientSecret"`
+	UsernameClaim string `json:"usernameClaim"`
+}
+
+// Auth is not used for OIDC – the redirect flow handles authentication.
+// Authentication happens via /api/auth/oidc and /api/auth/oidc/callback.
+func (a *OIDCAuth) Auth(_ *http.Request, _ users.Store, _ *settings.Settings, _ *settings.Server) (*users.User, error) {
+	return nil, os.ErrPermission
+}
+
+// LoginPage returns true because OIDC shows a login page with a SSO button.
+func (a *OIDCAuth) LoginPage() bool {
+	return true
+}
+
+func (a *OIDCAuth) getIssuerURL() string {
+	if v := os.Getenv("FB_OIDC_ISSUER"); v != "" {
+		return v
+	}
+	return a.IssuerURL
+}
+
+func (a *OIDCAuth) getClientID() string {
+	if v := os.Getenv("FB_OIDC_CLIENT_ID"); v != "" {
+		return v
+	}
+	return a.ClientID
+}
+
+func (a *OIDCAuth) getClientSecret() string {
+	if v := os.Getenv("FB_OIDC_CLIENT_SECRET"); v != "" {
+		return v
+	}
+	return a.ClientSecret
+}
+
+func (a *OIDCAuth) getUsernameClaim() string {
+	if v := os.Getenv("FB_OIDC_USERNAME_CLAIM"); v != "" {
+		return v
+	}
+	if a.UsernameClaim != "" {
+		return a.UsernameClaim
+	}
+	return "preferred_username"
+}
+
+// GetProvider fetches the OIDC provider via discovery.
+func (a *OIDCAuth) GetProvider(ctx context.Context) (*oidc.Provider, error) {
+	issuer := a.getIssuerURL()
+	if issuer == "" {
+		return nil, errors.New("OIDC issuer URL not configured (set FB_OIDC_ISSUER or auth.oidc.issuer)")
+	}
+	return oidc.NewProvider(ctx, issuer)
+}
+
+// GetOAuthConfig returns the oauth2.Config for the OIDC flow.
+func (a *OIDCAuth) GetOAuthConfig(provider *oidc.Provider, redirectURL string) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     a.getClientID(),
+		ClientSecret: a.getClientSecret(),
+		RedirectURL:  redirectURL,
+		Endpoint:     provider.Endpoint(),
+		Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+	}
+}
+
+// HandleCallback exchanges the OIDC code for a user, creating the user if needed.
+func (a *OIDCAuth) HandleCallback(
+	ctx context.Context,
+	code string,
+	redirectURL string,
+	usr users.Store,
+	setting *settings.Settings,
+	srv *settings.Server,
+) (*users.User, error) {
+	provider, err := a.GetProvider(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	oauth2Config := a.GetOAuthConfig(provider, redirectURL)
+
+	token, err := oauth2Config.Exchange(ctx, code)
+	if err != nil {
+		return nil, err
+	}
+
+	verifier := provider.Verifier(&oidc.Config{ClientID: a.getClientID()})
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok {
+		return nil, errors.New("no id_token in token response")
+	}
+
+	idToken, err := verifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		return nil, err
+	}
+
+	var claims map[string]interface{}
+	if err := idToken.Claims(&claims); err != nil {
+		return nil, err
+	}
+
+	// Merge UserInfo claims — Authelia (and some other providers) only include
+	// preferred_username in the UserInfo endpoint, not in the ID token itself.
+	userInfo, err := provider.UserInfo(ctx, oauth2.StaticTokenSource(token))
+	if err == nil {
+		var userInfoClaims map[string]interface{}
+		if userInfo.Claims(&userInfoClaims) == nil {
+			for k, v := range userInfoClaims {
+				if _, exists := claims[k]; !exists {
+					claims[k] = v
+				}
+			}
+		}
+	}
+
+	username := a.extractUsername(claims)
+	if username == "" {
+		return nil, fmt.Errorf("could not determine username from OIDC claims (tried claim %q)", a.getUsernameClaim())
+	}
+
+	user, err := usr.Get(srv.Root, username)
+	if errors.Is(err, fberrors.ErrNotExist) {
+		return createOIDCUser(usr, setting, srv, username)
+	}
+	return user, err
+}
+
+func (a *OIDCAuth) extractUsername(claims map[string]interface{}) string {
+	claim := a.getUsernameClaim()
+	if val, ok := claims[claim]; ok {
+		if s, ok := val.(string); ok && s != "" {
+			return s
+		}
+	}
+	// Fallback to email
+	if email, ok := claims["email"]; ok {
+		if s, ok := email.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func createOIDCUser(usr users.Store, setting *settings.Settings, srv *settings.Server, username string) (*users.User, error) {
+	const randomPasswordLength = settings.DefaultMinimumPasswordLength + 10
+	pwd, err := users.RandomPwd(randomPasswordLength)
+	if err != nil {
+		return nil, err
+	}
+
+	hashedPwd, err := users.ValidateAndHashPwd(pwd, setting.MinimumPasswordLength)
+	if err != nil {
+		return nil, err
+	}
+
+	user := &users.User{
+		Username:     username,
+		Password:     hashedPwd,
+		LockPassword: true,
+	}
+	setting.Defaults.Apply(user)
+
+	userHome, err := setting.MakeUserDir(user.Username, user.Scope, srv.Root)
+	if err != nil {
+		return nil, err
+	}
+	user.Scope = userHome
+
+	if err := usr.Save(user); err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
+// GenerateState generates a random state value for CSRF protection.
+func GenerateState() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(b), nil
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -46,6 +46,10 @@ func addConfigFlags(flags *pflag.FlagSet) {
 	flags.String("auth.header", "", "HTTP header for auth.method=proxy")
 	flags.String("auth.command", "", "command for auth.method=hook")
 	flags.String("auth.logoutPage", "", "url of custom logout page")
+	flags.String("auth.oidc.issuer", "", "OIDC issuer URL for auth.method=oidc (overridden by FB_OIDC_ISSUER)")
+	flags.String("auth.oidc.clientId", "", "OIDC client ID for auth.method=oidc (overridden by FB_OIDC_CLIENT_ID)")
+	flags.String("auth.oidc.clientSecret", "", "OIDC client secret for auth.method=oidc (overridden by FB_OIDC_CLIENT_SECRET)")
+	flags.String("auth.oidc.usernameClaim", "preferred_username", "OIDC claim to use as username (overridden by FB_OIDC_USERNAME_CLAIM)")
 
 	flags.String("recaptcha.host", "https://www.google.com", "use another host for ReCAPTCHA. recaptcha.net might be useful in China")
 	flags.String("recaptcha.key", "", "ReCaptcha site key")
@@ -153,6 +157,49 @@ func getJSONAuth(flags *pflag.FlagSet, defaultAuther map[string]interface{}) (au
 	return jsonAuth, nil
 }
 
+func getOIDCAuth(flags *pflag.FlagSet, defaultAuther map[string]interface{}) (auth.Auther, error) {
+	issuer, err := flags.GetString("auth.oidc.issuer")
+	if err != nil {
+		return nil, err
+	}
+	clientID, err := flags.GetString("auth.oidc.clientId")
+	if err != nil {
+		return nil, err
+	}
+	clientSecret, err := flags.GetString("auth.oidc.clientSecret")
+	if err != nil {
+		return nil, err
+	}
+	usernameClaim, err := flags.GetString("auth.oidc.usernameClaim")
+	if err != nil {
+		return nil, err
+	}
+
+	// Fall back to DB values when flags are not explicitly set
+	if issuer == "" && defaultAuther != nil {
+		if v, ok := defaultAuther["issuerUrl"].(string); ok {
+			issuer = v
+		}
+	}
+	if clientID == "" && defaultAuther != nil {
+		if v, ok := defaultAuther["clientId"].(string); ok {
+			clientID = v
+		}
+	}
+	if clientSecret == "" && defaultAuther != nil {
+		if v, ok := defaultAuther["clientSecret"].(string); ok {
+			clientSecret = v
+		}
+	}
+
+	return &auth.OIDCAuth{
+		IssuerURL:     issuer,
+		ClientID:      clientID,
+		ClientSecret:  clientSecret,
+		UsernameClaim: usernameClaim,
+	}, nil
+}
+
 func getHookAuth(flags *pflag.FlagSet, defaultAuther map[string]interface{}) (auth.Auther, error) {
 	command, err := flags.GetString("auth.command")
 	if err != nil {
@@ -185,6 +232,8 @@ func getAuthentication(flags *pflag.FlagSet, defaults ...interface{}) (settings.
 		auther, err = getJSONAuth(flags, defaultAuther)
 	case auth.MethodHookAuth:
 		auther, err = getHookAuth(flags, defaultAuther)
+	case auth.MethodOIDCAuth:
+		auther, err = getOIDCAuth(flags, defaultAuther)
 	default:
 		return "", nil, fberrors.ErrInvalidAuthMethod
 	}

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "دائم",
   "prompts": {

--- a/frontend/src/i18n/bg.json
+++ b/frontend/src/i18n/bg.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "Бяхте разлогнати поради неактивност"
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Постоянен",
   "prompts": {

--- a/frontend/src/i18n/ca.json
+++ b/frontend/src/i18n/ca.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanent",
   "prompts": {

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Trvalý",
   "prompts": {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Passwort muss mindestens {min} Zeichen lang sein",
     "logout_reasons": {
       "inactivity": "Du wurdest wegen Inaktivität abgemeldet."
-    }
+    },
+    "ssoLogin": "Mit SSO anmelden"
   },
   "permanent": "Permanent",
   "prompts": {

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Μόνιμο",
   "prompts": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanent",
   "prompts": {

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanente",
   "prompts": {

--- a/frontend/src/i18n/fa.json
+++ b/frontend/src/i18n/fa.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "دائمی",
   "prompts": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Le mot de passe doit contenir au moins {min} caractères",
     "logout_reasons": {
       "inactivity": "Vous avez été déconnecté(e) en raison d'une inactivité prolongée."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanent",
   "prompts": {

--- a/frontend/src/i18n/he.json
+++ b/frontend/src/i18n/he.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "קבוע",
   "prompts": {

--- a/frontend/src/i18n/hr.json
+++ b/frontend/src/i18n/hr.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Lozinka mora sadržavati minimalno {min} znakova",
     "logout_reasons": {
       "inactivity": "Odjavljeni ste zbog neaktivnosti."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Trajan",
   "prompts": {

--- a/frontend/src/i18n/hu.json
+++ b/frontend/src/i18n/hu.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Állandó",
   "prompts": {

--- a/frontend/src/i18n/is.json
+++ b/frontend/src/i18n/is.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Varanlegt",
   "prompts": {

--- a/frontend/src/i18n/it.json
+++ b/frontend/src/i18n/it.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanente",
   "prompts": {

--- a/frontend/src/i18n/ja.json
+++ b/frontend/src/i18n/ja.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "永久",
   "prompts": {

--- a/frontend/src/i18n/ko.json
+++ b/frontend/src/i18n/ko.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "비밀번호는 최소 {min}자 이상이어야 함",
     "logout_reasons": {
       "inactivity": "활동이 없어 로그아웃 되었습니다."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "영구",
   "prompts": {

--- a/frontend/src/i18n/lv.json
+++ b/frontend/src/i18n/lv.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Parolei jābūt vismaz {min} rakstzīmju garai",
     "logout_reasons": {
       "inactivity": "Jūs esat atteicies no sistēmas neaktivitātes dēļ."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Pastāvīgs",
   "prompts": {

--- a/frontend/src/i18n/nl-be.json
+++ b/frontend/src/i18n/nl-be.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanent",
   "prompts": {

--- a/frontend/src/i18n/nl.json
+++ b/frontend/src/i18n/nl.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Wachtwoord moet minstens {min} tekens bevatten",
     "logout_reasons": {
       "inactivity": "U bent uitgelogd vanwege inactiviteit."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanent",
   "prompts": {

--- a/frontend/src/i18n/no.json
+++ b/frontend/src/i18n/no.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "Du har blitt logget ut på grunn av inaktivitet"
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanent",
   "prompts": {

--- a/frontend/src/i18n/pl.json
+++ b/frontend/src/i18n/pl.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Wymagana minimalna liczba znaków hasła: {min}",
     "logout_reasons": {
       "inactivity": "Wylogowano z powodu braku aktywności."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanentny",
   "prompts": {

--- a/frontend/src/i18n/pt-br.json
+++ b/frontend/src/i18n/pt-br.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanente",
   "prompts": {

--- a/frontend/src/i18n/pt-pt.json
+++ b/frontend/src/i18n/pt-pt.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "A palavra-passe tem de ter pelo menos {min} caracteres",
     "logout_reasons": {
       "inactivity": "Foi terminada a sessão por inactividade."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanente",
   "prompts": {

--- a/frontend/src/i18n/pt.json
+++ b/frontend/src/i18n/pt.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanente",
   "prompts": {

--- a/frontend/src/i18n/ro.json
+++ b/frontend/src/i18n/ro.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanent",
   "prompts": {

--- a/frontend/src/i18n/ru.json
+++ b/frontend/src/i18n/ru.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Пароль должен состоять как минимум из {min} символов",
     "logout_reasons": {
       "inactivity": "Сессия завершена после долгого отсутствия."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Постоянный",
   "prompts": {

--- a/frontend/src/i18n/sk.json
+++ b/frontend/src/i18n/sk.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "Boli ste odhlásení z dôvodu nečinnosti."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Trvalé",
   "prompts": {

--- a/frontend/src/i18n/sv-se.json
+++ b/frontend/src/i18n/sv-se.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "Du har blivit utloggad på grund av inaktivitet."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Permanent",
   "prompts": {

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Kalıcı",
   "prompts": {

--- a/frontend/src/i18n/uk.json
+++ b/frontend/src/i18n/uk.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Постійний",
   "prompts": {

--- a/frontend/src/i18n/vi.json
+++ b/frontend/src/i18n/vi.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "Vĩnh viễn",
   "prompts": {

--- a/frontend/src/i18n/zh-cn.json
+++ b/frontend/src/i18n/zh-cn.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "密码必须至少包含 {min} 个字符",
     "logout_reasons": {
       "inactivity": "由于未活动，您已登出。"
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "永久",
   "prompts": {

--- a/frontend/src/i18n/zh-tw.json
+++ b/frontend/src/i18n/zh-tw.json
@@ -124,7 +124,8 @@
     "passwordTooShort": "Password must be at least {min} characters",
     "logout_reasons": {
       "inactivity": "You have been logged out due to inactivity."
-    }
+    },
+    "ssoLogin": "Login with SSO"
   },
   "permanent": "永久",
   "prompts": {

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="login" :class="{ recaptcha: recaptcha }">
-    <form @submit="submit">
+    <form v-if="!isOIDC" @submit="submit">
       <img :src="logoURL" alt="File Browser" />
       <h1>{{ name }}</h1>
       <p v-if="reason != null" class="logout-message">
@@ -41,6 +41,17 @@
         {{ createMode ? t("login.loginInstead") : t("login.createAnAccount") }}
       </p>
     </form>
+
+    <div v-else class="oidc-login">
+      <img :src="logoURL" alt="File Browser" />
+      <h1>{{ name }}</h1>
+      <p v-if="reason != null" class="logout-message">
+        {{ t(`login.logout_reasons.${reason}`) }}
+      </p>
+      <a :href="oidcLoginURL" class="button button--block oidc-button">
+        {{ t('login.ssoLogin') }}
+      </a>
+    </div>
   </div>
 </template>
 
@@ -53,8 +64,10 @@ import {
   recaptcha,
   recaptchaKey,
   signup,
+  authMethod,
+  baseURL,
 } from "@/utils/constants";
-import { inject, onMounted, ref } from "vue";
+import { computed, inject, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 
@@ -68,12 +81,14 @@ const passwordConfirm = ref<string>("");
 const route = useRoute();
 const router = useRouter();
 const { t } = useI18n({});
-// Define functions
-const toggleMode = () => (createMode.value = !createMode.value);
 
+const toggleMode = () => (createMode.value = !createMode.value);
 const $showError = inject<IToastError>("$showError")!;
 
 const reason = route.query["logout-reason"] ?? null;
+
+const isOIDC = computed(() => authMethod === "oidc");
+const oidcLoginURL = computed(() => `${baseURL}/api/auth/oidc`);
 
 const submit = async (event: Event) => {
   event.preventDefault();
@@ -106,7 +121,6 @@ const submit = async (event: Event) => {
     await auth.login(username.value, password.value, captcha);
     router.push({ path: redirect });
   } catch (e: any) {
-    // console.error(e);
     if (e instanceof StatusError) {
       if (e.status === 409) {
         error.value = t("login.usernameTaken");
@@ -126,8 +140,22 @@ const submit = async (event: Event) => {
   }
 };
 
-// Run hooks
-onMounted(() => {
+onMounted(async () => {
+  // Handle OIDC callback: token passed as query parameter
+  const token = route.query.token as string | undefined;
+  if (token) {
+    try {
+      auth.parseToken(token);
+      // Remove token from URL before navigating
+      const redirect = (route.query.redirect || "/files/") as string;
+      await router.replace({ path: route.path });
+      router.push({ path: redirect });
+    } catch {
+      error.value = t("login.wrongCredentials");
+    }
+    return;
+  }
+
   if (!recaptcha) return;
 
   window.grecaptcha.ready(function () {
@@ -137,3 +165,19 @@ onMounted(() => {
   });
 });
 </script>
+
+<style>
+.oidc-login {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.oidc-button {
+  display: block;
+  text-align: center;
+  text-decoration: none;
+  padding: 0.75rem 1.5rem;
+}
+</style>

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/bodgit/sevenzip v1.6.1 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/coreos/go-oidc/v3 v3.17.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -51,6 +52,7 @@ require (
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4 // indirect
@@ -78,6 +80,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
 	golang.org/x/net v0.51.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
+github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -101,6 +103,8 @@ github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8b
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
+github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
@@ -343,6 +347,8 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/http/auth.go
+++ b/http/auth.go
@@ -212,7 +212,8 @@ func renewHandler(tokenExpireTime time.Duration) handleFunc {
 	})
 }
 
-func printToken(w http.ResponseWriter, _ *http.Request, d *data, user *users.User, tokenExpirationTime time.Duration) (int, error) {
+// createToken generates a signed JWT for the given user.
+func createToken(d *data, user *users.User, tokenExpirationTime time.Duration) (string, error) {
 	claims := &authToken{
 		User: userInfo{
 			ID:                    user.ID,
@@ -236,7 +237,11 @@ func printToken(w http.ResponseWriter, _ *http.Request, d *data, user *users.Use
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	signed, err := token.SignedString(d.settings.Key)
+	return token.SignedString(d.settings.Key)
+}
+
+func printToken(w http.ResponseWriter, _ *http.Request, d *data, user *users.User, tokenExpirationTime time.Duration) (int, error) {
+	signed, err := createToken(d, user, tokenExpirationTime)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}

--- a/http/http.go
+++ b/http/http.go
@@ -49,6 +49,8 @@ func NewHandler(
 	api.Handle("/login", monkey(loginHandler(tokenExpirationTime), ""))
 	api.Handle("/signup", monkey(signupHandler, ""))
 	api.Handle("/renew", monkey(renewHandler(tokenExpirationTime), ""))
+	api.Handle("/auth/oidc", monkey(oidcRedirectHandler, "")).Methods("GET")
+	api.Handle("/auth/oidc/callback", monkey(oidcCallbackHandler(tokenExpirationTime), "")).Methods("GET")
 
 	users := api.PathPrefix("/users").Subrouter()
 	users.Handle("", monkey(usersGetHandler, "")).Methods("GET")

--- a/http/oidc.go
+++ b/http/oidc.go
@@ -1,0 +1,122 @@
+package fbhttp
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	fbAuth "github.com/filebrowser/filebrowser/v2/auth"
+)
+
+const oidcStateCookie = "oidc_state"
+
+// oidcRedirectHandler initiates the OIDC login flow by redirecting to the provider.
+var oidcRedirectHandler handleFunc = func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	auther, err := d.store.Auth.Get(d.settings.AuthMethod)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	oidcAuth, ok := auther.(*fbAuth.OIDCAuth)
+	if !ok {
+		return http.StatusBadRequest, fmt.Errorf("auth method is not oidc")
+	}
+
+	state, err := fbAuth.GenerateState()
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	// Persist state in a short-lived cookie for CSRF validation
+	http.SetCookie(w, &http.Cookie{
+		Name:     oidcStateCookie,
+		Value:    state,
+		Path:     "/",
+		MaxAge:   300, // 5 minutes
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	provider, err := oidcAuth.GetProvider(r.Context())
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	redirectURL := oidcCallbackURL(r, d)
+	oauth2Config := oidcAuth.GetOAuthConfig(provider, redirectURL)
+	authURL := oauth2Config.AuthCodeURL(state)
+
+	http.Redirect(w, r, authURL, http.StatusFound)
+	return 0, nil
+}
+
+// oidcCallbackHandler processes the OIDC callback: exchanges code, issues JWT,
+// then redirects the browser to the frontend login page with the token.
+func oidcCallbackHandler(tokenExpireTime time.Duration) handleFunc {
+	return func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+		// Validate CSRF state
+		stateCookie, err := r.Cookie(oidcStateCookie)
+		if err != nil || stateCookie.Value != r.URL.Query().Get("state") {
+			return http.StatusForbidden, fmt.Errorf("invalid OIDC state")
+		}
+
+		// Clear state cookie
+		http.SetCookie(w, &http.Cookie{
+			Name:   oidcStateCookie,
+			Value:  "",
+			Path:   "/",
+			MaxAge: -1,
+		})
+
+		auther, err := d.store.Auth.Get(d.settings.AuthMethod)
+		if err != nil {
+			return http.StatusInternalServerError, err
+		}
+
+		oidcAuth, ok := auther.(*fbAuth.OIDCAuth)
+		if !ok {
+			return http.StatusBadRequest, fmt.Errorf("auth method is not oidc")
+		}
+
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			return http.StatusBadRequest, fmt.Errorf("missing OIDC code")
+		}
+
+		user, err := oidcAuth.HandleCallback(
+			r.Context(),
+			code,
+			oidcCallbackURL(r, d),
+			d.store.Users,
+			d.settings,
+			d.server,
+		)
+		if err != nil {
+			return http.StatusForbidden, err
+		}
+
+		// Generate JWT token (reuse printToken logic, but capture output)
+		jwt, err := createToken(d, user, tokenExpireTime)
+		if err != nil {
+			return http.StatusInternalServerError, err
+		}
+
+		// Redirect to the login page with the token so the frontend can store it
+		redirectTarget := d.server.BaseURL + "/login?token=" + jwt
+		http.Redirect(w, r, redirectTarget, http.StatusFound)
+		return 0, nil
+	}
+}
+
+// oidcCallbackURL builds the absolute callback URL registered with the OIDC provider.
+func oidcCallbackURL(r *http.Request, d *data) string {
+	scheme := "https"
+	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" {
+		scheme = "http"
+	}
+	host := r.Host
+	if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" {
+		host = fwdHost
+	}
+	return fmt.Sprintf("%s://%s%s/api/auth/oidc/callback", scheme, host, d.server.BaseURL)
+}

--- a/storage/bolt/auth.go
+++ b/storage/bolt/auth.go
@@ -24,6 +24,8 @@ func (s authBackend) Get(t settings.AuthMethod) (auth.Auther, error) {
 		auther = &auth.HookAuth{}
 	case auth.MethodNoAuth:
 		auther = &auth.NoAuth{}
+	case auth.MethodOIDCAuth:
+		auther = &auth.OIDCAuth{}
 	default:
 		return nil, fberrors.ErrInvalidAuthMethod
 	}


### PR DESCRIPTION
## Summary

This PR adds a native OIDC/OAuth2 authentication method to filebrowser, enabling SSO login via any OIDC-compatible provider (tested with Authelia).

- New `oidc` auth method with `IssuerURL`, `ClientID`, `ClientSecret`, `UsernameClaim` config fields
- `GET /api/auth/oidc` — initiates the OAuth2 authorization code flow (CSRF state cookie)
- `GET /api/auth/oidc/callback` — exchanges the code, verifies the ID token, fetches UserInfo claims (for providers that only expose `preferred_username` via UserInfo), issues a filebrowser JWT, redirects to `/login?token=…`
- Frontend `Login.vue`: shows an SSO button instead of username/password form when `authMethod === "oidc"`; handles `?token=` query param on mount
- Users are auto-created on first OIDC login with a locked random password
- Config via CLI flags (`--auth.oidc.issuer` etc.) or env vars (`FB_OIDC_ISSUER`, `FB_OIDC_CLIENT_ID`, `FB_OIDC_CLIENT_SECRET`, `FB_OIDC_USERNAME_CLAIM`)
- `ssoLogin` i18n key added to all locale files

## Dependencies

- `github.com/coreos/go-oidc/v3` — OIDC provider discovery & ID token verification
- `golang.org/x/oauth2` — OAuth2 code exchange

## Test plan

- [ ] Configure an OIDC provider (e.g. Authelia, Keycloak, Dex) and set `--auth.method=oidc` with the appropriate flags/env vars
- [ ] Navigate to `/login` — SSO button should appear
- [ ] Click the button, authenticate with the provider, verify redirect back to `/files/`
- [ ] First login auto-creates the user; subsequent logins reuse the existing user record
- [ ] Verify `preferred_username` (or configured claim) is resolved correctly — providers that only expose it via UserInfo are handled via the UserInfo endpoint merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)