### PR TITLE
fix: preserve ASCII filenames in downloads

### DIFF
--- a/http/raw.go
+++ b/http/raw.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	gopath "path"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/mholt/archives"
@@ -71,13 +72,26 @@ func parseQueryAlgorithm(r *http.Request) (string, archives.Archival, error) {
 }
 
 func setContentDisposition(w http.ResponseWriter, r *http.Request, file *files.FileInfo) {
+	disposition := "attachment"
 	if r.URL.Query().Get("inline") == "true" {
-		// As per RFC6266 section 4.3
-		w.Header().Set("Content-Disposition", "inline; filename*=utf-8''"+url.PathEscape(file.Name))
-	} else {
-		// As per RFC6266 section 4.3
-		w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.PathEscape(file.Name))
+		disposition = "inline"
 	}
+
+	header := disposition + "; filename*=utf-8''" + url.PathEscape(file.Name)
+	if isASCIIFilename(file.Name) {
+		header = disposition + "; filename=" + strconv.Quote(file.Name) + "; filename*=utf-8''" + url.PathEscape(file.Name)
+	}
+	// As per RFC6266 section 4.3
+	w.Header().Set("Content-Disposition", header)
+}
+
+func isASCIIFilename(name string) bool {
+	for _, r := range name {
+		if r < 0x20 || r > 0x7e {
+			return false
+		}
+	}
+	return name != ""
 }
 
 var rawHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {

--- a/http/raw_test.go
+++ b/http/raw_test.go
@@ -20,12 +20,17 @@ func TestSetContentDisposition(t *testing.T) {
 		"inline simple filename": {
 			filename: "document.pdf",
 			inline:   true,
-			expected: "inline; filename*=utf-8''" + url.PathEscape("document.pdf"),
+			expected: `inline; filename="document.pdf"; filename*=utf-8''` + url.PathEscape("document.pdf"),
 		},
 		"attachment simple filename": {
 			filename: "document.pdf",
 			inline:   false,
-			expected: "attachment; filename*=utf-8''" + url.PathEscape("document.pdf"),
+			expected: `attachment; filename="document.pdf"; filename*=utf-8''` + url.PathEscape("document.pdf"),
+		},
+		"attachment gpx filename keeps original extension": {
+			filename: "abc.gpx",
+			inline:   false,
+			expected: `attachment; filename="abc.gpx"; filename*=utf-8''` + url.PathEscape("abc.gpx"),
 		},
 		"inline non-ASCII filename": {
 			filename: "日本語.txt",
@@ -40,12 +45,12 @@ func TestSetContentDisposition(t *testing.T) {
 		"inline filename with spaces": {
 			filename: "my file.txt",
 			inline:   true,
-			expected: "inline; filename*=utf-8''" + url.PathEscape("my file.txt"),
+			expected: `inline; filename="my file.txt"; filename*=utf-8''` + url.PathEscape("my file.txt"),
 		},
 		"attachment filename with spaces": {
 			filename: "my file.txt",
 			inline:   false,
-			expected: "attachment; filename*=utf-8''" + url.PathEscape("my file.txt"),
+			expected: `attachment; filename="my file.txt"; filename*=utf-8''` + url.PathEscape("my file.txt"),
 		},
 	}
 


### PR DESCRIPTION
## Description

Fixes #5939.

Adds a classic `filename="..."` fallback for ASCII download names while keeping the existing RFC5987 `filename*` value for UTF-8 filenames. Some Android browsers appear to fall back to MIME/content sniffing when only `filename*` is present, which can make XML-based `.gpx` downloads save as `.gpx.xml`.

Non-ASCII filenames continue to use `filename*` only.

## Verification

- `go test ./http -run TestSetContentDisposition`
- `git diff --check`