### PR TITLE
docs: Update documentation links in Global.vue

### DIFF
--- a/frontend/src/views/settings/Global.vue
+++ b/frontend/src/views/settings/Global.vue
@@ -70,7 +70,7 @@
             <a
               class="link"
               target="_blank"
-              href="https://filebrowser.org/configuration.html#custom-branding"
+              href="https://filebrowser.org/customization.html#custom-branding"
               >{{ t("settings.documentation") }}</a
             >
           </i18n-t>
@@ -209,7 +209,7 @@
             <a
               class="link"
               target="_blank"
-              href="https://filebrowser.org/configuration.html#command-runner"
+              href="https://filebrowser.org/command-execution.html#hook-runner"
               >{{ t("settings.documentation") }}</a
             >
           </i18n-t>


### PR DESCRIPTION
## Description

Updates outdated documentation links in the `Global.vue` settings view. Previous URLs pointed to `configuration.html` which currently results in 404. I updated them to the correct sections under `customization.html` and `command-execution.html`.

## Additional Information

I have updated the following links:
- Custom branding: Changed from `configuration.html#custom-branding` to `customization.html#custom-branding`.
- Command/Hook runner: Changed from `configuration.html#command-runner` to `command-execution.html#hook-runner`.

## Checklist

- [x] I am aware the project is currently in **maintenance-only** mode and new feature requests won't be accepted. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).