### PR TITLE
chore(i18n): add a translation for disk usage

### DIFF
--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -92,7 +92,7 @@
     >
       <progress-bar :val="usage.usedPercentage" size="small"></progress-bar>
       <br />
-      {{ usage.used }} of {{ usage.total }} used
+      {{ $t("sidebar.diskUsed", { used: usage.used, total: usage.total }) }}
     </div>
 
     <p class="credits">

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -281,6 +281,7 @@
     "currentPassword": "Your Current Password"
   },
   "sidebar": {
+    "diskUsed": "{used} of {total} used",
     "help": "Help",
     "hugoNew": "Hugo New",
     "login": "Login",

--- a/frontend/src/i18n/pl.json
+++ b/frontend/src/i18n/pl.json
@@ -281,6 +281,7 @@
     "currentPassword": "Twoje aktualne hasło"
   },
   "sidebar": {
+    "diskUsed": "Wykorzystano {used} z {total}",
     "help": "Pomoc",
     "hugoNew": "Nowy Hugo",
     "login": "Zaloguj",


### PR DESCRIPTION
## Description
This PR adds a translation for `{used} of {total} used` in the sidebar

## Additional Information
Example screenshots:
### English
<img width="274" height="545" alt="filebrowser_english" src="https://github.com/user-attachments/assets/b8993b55-b219-4874-a583-e394b56866b8" />

### Polish
<img width="282" height="544" alt="filebrowser_polish" src="https://github.com/user-attachments/assets/ec9142f3-0f27-4cd3-b86e-12477136ead1" />


## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in **maintenance-only** mode and new feature requests won't be accepted. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [X] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
