### PR TITLE
fix(preview): let arrow keys seek video instead of switching files

### DIFF
--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -383,11 +383,19 @@ const key = (event: KeyboardEvent) => {
   if (layoutStore.currentPrompt !== null) {
     return;
   }
-  if (event.which === 13 || event.which === 39) {
+  // When previewing a video, let arrow keys fall through to video.js for
+  // seeking instead of switching to the prev/next file. Enter still advances.
+  const isVideo = fileStore.req?.type === "video";
+  if (event.which === 13) {
+    // enter
+    if (hasNext.value) next();
+  } else if (event.which === 39) {
     // right arrow
+    if (isVideo) return;
     if (hasNext.value) next();
   } else if (event.which === 37) {
     // left arrow
+    if (isVideo) return;
     if (hasPrevious.value) prev();
   } else if (event.which === 27) {
     // esc


### PR DESCRIPTION
## Description

When previewing a video in a folder containing more than one file, pressing the left/right arrow keys switches to the previous/next file instead of seeking the video. This makes it impossible to use the keyboard to seek videos in any folder with multiple items — single-video folders work because there is nothing to switch to, so the event falls through to video.js.

The root cause is in `frontend/src/views/files/Preview.vue`: the `key` handler unconditionally maps `ArrowLeft` / `ArrowRight` to `prev()` / `next()` without checking the current file type, so video.js never gets a chance to handle them.

## Additional Information

This PR adds a small guard: when the current preview is a video (`fileStore.req?.type === "video"`), `ArrowLeft` and `ArrowRight` return early and the event falls through to video.js for seeking. `Enter` is preserved as an "advance to next file" shortcut so multi-video folders still have a keyboard way to switch, and `Esc` is unchanged.

Behavior summary:

| Key | Non-video preview | Video preview (after this PR) |
|---|---|---|
| ArrowLeft | prev file | video.js seek backward |
| ArrowRight | next file | video.js seek forward |
| Enter | next file | next file (unchanged) |
| Esc | close | close (unchanged) |

Related discussion: #4908 (video player improvements).

## Checklist

- [x] I am aware the project is currently in maintenance-only mode.
- [x] I am aware that translations MUST be made through Transifex and that this PR is NOT a translation update.
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. (Built and verified locally; the patched image has been running healthy on my own deployment.)