### PR TITLE
fix: skip inaccessible children when listing directories

### DIFF
--- a/files/file.go
+++ b/files/file.go
@@ -18,6 +18,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -456,8 +457,7 @@ func (i *FileInfo) addSubtitle(fPath string) {
 }
 
 func (i *FileInfo) readListing(checker rules.Checker, readHeader bool, calcImgRes bool) error {
-	afs := &afero.Afero{Fs: i.Fs}
-	dir, err := afs.ReadDir(i.Path)
+	dir, err := readDir(i.Fs, i.Path)
 	if err != nil {
 		return err
 	}
@@ -531,4 +531,57 @@ func (i *FileInfo) readListing(checker rules.Checker, readHeader bool, calcImgRe
 
 	i.Listing = listing
 	return nil
+}
+
+func readDir(afs afero.Fs, dirname string) ([]os.FileInfo, error) {
+	dir, err := afero.ReadDir(afs, dirname)
+	if err == nil {
+		return dir, nil
+	}
+
+	dir, fallbackErr := readDirNames(afs, dirname)
+	if fallbackErr != nil {
+		return nil, err
+	}
+
+	return dir, nil
+}
+
+func readDirNames(afs afero.Fs, dirname string) ([]os.FileInfo, error) {
+	file, err := afs.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+
+	names, err := file.Readdirnames(-1)
+	if closeErr := file.Close(); err == nil && closeErr != nil {
+		err = closeErr
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(names)
+	dir := make([]os.FileInfo, 0, len(names))
+	for _, name := range names {
+		fPath := path.Join(dirname, name)
+		info, err := lstatIfPossible(afs, fPath)
+		if err != nil {
+			log.Printf("Skipping inaccessible file %s: %v", fPath, err)
+			continue
+		}
+
+		dir = append(dir, info)
+	}
+
+	return dir, nil
+}
+
+func lstatIfPossible(afs afero.Fs, name string) (os.FileInfo, error) {
+	if lstaterFs, ok := afs.(afero.Lstater); ok {
+		info, _, err := lstaterFs.LstatIfPossible(name)
+		return info, err
+	}
+
+	return afs.Stat(name)
 }

--- a/files/file_test.go
+++ b/files/file_test.go
@@ -158,15 +158,15 @@ func TestReadListingSkipsInaccessibleChildren(t *testing.T) {
 		t.Fatal("expected root listing")
 	}
 
-	if got := len(file.Listing.Items); got != 1 {
+	if got := len(file.Items); got != 1 {
 		t.Fatalf("expected one accessible child, got %d", got)
 	}
 
-	if got := file.Listing.Items[0].Name; got != "media" {
+	if got := file.Items[0].Name; got != "media" {
 		t.Fatalf("expected accessible child to be listed, got %q", got)
 	}
 
-	if got := file.Listing.NumDirs; got != 1 {
+	if got := file.NumDirs; got != 1 {
 		t.Fatalf("expected one listed directory, got %d", got)
 	}
 }

--- a/files/file_test.go
+++ b/files/file_test.go
@@ -2,6 +2,7 @@ package files
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -80,4 +81,92 @@ func TestWithinScope(t *testing.T) {
 			t.Fatal("expected escaping symlink to a sibling directory to be rejected")
 		}
 	})
+}
+
+type allowAllChecker struct{}
+
+func (allowAllChecker) Check(string) bool {
+	return true
+}
+
+type inaccessibleChildFs struct {
+	afero.Fs
+	child string
+}
+
+func (fs inaccessibleChildFs) Open(name string) (afero.File, error) {
+	file, err := fs.Fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if path.Clean(name) == "/" {
+		return inaccessibleChildDir{File: file}, nil
+	}
+
+	return file, nil
+}
+
+func (fs inaccessibleChildFs) Stat(name string) (os.FileInfo, error) {
+	if path.Clean(name) == fs.child {
+		return nil, os.ErrPermission
+	}
+
+	return fs.Fs.Stat(name)
+}
+
+func (fs inaccessibleChildFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+	if path.Clean(name) == fs.child {
+		return nil, false, os.ErrPermission
+	}
+
+	if lstater, ok := fs.Fs.(afero.Lstater); ok {
+		return lstater.LstatIfPossible(name)
+	}
+
+	info, err := fs.Fs.Stat(name)
+	return info, false, err
+}
+
+type inaccessibleChildDir struct {
+	afero.File
+}
+
+func (dir inaccessibleChildDir) Readdir(int) ([]os.FileInfo, error) {
+	return nil, os.ErrPermission
+}
+
+func TestReadListingSkipsInaccessibleChildren(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+	for _, dir := range []string{"/media", "/proton-mount"} {
+		if err := memFs.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	file, err := NewFileInfo(&FileOptions{
+		Fs:      inaccessibleChildFs{Fs: memFs, child: "/proton-mount"},
+		Path:    "/",
+		Expand:  true,
+		Checker: allowAllChecker{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if file.Listing == nil {
+		t.Fatal("expected root listing")
+	}
+
+	if got := len(file.Listing.Items); got != 1 {
+		t.Fatalf("expected one accessible child, got %d", got)
+	}
+
+	if got := file.Listing.Items[0].Name; got != "media" {
+		t.Fatalf("expected accessible child to be listed, got %q", got)
+	}
+
+	if got := file.Listing.NumDirs; got != 1 {
+		t.Fatalf("expected one listed directory, got %d", got)
+	}
 }


### PR DESCRIPTION
## Description

Fixes directory listing so one inaccessible child does not make the whole parent directory fail to load.

When `afero.ReadDir` fails because a child cannot be statted, the listing now falls back to reading names only, stats each child separately, and skips only entries that still cannot be read. Accessible siblings continue to be returned in the listing.

Fixes #5627

## Additional Information

This keeps the current fast path unchanged. The fallback is only used after the normal directory read fails.

## Testing

- Red before fix: `GOMODCACHE=/tmp/filebrowser-5627-gomodcache GOCACHE=/tmp/filebrowser-5627-gocache go test ./files -run TestReadListingSkipsInaccessibleChildren -count=1` failed with `permission denied`
- `GOMODCACHE=/tmp/filebrowser-5627-gomodcache GOCACHE=/tmp/filebrowser-5627-gocache go test ./files -run TestReadListingSkipsInaccessibleChildren -count=1`
- `GOMODCACHE=/tmp/filebrowser-5627-gomodcache GOCACHE=/tmp/filebrowser-5627-gocache go test ./files -count=1`
- `test -z "$(gofmt -l files/file.go files/file_test.go)"`
- `git diff --cached --check`
- `GOMODCACHE=/tmp/filebrowser-5627-gomodcache GOCACHE=/tmp/filebrowser-5627-gocache go test ./...`
- `GOMODCACHE=/tmp/filebrowser-5627-gomodcache GOCACHE=/tmp/filebrowser-5627-gocache go build ./...`

`golangci-lint` is not installed in my local environment, so I could not run the repo lint config locally.

## Checklist

- [x] I am aware the project is currently in **maintenance-only** mode and new feature requests won't be accepted. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
