### PR TITLE
fix: correct environment variable in compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
     volumes:
       - filebrowser:/flux/vault
     environment:
-      - REDIS_CACHE_URL=redis://default:filebrowser@redis:6379 # Use rediss:// for ssl
+      - FB_REDIS_CACHE_URL=redis://default:filebrowser@redis:6379 # Use rediss:// for ssl
 
   redis:
     container_name: redis


### PR DESCRIPTION
## Description

Hi there,

The compose.yml file was missing the `FB_` prefix, so it was being silently ignored.

This corrects the environment variable name to use, so FileBrowser will attempt to connect to and use the Redis server that is being spun up by Docker Compose.

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [X] I am aware the project is currently in **maintenance-only** mode and new feature requests won't be accepted. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [ ] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [X] I am making a PR against the `master` branch.
- [ ] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
