### PR TITLE
fix: force octet-stream for attachment downloads

### DIFF
--- a/http/raw.go
+++ b/http/raw.go
@@ -77,6 +77,7 @@ func setContentDisposition(w http.ResponseWriter, r *http.Request, file *files.F
 	} else {
 		// As per RFC6266 section 4.3
 		w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.PathEscape(file.Name))
+		w.Header().Set("Content-Type", "application/octet-stream")
 	}
 }
 

--- a/http/raw_test.go
+++ b/http/raw_test.go
@@ -70,6 +70,14 @@ func TestSetContentDisposition(t *testing.T) {
 			if got != tc.expected {
 				t.Errorf("Content-Disposition = %q, want %q", got, tc.expected)
 			}
+
+			contentType := recorder.Header().Get("Content-Type")
+			if tc.inline && contentType != "" {
+				t.Errorf("Content-Type = %q, want empty", contentType)
+			}
+			if !tc.inline && contentType != "application/octet-stream" {
+				t.Errorf("Content-Type = %q, want application/octet-stream", contentType)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes #5939.

## Summary
- keep inline responses available for browser preview
- set attachment downloads to `application/octet-stream` so browsers do not infer a different extension from detected MIME type
- extend the content-disposition helper test to cover the download content type

## Verification
- go test ./http
- go test ./...
- git diff --check