### PR TITLE
fix: check download permission in resource handler

### DIFF
--- a/http/resource.go
+++ b/http/resource.go
@@ -30,7 +30,7 @@ var resourceGetHandler = withUser(func(w http.ResponseWriter, r *http.Request, d
 		Expand:     true,
 		ReadHeader: d.server.TypeDetectionByHeader,
 		Checker:    d,
-		Content:    true,
+		Content:    d.user.Perm.Download,
 	})
 	if err != nil {
 		return errToStatus(err), err
@@ -42,6 +42,9 @@ var resourceGetHandler = withUser(func(w http.ResponseWriter, r *http.Request, d
 		file.ApplySort()
 		return renderJSON(w, r, file)
 	} else if encoding == "true" {
+		if !d.user.Perm.Download {
+			return http.StatusAccepted, nil
+		}
 		if file.Type != "text" {
 			return renderJSON(w, r, file)
 		}


### PR DESCRIPTION
## Summary

- `resourceGetHandler` served text file content and raw bytes via `X-Encoding` without checking `Perm.Download`
- The three other content-serving endpoints (`/api/raw`, `/api/preview`, `/api/subtitle`) all enforce this check
- Set `Content: d.user.Perm.Download` and add a download guard before the `X-Encoding` raw byte path

Ref: GHSA-67cg-cpj7-qgc9