### PR TITLE
fix: show item shares from all users to admins

### DIFF
--- a/http/share.go
+++ b/http/share.go
@@ -57,7 +57,15 @@ var shareListHandler = withPermShare(func(w http.ResponseWriter, r *http.Request
 })
 
 var shareGetsHandler = withPermShare(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
-	s, err := d.store.Share.Gets(r.URL.Path, d.user.ID)
+	var (
+		s   []*share.Link
+		err error
+	)
+	if d.user.Perm.Admin {
+		s, err = d.store.Share.GetsByPath(r.URL.Path)
+	} else {
+		s, err = d.store.Share.Gets(r.URL.Path, d.user.ID)
+	}
 	if errors.Is(err, fberrors.ErrNotExist) {
 		return renderJSON(w, r, []*share.Link{})
 	}

--- a/share/storage.go
+++ b/share/storage.go
@@ -110,6 +110,23 @@ func (s *Storage) Gets(path string, id uint) ([]*Link, error) {
 	return links, nil
 }
 
+// GetsByPath returns all non-expired links for a path.
+func (s *Storage) GetsByPath(path string) ([]*Link, error) {
+	links, err := s.All()
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]*Link, 0, len(links))
+	for _, link := range links {
+		if link.Path == path {
+			filtered = append(filtered, link)
+		}
+	}
+
+	return filtered, nil
+}
+
 // Save wraps a StorageBackend.Save
 func (s *Storage) Save(l *Link) error {
 	return s.back.Save(l)

--- a/share/storage_test.go
+++ b/share/storage_test.go
@@ -1,0 +1,85 @@
+package share
+
+import (
+	"reflect"
+	"testing"
+)
+
+type fakeBackend struct {
+	links []*Link
+}
+
+func (f fakeBackend) All() ([]*Link, error) {
+	return f.links, nil
+}
+
+func (f fakeBackend) FindByUserID(id uint) ([]*Link, error) {
+	var links []*Link
+	for _, link := range f.links {
+		if link.UserID == id {
+			links = append(links, link)
+		}
+	}
+	return links, nil
+}
+
+func (f fakeBackend) GetByHash(hash string) (*Link, error) {
+	for _, link := range f.links {
+		if link.Hash == hash {
+			return link, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f fakeBackend) GetPermanent(path string, id uint) (*Link, error) {
+	for _, link := range f.links {
+		if link.Path == path && link.UserID == id && link.Expire == 0 {
+			return link, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f fakeBackend) Gets(path string, id uint) ([]*Link, error) {
+	var links []*Link
+	for _, link := range f.links {
+		if link.Path == path && link.UserID == id {
+			links = append(links, link)
+		}
+	}
+	return links, nil
+}
+
+func (f fakeBackend) Save(_ *Link) error {
+	return nil
+}
+
+func (f fakeBackend) Delete(_ string) error {
+	return nil
+}
+
+func (f fakeBackend) DeleteWithPathPrefix(_ string) error {
+	return nil
+}
+
+func TestGetsByPathReturnsLinksFromAllUsers(t *testing.T) {
+	t.Parallel()
+
+	expected := []*Link{
+		{Hash: "a", Path: "/file.txt", UserID: 1},
+		{Hash: "b", Path: "/file.txt", UserID: 2},
+	}
+	store := NewStorage(fakeBackend{
+		links: append(expected, &Link{Hash: "c", Path: "/other.txt", UserID: 3}),
+	})
+
+	links, err := store.GetsByPath("/file.txt")
+	if err != nil {
+		t.Fatalf("GetsByPath returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(links, expected) {
+		t.Fatalf("GetsByPath returned %#v, want %#v", links, expected)
+	}
+}


### PR DESCRIPTION
## Description

Fixes #5932.

The share management view already lets admins see shares from all users, but the item-level share dialog used `Gets(path, userID)` and therefore only returned shares created by the current admin account.

For admins, the item-level share lookup now filters all active shares by path, so shares created by other users are visible from the file itself. Non-admin users keep the existing owner-scoped lookup.

## Verification

- `go test ./share ./http`
- `git diff --check`