### PR TITLE
fix(router): handle undefined catchAll param on root redirect

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -145,8 +145,11 @@ const routes = [
   },
   {
     path: "/:catchAll(.*)*",
-    redirect: (to: RouteLocation) =>
-      `/files/${[...to.params.catchAll].join("/")}`,
+    redirect: (to: RouteLocation) => {
+      const catchAll = to.params.catchAll;
+      if (!catchAll) return "/files/";
+      return `/files/${Array.isArray(catchAll) ? catchAll.join("/") : catchAll}`;
+    },
   },
 ];
 


### PR DESCRIPTION
When accessing '/', Vue Router sets 'to.params.catchAll' to undefined for the catch-all route '/:catchAll(.*)*'. The previous code used the spread operator '[...to.params.catchAll]' which threw:

  TypeError: e.params.catchAll is not iterable

Fix by safely checking if catchAll is defined before spreading, and handling both array and string forms of the param. Falls back to '/files/' when catchAll is empty/undefined.

## Description

<!-- Please explain the changes you made here. -->

## Additional Information

<!-- If it is a relatively large or complex change, please add more information to explain what you did, how you did it, if you considered any alternatives, etc. -->

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [X] I am aware the project is currently in **maintenance-only** mode and new feature requests won't be accepted. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [X] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [X] I am making a PR against the `master` branch.
- [X] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
