### PR TITLE
chore: Integrate Collabora office suite

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -229,6 +229,10 @@ func printSettings(ser *settings.Server, set *settings.Settings, auther auth.Aut
 	fmt.Fprintf(w, "\tThumbnails Enabled:\t%t\n", ser.EnableThumbnails)
 	fmt.Fprintf(w, "\tResize Preview:\t%t\n", ser.ResizePreview)
 	fmt.Fprintf(w, "\tType Detection by Header:\t%t\n", ser.TypeDetectionByHeader)
+	fmt.Fprintf(w, "\tCollabora Enabled:\t%t\n", ser.CollaboraEnabled)
+	fmt.Fprintf(w, "\tCollabora URL:\t%s\n", ser.CollaboraURL)
+	fmt.Fprintf(w, "\tCollabora Public URL:\t%s\n", ser.CollaboraPublicURL)
+	fmt.Fprintf(w, "\tCollabora Token TTL:\t%s\n", ser.CollaboraTokenTTL)
 
 	fmt.Fprintln(w, "\nTUS:")
 	fmt.Fprintf(w, "\tChunk size:\t%d\n", set.Tus.ChunkSize)
@@ -313,6 +317,16 @@ func getSettings(flags *pflag.FlagSet, set *settings.Settings, ser *settings.Ser
 		case "disableImageResolutionCalc":
 			ser.ImageResolutionCal, err = flags.GetBool(flag.Name)
 			ser.ImageResolutionCal = !ser.ImageResolutionCal
+		case "collabora.enabled":
+			ser.CollaboraEnabled, err = flags.GetBool(flag.Name)
+		case "collabora.url":
+			ser.CollaboraURL, err = flags.GetString(flag.Name)
+		case "collabora.publicURL":
+			ser.CollaboraPublicURL, err = flags.GetString(flag.Name)
+		case "collabora.wopiSecret":
+			ser.CollaboraWOPISecret, err = flags.GetString(flag.Name)
+		case "collabora.tokenTTL":
+			ser.CollaboraTokenTTL, err = flags.GetString(flag.Name)
 
 		// Settings flags from [addConfigFlags]
 		case "signup":

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,7 +113,8 @@ func addServerFlags(flags *pflag.FlagSet) {
 	flags.Bool("disableImageResolutionCalc", false, "disables image resolution calculation by reading image files")
 	flags.Bool("collabora.enabled", false, "enable Collabora Online / WOPI integration")
 	flags.String("collabora.url", "", "Collabora Online public URL, for example https://collabora.example.com")
-	flags.String("collabora.publicURL", "", "public File Browser URL used by Collabora for WOPI callbacks; include baseURL if File Browser is mounted under a path")
+	flags.String("collabora.publicURL", "", "external/public File Browser URL used by Collabora for WOPI callbacks; include baseURL if File Browser is mounted under a path")
+	flags.String("collabora.internalURL", "", "internal/LAN File Browser URL used by Collabora for WOPI callbacks when File Browser is opened from LAN")
 	flags.String("collabora.wopiSecret", "", "secret used to sign short-lived Collabora WOPI access tokens; falls back to File Browser key if empty")
 	flags.String("collabora.tokenTTL", "2h", "Collabora WOPI token lifetime")
 }
@@ -370,6 +371,10 @@ func getServerSettings(v *viper.Viper, st *storage.Storage) (*settings.Server, e
 		server.CollaboraPublicURL = v.GetString("collabora.publicURL")
 	}
 
+	if v.IsSet("collabora.internalURL") {
+		server.CollaboraInternalURL = v.GetString("collabora.internalURL")
+	}
+
 	if v.IsSet("collabora.wopiSecret") {
 		server.CollaboraWOPISecret = v.GetString("collabora.wopiSecret")
 	}
@@ -487,6 +492,7 @@ func quickSetup(v *viper.Viper, s *storage.Storage) error {
 		CollaboraEnabled:      v.GetBool("collabora.enabled"),
 		CollaboraURL:          v.GetString("collabora.url"),
 		CollaboraPublicURL:    v.GetString("collabora.publicURL"),
+		CollaboraInternalURL:  v.GetString("collabora.internalURL"),
 		CollaboraWOPISecret:   v.GetString("collabora.wopiSecret"),
 		CollaboraTokenTTL:     v.GetString("collabora.tokenTTL"),
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,6 +111,11 @@ func addServerFlags(flags *pflag.FlagSet) {
 	flags.Bool("disableExec", true, "disables Command Runner feature")
 	flags.Bool("disableTypeDetectionByHeader", false, "disables type detection by reading file headers")
 	flags.Bool("disableImageResolutionCalc", false, "disables image resolution calculation by reading image files")
+	flags.Bool("collabora.enabled", false, "enable Collabora Online / WOPI integration")
+	flags.String("collabora.url", "", "Collabora Online public URL, for example https://collabora.example.com")
+	flags.String("collabora.publicURL", "", "public File Browser URL used by Collabora for WOPI callbacks; include baseURL if File Browser is mounted under a path")
+	flags.String("collabora.wopiSecret", "", "secret used to sign short-lived Collabora WOPI access tokens; falls back to File Browser key if empty")
+	flags.String("collabora.tokenTTL", "2h", "Collabora WOPI token lifetime")
 }
 
 var rootCmd = &cobra.Command{
@@ -353,6 +358,26 @@ func getServerSettings(v *viper.Viper, st *storage.Storage) (*settings.Server, e
 		server.EnableExec = !v.GetBool("disableExec")
 	}
 
+	if v.IsSet("collabora.enabled") {
+		server.CollaboraEnabled = v.GetBool("collabora.enabled")
+	}
+
+	if v.IsSet("collabora.url") {
+		server.CollaboraURL = v.GetString("collabora.url")
+	}
+
+	if v.IsSet("collabora.publicURL") {
+		server.CollaboraPublicURL = v.GetString("collabora.publicURL")
+	}
+
+	if v.IsSet("collabora.wopiSecret") {
+		server.CollaboraWOPISecret = v.GetString("collabora.wopiSecret")
+	}
+
+	if v.IsSet("collabora.tokenTTL") {
+		server.CollaboraTokenTTL = v.GetString("collabora.tokenTTL")
+	}
+
 	if isAddrSet && isSocketSet {
 		return nil, errors.New("--socket flag cannot be used with --address, --port, --key nor --cert")
 	}
@@ -459,6 +484,11 @@ func quickSetup(v *viper.Viper, s *storage.Storage) error {
 		EnableExec:            !v.GetBool("disableExec"),
 		TypeDetectionByHeader: !v.GetBool("disableTypeDetectionByHeader"),
 		ImageResolutionCal:    !v.GetBool("disableImageResolutionCalc"),
+		CollaboraEnabled:      v.GetBool("collabora.enabled"),
+		CollaboraURL:          v.GetString("collabora.url"),
+		CollaboraPublicURL:    v.GetString("collabora.publicURL"),
+		CollaboraWOPISecret:   v.GetString("collabora.wopiSecret"),
+		CollaboraTokenTTL:     v.GetString("collabora.tokenTTL"),
 	}
 
 	err = s.Settings.SaveServer(ser)

--- a/frontend/src/api/collabora.ts
+++ b/frontend/src/api/collabora.ts
@@ -1,0 +1,54 @@
+import { fetchJSON } from "./utils";
+
+export interface CollaboraOpenResponse {
+  url: string;
+  fileID: string;
+  canWrite: boolean;
+  name: string;
+}
+
+const officeExtensions = new Set([
+  ".doc",
+  ".docx",
+  ".docm",
+  ".dot",
+  ".dotx",
+  ".odt",
+  ".ott",
+  ".rtf",
+  ".xls",
+  ".xlsx",
+  ".xlsm",
+  ".xlt",
+  ".xltx",
+  ".ods",
+  ".ots",
+  ".csv",
+  ".ppt",
+  ".pptx",
+  ".pptm",
+  ".pot",
+  ".potx",
+  ".odp",
+  ".otp",
+  ".vsd",
+  ".vsdx",
+  ".odg",
+  ".pdf",
+]);
+
+export function isSupportedExtension(extension?: string): boolean {
+  if (!extension) return false;
+  return officeExtensions.has(extension.toLowerCase());
+}
+
+export async function openPath(path: string): Promise<CollaboraOpenResponse> {
+  if (!path.startsWith("/")) {
+    path = `/${path}`;
+  }
+
+  const params = new URLSearchParams({ path });
+  return fetchJSON<CollaboraOpenResponse>(`/api/collabora/open?${params.toString()}`, {
+    method: "GET",
+  });
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -5,5 +5,6 @@ import * as settings from "./settings";
 import * as pub from "./pub";
 import search from "./search";
 import commands from "./commands";
+import * as collabora from "./collabora";
 
-export { files, share, users, settings, pub, commands, search };
+export { files, share, users, settings, pub, commands, search, collabora };

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -1,5 +1,16 @@
 import { fetchURL, fetchJSON } from "./utils";
 
+export interface CollaboraTestCheck {
+  name: string;
+  status: "success" | "warning" | "error";
+  message: string;
+}
+
+export interface CollaboraTestResponse {
+  ok: boolean;
+  checks: CollaboraTestCheck[];
+}
+
 export function get() {
   return fetchJSON<ISettings>(`/api/settings`, {});
 }
@@ -8,5 +19,12 @@ export async function update(settings: ISettings) {
   await fetchURL(`/api/settings`, {
     method: "PUT",
     body: JSON.stringify(settings),
+  });
+}
+
+export async function testCollabora(collabora: SettingsCollabora) {
+  return fetchJSON<CollaboraTestResponse>(`/api/collabora/test`, {
+    method: "POST",
+    body: JSON.stringify({ collabora }),
   });
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -214,10 +214,10 @@
     "commandRunnerHelp": "Here you can set commands that are executed in the named events. You must write one per line. The environment variables {0} and {1} will be available, being {0} relative to {1}. For more information about this feature and the available environment variables, please read the {2}.",
     "commandsUpdated": "Commands updated!",
     "collabora": "Collabora Online",
-    "collaboraHelp": "Configure Collabora Online / WOPI directly from File Browser. The public File Browser URL must be reachable from the Collabora server.",
+    "collaboraHelp": "Configure Collabora Online / WOPI directly from File Browser. Use both external and internal File Browser URLs when the same server is accessed from public DNS and LAN IP.",
     "collaboraEnabled": "Enable Collabora integration",
     "collaboraURL": "Collabora URL",
-    "collaboraPublicURL": "Public File Browser URL",
+    "collaboraPublicURL": "External File Browser URL",
     "collaboraWOPISecret": "WOPI token secret",
     "collaboraTokenTTL": "WOPI token lifetime",
     "createUserDir": "Auto create user home dir while adding new user",
@@ -295,7 +295,10 @@
     "collaboraTest": "Test Collabora connection",
     "collaboraTesting": "Testing Collabora connection...",
     "collaboraTestPassed": "Collabora connection test passed.",
-    "collaboraTestNeedsAttention": "Collabora connection test completed with warnings or errors."
+    "collaboraTestNeedsAttention": "Collabora connection test completed with warnings or errors.",
+    "collaboraPublicURLHelp": "Used when File Browser is opened through the public/external DNS name, for example https://filebrowser.koszhome.ro.",
+    "collaboraInternalURL": "Internal File Browser URL",
+    "collaboraInternalURLHelp": "Used when File Browser is opened from LAN, for example http://192.168.68.204:8080. Leave empty if you only use the external URL."
   },
   "sidebar": {
     "diskUsed": "{used} of {total} used",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -54,7 +54,11 @@
     "overrideAll": "Replace all files in destination folder",
     "skipAll": "Skip all conflicting files",
     "renameAll": "Rename all files (create a copy)",
-    "singleDecision": "Decide for each conflicting file"
+    "singleDecision": "Decide for each conflicting file",
+    "openWithCollabora": "Open with Collabora",
+    "reloadCollabora": "Reload Collabora",
+    "fullscreen": "Full screen",
+    "exitFullscreen": "Exit full screen"
   },
   "download": {
     "downloadFile": "Download File",
@@ -209,6 +213,13 @@
     "commandRunner": "Command runner",
     "commandRunnerHelp": "Here you can set commands that are executed in the named events. You must write one per line. The environment variables {0} and {1} will be available, being {0} relative to {1}. For more information about this feature and the available environment variables, please read the {2}.",
     "commandsUpdated": "Commands updated!",
+    "collabora": "Collabora Online",
+    "collaboraHelp": "Configure Collabora Online / WOPI directly from File Browser. The public File Browser URL must be reachable from the Collabora server.",
+    "collaboraEnabled": "Enable Collabora integration",
+    "collaboraURL": "Collabora URL",
+    "collaboraPublicURL": "Public File Browser URL",
+    "collaboraWOPISecret": "WOPI token secret",
+    "collaboraTokenTTL": "WOPI token lifetime",
     "createUserDir": "Auto create user home dir while adding new user",
     "minimumPasswordLength": "Minimum password length",
     "tusUploads": "Chunked Uploads",
@@ -280,7 +291,11 @@
     "userUpdated": "User updated!",
     "username": "Username",
     "users": "Users",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "collaboraTest": "Test Collabora connection",
+    "collaboraTesting": "Testing Collabora connection...",
+    "collaboraTestPassed": "Collabora connection test passed.",
+    "collaboraTestNeedsAttention": "Collabora connection test completed with warnings or errors."
   },
   "sidebar": {
     "diskUsed": "{used} of {total} used",

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -47,6 +47,7 @@ interface SettingsCollabora {
   enabled: boolean;
   url: string;
   publicURL: string;
+  internalURL: string;
   wopiSecret: string;
   tokenTTL: string;
 }

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -9,6 +9,7 @@ interface ISettings {
   rules: any[];
   branding: SettingsBranding;
   tus: SettingsTus;
+  collabora: SettingsCollabora;
   shell: string[];
   commands: SettingsCommand;
 }
@@ -39,6 +40,15 @@ interface SettingsBranding {
 interface SettingsTus {
   chunkSize: number;
   retryCount: number;
+}
+
+interface SettingsCollabora {
+  configured: boolean;
+  enabled: boolean;
+  url: string;
+  publicURL: string;
+  wopiSecret: string;
+  tokenTTL: string;
 }
 
 interface SettingsCommand {

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -20,6 +20,7 @@ const tusSettings = window.FileBrowser.TusSettings;
 const origin = window.location.origin;
 const tusEndpoint = `/api/tus`;
 const hideLoginButton = window.FileBrowser.HideLoginButton;
+const collaboraEnabled: boolean = window.FileBrowser.CollaboraEnabled;
 
 export {
   name,
@@ -43,4 +44,5 @@ export {
   origin,
   tusEndpoint,
   hideLoginButton,
+  collaboraEnabled,
 };

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -6,7 +6,7 @@
       showLogo
     />
 
-    <breadcrumbs base="/files" />
+    <breadcrumbs v-if="!isCollaboraOfficeView" base="/files" />
     <errors v-if="error" :errorCode="error.status" />
     <component v-else-if="currentView" :is="currentView"></component>
     <div v-else>
@@ -32,7 +32,7 @@ import {
   ref,
   watch,
 } from "vue";
-import { files as api } from "@/api";
+import { collabora, files as api } from "@/api";
 import { storeToRefs } from "pinia";
 import { useFileStore } from "@/stores/file";
 import { useLayoutStore } from "@/stores/layout";
@@ -44,10 +44,11 @@ import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
 import FileListing from "@/views/files/FileListing.vue";
 import { StatusError } from "@/api/utils";
-import { name } from "../utils/constants";
+import { collaboraEnabled, name } from "../utils/constants";
 
 const Editor = defineAsyncComponent(() => import("@/views/files/Editor.vue"));
 const Preview = defineAsyncComponent(() => import("@/views/files/Preview.vue"));
+const Collabora = defineAsyncComponent(() => import("@/views/files/Collabora.vue"));
 
 const layoutStore = useLayoutStore();
 const fileStore = useFileStore();
@@ -62,6 +63,14 @@ let fetchDataController = new AbortController();
 
 const error = ref<StatusError | null>(null);
 
+const isCollaboraOfficeView = computed(() =>
+  route.query.office === "true" &&
+  collaboraEnabled &&
+  !!fileStore.req &&
+  !fileStore.req.isDir &&
+  collabora.isSupportedExtension(fileStore.req.extension)
+);
+
 const currentView = computed(() => {
   if (fileStore.req?.type === undefined) {
     return null;
@@ -69,6 +78,8 @@ const currentView = computed(() => {
 
   if (fileStore.req.isDir) {
     return FileListing;
+  } else if (isCollaboraOfficeView.value) {
+    return Collabora;
   } else if (fileStore.req.extension.toLowerCase() === ".csv") {
     // CSV files use Preview for table view, unless ?edit=true
     if (route.query.edit === "true") {

--- a/frontend/src/views/Layout.vue
+++ b/frontend/src/views/Layout.vue
@@ -7,12 +7,15 @@
         }"
       ></div>
     </div>
-    <sidebar></sidebar>
-    <main>
+    <sidebar v-if="!isCollaboraOfficeRoute"></sidebar>
+    <main :class="{ 'office-fullscreen-main': isCollaboraOfficeRoute }">
       <router-view></router-view>
       <shell
         v-if="
-          enableExec && authStore.isLoggedIn && authStore.user?.perm.execute
+          !isCollaboraOfficeRoute &&
+          enableExec &&
+          authStore.isLoggedIn &&
+          authStore.user?.perm.execute
         "
       />
     </main>
@@ -44,6 +47,10 @@ const sentPercent = computed(() =>
   ((uploadStore.sentBytes / uploadStore.totalBytes) * 100).toFixed(2)
 );
 
+const isCollaboraOfficeRoute = computed(
+  () => route.path.startsWith("/files") && route.query.office === "true"
+);
+
 watch(route, () => {
   fileStore.selected = [];
   fileStore.multiple = false;
@@ -52,3 +59,11 @@ watch(route, () => {
   }
 });
 </script>
+
+
+<style scoped>
+main.office-fullscreen-main {
+  margin: 0;
+  width: 100%;
+}
+</style>

--- a/frontend/src/views/files/Collabora.vue
+++ b/frontend/src/views/files/Collabora.vue
@@ -1,0 +1,215 @@
+<template>
+  <div id="collabora-container">
+    <header-bar>
+      <action icon="close" :label="t('buttons.close')" @action="close" />
+      <span class="collabora-title">{{ fileStore.req?.name ?? title }}</span>
+
+      <template #actions>
+        <action
+          icon="refresh"
+          :label="t('buttons.reloadCollabora')"
+          @action="loadEditor"
+        />
+        <action
+          :icon="isNativeFullscreen ? 'fullscreen_exit' : 'fullscreen'"
+          :label="isNativeFullscreen ? t('buttons.exitFullscreen') : t('buttons.fullscreen')"
+          @action="toggleNativeFullscreen"
+        />
+        <action
+          v-if="fileStore.req"
+          icon="file_download"
+          :label="t('buttons.download')"
+          @action="download"
+        />
+      </template>
+    </header-bar>
+
+    <div class="loading delayed" v-if="layoutStore.loading">
+      <div class="spinner">
+        <div class="bounce1"></div>
+        <div class="bounce2"></div>
+        <div class="bounce3"></div>
+      </div>
+    </div>
+
+    <iframe
+      v-else-if="editorUrl"
+      :key="editorUrl"
+      :src="editorUrl"
+      allow="clipboard-read; clipboard-write; fullscreen"
+      referrerpolicy="no-referrer-when-downgrade"
+    ></iframe>
+
+    <div v-else class="info">
+      <div class="title">
+        <i class="material-icons">feedback</i>
+        {{ errorMessage || "Collabora could not be opened." }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { inject, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
+
+import { collabora, files as api } from "@/api";
+import url from "@/utils/url";
+import { useFileStore } from "@/stores/file";
+import { useLayoutStore } from "@/stores/layout";
+import HeaderBar from "@/components/header/HeaderBar.vue";
+import Action from "@/components/header/Action.vue";
+
+const fileStore = useFileStore();
+const layoutStore = useLayoutStore();
+const route = useRoute();
+const router = useRouter();
+const { t } = useI18n();
+
+const $showError = inject<IToastError>("$showError")!;
+
+const editorUrl = ref("");
+const errorMessage = ref("");
+const title = ref("Collabora");
+const isNativeFullscreen = ref(false);
+
+const loadEditor = async () => {
+  if (!fileStore.req) return;
+
+  editorUrl.value = "";
+  errorMessage.value = "";
+  layoutStore.loading = true;
+
+  try {
+    const response = await collabora.openPath(fileStore.req.path);
+    title.value = response.name;
+    editorUrl.value = response.url;
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : String(error);
+    $showError(error as Error);
+  } finally {
+    layoutStore.loading = false;
+  }
+};
+
+const close = () => {
+  if (fileStore.req) {
+    fileStore.preselect = fileStore.req.path;
+  }
+
+  const uri = url.removeLastDir(route.path) + "/";
+  router.push({ path: uri });
+};
+
+const handleCollaboraMessage = (event: MessageEvent) => {
+  if (!editorUrl.value) return;
+
+  try {
+    const editorOrigin = new URL(editorUrl.value).origin;
+    if (event.origin !== editorOrigin) return;
+  } catch {
+    return;
+  }
+
+  let data: any = event.data;
+  if (typeof data === "string") {
+    try {
+      data = JSON.parse(data);
+    } catch {
+      data = { MessageId: data };
+    }
+  }
+
+  const messageId = data?.MessageId ?? data?.messageId ?? data?.type;
+  if (["UI_Close", "UI_CloseClicked", "close", "Close"].includes(messageId)) {
+    close();
+  }
+};
+
+const download = () => {
+  if (fileStore.req) {
+    window.open(api.getDownloadURL(fileStore.req, false));
+  }
+};
+
+const syncFullscreenState = () => {
+  isNativeFullscreen.value = !!document.fullscreenElement;
+};
+
+const toggleNativeFullscreen = async () => {
+  const container = document.getElementById("collabora-container");
+
+  try {
+    if (document.fullscreenElement) {
+      await document.exitFullscreen();
+    } else if (container?.requestFullscreen) {
+      await container.requestFullscreen();
+    }
+  } catch (error) {
+    $showError(error as Error);
+  }
+};
+
+onMounted(() => {
+  document.body.classList.add("collabora-open");
+  document.addEventListener("fullscreenchange", syncFullscreenState);
+  window.addEventListener("message", handleCollaboraMessage);
+  loadEditor();
+});
+
+onBeforeUnmount(() => {
+  document.body.classList.remove("collabora-open");
+  document.removeEventListener("fullscreenchange", syncFullscreenState);
+  window.removeEventListener("message", handleCollaboraMessage);
+});
+watch(
+  () => fileStore.req?.path,
+  () => loadEditor()
+);
+</script>
+
+<style scoped>
+:global(body.collabora-open) {
+  overflow: hidden;
+}
+
+#collabora-container {
+  position: fixed;
+  inset: 0;
+  z-index: 200000;
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  min-height: 100dvh;
+  padding-top: 4em;
+  box-sizing: border-box;
+  background: var(--background);
+}
+
+#collabora-container :deep(header) {
+  z-index: 200001;
+}
+
+#collabora-container iframe {
+  border: 0;
+  flex: 1 1 auto;
+  height: calc(100dvh - 4em);
+  width: 100%;
+  background: white;
+}
+
+#collabora-container .loading,
+#collabora-container .info {
+  flex: 1 1 auto;
+}
+
+.collabora-title {
+  flex: 1 1 auto;
+  padding: 0 1em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+}
+</style>

--- a/frontend/src/views/files/FileListing.vue
+++ b/frontend/src/views/files/FileListing.vue
@@ -25,6 +25,12 @@
             show="rename"
           />
           <action
+            v-if="headerButtons.collabora"
+            icon="description"
+            :label="t('buttons.openWithCollabora')"
+            @action="openSelectedWithCollabora"
+          />
+          <action
             v-if="headerButtons.copy"
             id="copy-button"
             icon="content_copy"
@@ -102,6 +108,12 @@
         icon="mode_edit"
         :label="t('buttons.rename')"
         show="rename"
+      />
+      <action
+        v-if="headerButtons.collabora"
+        icon="description"
+        :label="t('buttons.openWithCollabora')"
+        @action="openSelectedWithCollabora"
       />
       <action
         v-if="headerButtons.copy"
@@ -275,6 +287,12 @@
             show="rename"
           />
           <action
+            v-if="headerButtons.collabora"
+            icon="description"
+            :label="t('buttons.openWithCollabora')"
+            @action="openSelectedWithCollabora"
+          />
+          <action
             v-if="headerButtons.copy"
             id="copy-button"
             icon="content_copy"
@@ -345,8 +363,8 @@ import { useClipboardStore } from "@/stores/clipboard";
 import { useFileStore } from "@/stores/file";
 import { useLayoutStore } from "@/stores/layout";
 
-import { users, files as api } from "@/api";
-import { enableExec } from "@/utils/constants";
+import { collabora, users, files as api } from "@/api";
+import { collaboraEnabled, enableExec } from "@/utils/constants";
 import * as upload from "@/utils/upload";
 import css from "@/utils/css";
 import { throttle } from "lodash-es";
@@ -366,7 +384,7 @@ import {
   ref,
   watch,
 } from "vue";
-import { useRoute, onBeforeRouteUpdate } from "vue-router";
+import { useRoute, useRouter, onBeforeRouteUpdate } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { storeToRefs } from "pinia";
 import { removePrefix } from "@/api/utils";
@@ -389,6 +407,7 @@ const layoutStore = useLayoutStore();
 const { req } = storeToRefs(fileStore);
 
 const route = useRoute();
+const router = useRouter();
 onBeforeRouteUpdate(() => {
   hideContextMenu();
 });
@@ -473,6 +492,26 @@ const viewIcon = computed(() => {
     : icons[authStore.user.viewMode];
 });
 
+const selectedResource = computed<ResourceItem | null>(() => {
+  if (fileStore.selectedCount !== 1 || !fileStore.req) {
+    return null;
+  }
+
+  return fileStore.req.items[fileStore.selected[0]] ?? null;
+});
+
+const canOpenSelectedWithCollabora = computed(() => {
+  const item = selectedResource.value;
+
+  return !!(
+    collaboraEnabled &&
+    item &&
+    !item.isDir &&
+    authStore.user?.perm.download &&
+    collabora.isSupportedExtension(item.extension)
+  );
+});
+
 const headerButtons = computed(() => {
   return {
     upload: authStore.user?.perm.create,
@@ -484,6 +523,7 @@ const headerButtons = computed(() => {
       fileStore.selectedCount === 1 &&
       authStore.user?.perm.share &&
       authStore.user?.perm.download,
+    collabora: canOpenSelectedWithCollabora.value,
     move: fileStore.selectedCount > 0 && authStore.user?.perm.rename,
     copy: fileStore.selectedCount > 0 && authStore.user?.perm.create,
   };
@@ -971,6 +1011,13 @@ const windowsResize = throttle(() => {
   // Fill but not fit the window
   fillWindow();
 }, 100);
+
+const openSelectedWithCollabora = () => {
+  const item = selectedResource.value;
+  if (!item) return;
+
+  router.push({ path: item.url, query: { office: "true" } });
+};
 
 const download = () => {
   if (fileStore.req === null) return;

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -26,6 +26,13 @@
         />
         <action
           :disabled="layoutStore.loading"
+          v-if="canOpenWithCollabora"
+          icon="description"
+          :label="t('buttons.openWithCollabora')"
+          @action="openWithCollabora"
+        />
+        <action
+          :disabled="layoutStore.loading"
           v-if="isCsv && authStore.user?.perm.modify"
           icon="edit_note"
           :label="t('buttons.editAsText')"
@@ -138,10 +145,21 @@
               </div>
             </a>
             <a
+              href=""
+              class="button button--flat"
+              v-if="canOpenWithCollabora"
+              @click.prevent="openWithCollabora"
+            >
+              <div>
+                <i class="material-icons">description</i
+                >{{ t("buttons.openWithCollabora") }}
+              </div>
+            </a>
+            <a
               target="_blank"
               :href="previewUrl"
               class="button button--flat"
-              v-if="!fileStore.req?.isDir"
+              v-else-if="!fileStore.req?.isDir"
             >
               <div>
                 <i class="material-icons">open_in_new</i
@@ -184,9 +202,9 @@ import { useAuthStore } from "@/stores/auth";
 import { useFileStore } from "@/stores/file";
 import { useLayoutStore } from "@/stores/layout";
 
-import { files as api } from "@/api";
+import { collabora, files as api } from "@/api";
 import { createURL } from "@/api/utils";
-import { resizePreview } from "@/utils/constants";
+import { collaboraEnabled, resizePreview } from "@/utils/constants";
 import url from "@/utils/url";
 import { throttle } from "lodash-es";
 import HeaderBar from "@/components/header/HeaderBar.vue";
@@ -314,6 +332,14 @@ const isCsv = computed(
   () =>
     fileStore.req?.extension.toLowerCase() == ".csv" &&
     fileStore.req.size <= CSV_MAX_SIZE
+);
+
+const canOpenWithCollabora = computed(
+  () =>
+    collaboraEnabled &&
+    !fileStore.req?.isDir &&
+    authStore.user?.perm.download &&
+    collabora.isSupportedExtension(fileStore.req?.extension)
 );
 
 const isResizeEnabled = computed(() => resizePreview);
@@ -499,5 +525,9 @@ const openDirect = () => window.open(directUrl.value);
 
 const editAsText = () => {
   router.push({ path: route.path, query: { edit: "true" } });
+};
+
+const openWithCollabora = () => {
+  router.push({ path: route.path, query: { office: "true" } });
 };
 </script>

--- a/frontend/src/views/settings/Global.vue
+++ b/frontend/src/views/settings/Global.vue
@@ -153,6 +153,109 @@
               />
             </p>
           </div>
+
+          <h3>{{ t("settings.collabora") }}</h3>
+
+          <p class="small">{{ t("settings.collaboraHelp") }}</p>
+
+          <p>
+            <input
+              type="checkbox"
+              v-model="settings.collabora.enabled"
+              id="collabora-enabled"
+            />
+            {{ t("settings.collaboraEnabled") }}
+          </p>
+
+          <p>
+            <label for="collabora-url">{{ t("settings.collaboraURL") }}</label>
+            <input
+              class="input input--block"
+              type="url"
+              placeholder="https://collabora.koszhome.ro"
+              v-model.trim="settings.collabora.url"
+              id="collabora-url"
+            />
+          </p>
+
+          <p>
+            <label for="collabora-public-url">{{
+              t("settings.collaboraPublicURL")
+            }}</label>
+            <input
+              class="input input--block"
+              type="url"
+              placeholder="https://filebrowser.koszhome.ro"
+              v-model.trim="settings.collabora.publicURL"
+              id="collabora-public-url"
+            />
+          </p>
+
+          <p>
+            <label for="collabora-wopi-secret">{{
+              t("settings.collaboraWOPISecret")
+            }}</label>
+            <input
+              class="input input--block"
+              type="password"
+              autocomplete="off"
+              placeholder="long random secret"
+              v-model.trim="settings.collabora.wopiSecret"
+              id="collabora-wopi-secret"
+            />
+          </p>
+
+          <p>
+            <label for="collabora-token-ttl">{{
+              t("settings.collaboraTokenTTL")
+            }}</label>
+            <input
+              class="input input--block"
+              type="text"
+              placeholder="2h"
+              v-model.trim="settings.collabora.tokenTTL"
+              id="collabora-token-ttl"
+            />
+          </p>
+
+          <p>
+            <button
+              class="button button--flat"
+              type="button"
+              :disabled="collaboraTesting"
+              @click="testCollabora"
+            >
+              {{
+                collaboraTesting
+                  ? t("settings.collaboraTesting")
+                  : t("settings.collaboraTest")
+              }}
+            </button>
+          </p>
+
+          <div
+            v-if="collaboraTestResult"
+            class="collabora-test-results"
+            :class="{ 'collabora-test-results--ok': collaboraTestResult.ok }"
+          >
+            <p class="small">
+              {{
+                collaboraTestResult.ok
+                  ? t("settings.collaboraTestPassed")
+                  : t("settings.collaboraTestNeedsAttention")
+              }}
+            </p>
+            <ul>
+              <li
+                v-for="check in collaboraTestResult.checks"
+                :key="check.name"
+                :class="`collabora-test-results__item collabora-test-results__item--${check.status}`"
+              >
+                <strong>{{ check.status.toUpperCase() }}</strong>
+                <span>{{ check.message }}</span>
+              </li>
+            </ul>
+          </div>
         </div>
 
         <div class="card-action">
@@ -247,6 +350,7 @@
 
 <script setup lang="ts">
 import { settings as api } from "@/api";
+import type { CollaboraTestResponse } from "@/api/settings";
 import { StatusError } from "@/api/utils";
 import Rules from "@/components/settings/Rules.vue";
 import Themes from "@/components/settings/Themes.vue";
@@ -262,6 +366,8 @@ const error = ref<StatusError | null>(null);
 const originalSettings = ref<ISettings | null>(null);
 const settings = ref<ISettings | null>(null);
 const debounceTimeout = ref<number | null>(null);
+const collaboraTesting = ref(false);
+const collaboraTestResult = ref<CollaboraTestResponse | null>(null);
 
 const commandObject = ref<{
   [key: string]: string[] | string;
@@ -309,6 +415,37 @@ const capitalize = (name: string, where: string | RegExp = "_") => {
   return name.slice(0, -1);
 };
 
+const normalizedCollaboraSettings = (): SettingsCollabora => ({
+  configured: true,
+  enabled: Boolean(settings.value?.collabora?.enabled),
+  url: settings.value?.collabora?.url?.trim() ?? "",
+  publicURL: settings.value?.collabora?.publicURL?.trim() ?? "",
+  wopiSecret: settings.value?.collabora?.wopiSecret?.trim() ?? "",
+  tokenTTL: settings.value?.collabora?.tokenTTL?.trim() || "2h",
+});
+
+const testCollabora = async () => {
+  if (settings.value === null || collaboraTesting.value) return;
+
+  collaboraTesting.value = true;
+  collaboraTestResult.value = null;
+
+  try {
+    collaboraTestResult.value = await api.testCollabora(
+      normalizedCollaboraSettings()
+    );
+    if (collaboraTestResult.value.ok) {
+      $showSuccess(t("settings.collaboraTestPassed"));
+    } else {
+      $showError(t("settings.collaboraTestNeedsAttention"));
+    }
+  } catch (e: any) {
+    $showError(e);
+  } finally {
+    collaboraTesting.value = false;
+  }
+};
+
 const save = async () => {
   if (settings.value === null) return false;
   const newSettings: ISettings = {
@@ -321,6 +458,8 @@ const save = async () => {
         .filter((s: string) => s !== "") ?? [],
     commands: {},
   };
+
+  newSettings.collabora = normalizedCollaboraSettings();
 
   const keys = Object.keys(settings.value.commands) as Array<
     keyof SettingsCommand
@@ -396,7 +535,18 @@ onMounted(async () => {
   try {
     layoutStore.loading = true;
     const original: ISettings = await api.get();
-    const newSettings: ISettings = { ...original, commands: {} };
+    const newSettings: ISettings = {
+      ...original,
+      collabora: {
+        configured: original.collabora?.configured ?? true,
+        enabled: original.collabora?.enabled ?? false,
+        url: original.collabora?.url ?? "",
+        publicURL: original.collabora?.publicURL ?? "",
+        wopiSecret: original.collabora?.wopiSecret ?? "",
+        tokenTTL: original.collabora?.tokenTTL || "2h",
+      },
+      commands: {},
+    };
 
     const keys = Object.keys(original.commands) as Array<keyof SettingsCommand>;
     for (const key of keys) {
@@ -423,3 +573,42 @@ onBeforeUnmount(() => {
   }
 });
 </script>
+
+
+<style scoped>
+.collabora-test-results {
+  border-left: 4px solid var(--red);
+  margin: 1em 0;
+  padding: 0.75em 1em;
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.collabora-test-results--ok {
+  border-left-color: var(--icon-green);
+}
+
+.collabora-test-results ul {
+  margin: 0.5em 0 0;
+  padding-left: 0;
+  list-style: none;
+}
+
+.collabora-test-results__item {
+  display: flex;
+  gap: 0.75em;
+  align-items: flex-start;
+  margin: 0.4em 0;
+}
+
+.collabora-test-results__item--success strong {
+  color: var(--icon-green);
+}
+
+.collabora-test-results__item--warning strong {
+  color: var(--icon-yellow);
+}
+
+.collabora-test-results__item--error strong {
+  color: var(--red);
+}
+</style>

--- a/frontend/src/views/settings/Global.vue
+++ b/frontend/src/views/settings/Global.vue
@@ -189,6 +189,21 @@
               v-model.trim="settings.collabora.publicURL"
               id="collabora-public-url"
             />
+            <span class="small">{{ t("settings.collaboraPublicURLHelp") }}</span>
+          </p>
+
+          <p>
+            <label for="collabora-internal-url">{{
+              t("settings.collaboraInternalURL")
+            }}</label>
+            <input
+              class="input input--block"
+              type="url"
+              placeholder="http://192.168.68.204:8080"
+              v-model.trim="settings.collabora.internalURL"
+              id="collabora-internal-url"
+            />
+            <span class="small">{{ t("settings.collaboraInternalURLHelp") }}</span>
           </p>
 
           <p>
@@ -420,6 +435,7 @@ const normalizedCollaboraSettings = (): SettingsCollabora => ({
   enabled: Boolean(settings.value?.collabora?.enabled),
   url: settings.value?.collabora?.url?.trim() ?? "",
   publicURL: settings.value?.collabora?.publicURL?.trim() ?? "",
+  internalURL: settings.value?.collabora?.internalURL?.trim() ?? "",
   wopiSecret: settings.value?.collabora?.wopiSecret?.trim() ?? "",
   tokenTTL: settings.value?.collabora?.tokenTTL?.trim() || "2h",
 });
@@ -542,6 +558,7 @@ onMounted(async () => {
         enabled: original.collabora?.enabled ?? false,
         url: original.collabora?.url ?? "",
         publicURL: original.collabora?.publicURL ?? "",
+        internalURL: original.collabora?.internalURL ?? "",
         wopiSecret: original.collabora?.wopiSecret ?? "",
         tokenTTL: original.collabora?.tokenTTL || "2h",
       },

--- a/http/collabora.go
+++ b/http/collabora.go
@@ -8,7 +8,9 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	gopath "path"
 	"regexp"
@@ -87,6 +89,7 @@ var collaboraTestHandler = withAdmin(func(w http.ResponseWriter, r *http.Request
 	cfg := req.Collabora
 	cfg.URL = strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
 	cfg.PublicURL = strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/")
+	cfg.InternalURL = strings.TrimRight(strings.TrimSpace(cfg.InternalURL), "/")
 	cfg.WOPISecret = strings.TrimSpace(cfg.WOPISecret)
 	cfg.TokenTTL = strings.TrimSpace(cfg.TokenTTL)
 	if cfg.TokenTTL == "" {
@@ -115,16 +118,17 @@ var collaboraTestHandler = withAdmin(func(w http.ResponseWriter, r *http.Request
 	}
 	add("collabora_url", "success", "Collabora URL format is valid: "+cfg.URL)
 
-	publicURL, err := url.Parse(cfg.PublicURL)
-	if cfg.PublicURL == "" || err != nil || publicURL.Scheme == "" || publicURL.Host == "" {
-		add("public_url", "error", "Public File Browser URL must be set and must be an absolute URL reachable by the Collabora server.")
+	validExternal := validateCollaboraBaseURL("external_url", "External File Browser URL", cfg.PublicURL, false, add)
+	validInternal := validateCollaboraBaseURL("internal_url", "Internal File Browser URL", cfg.InternalURL, true, add)
+	if !validExternal && !validInternal {
+		add("wopi_urls", "error", "At least one File Browser WOPI URL must be configured. Set External File Browser URL, Internal File Browser URL, or both.")
 		return renderCollaboraTest(w, r, checks), nil
 	}
-	if publicURL.Scheme != "http" && publicURL.Scheme != "https" {
-		add("public_url", "error", "Public File Browser URL must use http or https.")
-		return renderCollaboraTest(w, r, checks), nil
+
+	selectedWOPIURL := selectCollaboraWOPIBaseURL(cfg, r, d)
+	if selectedWOPIURL != "" {
+		add("selected_wopi_url", "success", "For this request File Browser would use WOPI URL: "+selectedWOPIURL)
 	}
-	add("public_url", "success", "Public File Browser URL format is valid: "+cfg.PublicURL)
 
 	if strings.TrimSpace(cfg.WOPISecret) == "" {
 		add("wopi_secret", "warning", "WOPI token secret is empty. File Browser will fall back to the instance key, but a dedicated long random secret is recommended.")
@@ -170,25 +174,8 @@ var collaboraTestHandler = withAdmin(func(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	wopiProbeURL := strings.TrimRight(cfg.PublicURL, "/") + "/wopi/files/__collabora_test__?access_token=invalid"
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-	probeReq, err := http.NewRequestWithContext(ctx, http.MethodGet, wopiProbeURL, nil)
-	if err != nil {
-		add("wopi_public_url", "error", "Could not build WOPI probe request: "+err.Error())
-	} else {
-		probeRes, err := http.DefaultClient.Do(probeReq)
-		if err != nil {
-			add("wopi_public_url", "warning", "Public File Browser URL was not reachable from this server: "+err.Error()+". Collabora must be able to reach this URL.")
-		} else {
-			defer probeRes.Body.Close()
-			if probeRes.StatusCode == http.StatusUnauthorized || probeRes.StatusCode == http.StatusNotFound {
-				add("wopi_public_url", "success", "Public File Browser URL reached the WOPI endpoint. Collabora should use this as aliasgroup1/allowed WOPI host.")
-			} else {
-				add("wopi_public_url", "warning", fmt.Sprintf("Public File Browser URL responded with HTTP %d during WOPI probe. Collabora may still fail if aliasgroup1/allowed WOPI host is not set to %s.", probeRes.StatusCode, cfg.PublicURL))
-			}
-		}
-	}
+	probeCollaboraWOPIURL(r.Context(), "external", cfg.PublicURL, add)
+	probeCollaboraWOPIURL(r.Context(), "internal", cfg.InternalURL, add)
 
 	return renderCollaboraTest(w, r, checks), nil
 })
@@ -263,8 +250,8 @@ var collaboraOpenHandler = withUser(func(w http.ResponseWriter, r *http.Request,
 		return http.StatusInternalServerError, err
 	}
 
-	publicURL := collaboraPublicURL(d, r)
-	wopiSrc := strings.TrimRight(publicURL, "/") + "/wopi/files/" + url.PathEscape(fileID)
+	wopiBaseURL := selectCollaboraWOPIBaseURL(cfg, r, d)
+	wopiSrc := strings.TrimRight(wopiBaseURL, "/") + "/wopi/files/" + url.PathEscape(fileID)
 
 	action, err := collaboraActionForExt(r.Context(), cfg.URL, ext, canWrite)
 	if err != nil {
@@ -329,12 +316,93 @@ func wopiFileID(userID uint, filePath string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func collaboraPublicURL(d *data, r *http.Request) string {
-	cfg := d.collaboraConfig()
-	if strings.TrimSpace(cfg.PublicURL) != "" {
-		return strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/")
+func validateCollaboraBaseURL(checkName, label, raw string, optional bool, add func(string, string, string)) bool {
+	raw = strings.TrimRight(strings.TrimSpace(raw), "/")
+	if raw == "" {
+		if optional {
+			add(checkName, "warning", label+" is empty. It will not be used for WOPI callbacks.")
+		} else {
+			add(checkName, "warning", label+" is empty. External/public access will only work if another WOPI URL matches the request.")
+		}
+		return false
 	}
 
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		add(checkName, "error", label+" must be a valid absolute URL.")
+		return false
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		add(checkName, "error", label+" must use http or https.")
+		return false
+	}
+
+	add(checkName, "success", label+" format is valid: "+raw)
+	return true
+}
+
+func probeCollaboraWOPIURL(ctx context.Context, label, raw string, add func(string, string, string)) {
+	raw = strings.TrimRight(strings.TrimSpace(raw), "/")
+	if raw == "" {
+		return
+	}
+
+	wopiProbeURL := raw + "/wopi/files/__collabora_test__?access_token=invalid"
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	probeReq, err := http.NewRequestWithContext(ctx, http.MethodGet, wopiProbeURL, nil)
+	if err != nil {
+		add("wopi_"+label+"_url", "error", "Could not build "+label+" WOPI probe request: "+err.Error())
+		return
+	}
+
+	probeRes, err := http.DefaultClient.Do(probeReq)
+	if err != nil {
+		add("wopi_"+label+"_url", "warning", collaboraLabel(label)+" File Browser URL was not reachable from this server: "+err.Error()+". Collabora must be able to reach this URL when this URL is selected.")
+		return
+	}
+	defer probeRes.Body.Close()
+
+	if probeRes.StatusCode == http.StatusUnauthorized || probeRes.StatusCode == http.StatusNotFound {
+		add("wopi_"+label+"_url", "success", collaboraLabel(label)+" File Browser URL reached the WOPI endpoint. Add this URL to Collabora aliasgroup/allowed WOPI hosts: "+raw)
+		return
+	}
+
+	add("wopi_"+label+"_url", "warning", fmt.Sprintf("%s File Browser URL responded with HTTP %d during WOPI probe. Collabora may still fail if the matching aliasgroup/allowed WOPI host is not set to %s.", collaboraLabel(label), probeRes.StatusCode, raw))
+}
+
+func collaboraLabel(label string) string {
+	if label == "" {
+		return label
+	}
+	return strings.ToUpper(label[:1]) + label[1:]
+}
+
+func selectCollaboraWOPIBaseURL(cfg settings.Collabora, r *http.Request, d *data) string {
+	externalURL := strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/")
+	internalURL := strings.TrimRight(strings.TrimSpace(cfg.InternalURL), "/")
+	currentURL := currentFileBrowserURL(d, r)
+
+	if internalURL != "" && sameURLOrigin(currentURL, internalURL) {
+		return internalURL
+	}
+	if externalURL != "" && sameURLOrigin(currentURL, externalURL) {
+		return externalURL
+	}
+	if internalURL != "" && requestLooksInternal(currentURL) {
+		return internalURL
+	}
+	if externalURL != "" {
+		return externalURL
+	}
+	if internalURL != "" {
+		return internalURL
+	}
+	return currentURL
+}
+
+func currentFileBrowserURL(d *data, r *http.Request) string {
 	scheme := r.Header.Get("X-Forwarded-Proto")
 	if scheme == "" {
 		if r.TLS != nil {
@@ -350,6 +418,57 @@ func collaboraPublicURL(d *data, r *http.Request) string {
 	}
 
 	return strings.TrimRight(scheme+"://"+host+d.server.BaseURL, "/")
+}
+
+func sameURLOrigin(left, right string) bool {
+	l, err := url.Parse(strings.TrimSpace(left))
+	if err != nil || l.Scheme == "" || l.Host == "" {
+		return false
+	}
+	r, err := url.Parse(strings.TrimSpace(right))
+	if err != nil || r.Scheme == "" || r.Host == "" {
+		return false
+	}
+	return strings.EqualFold(l.Scheme, r.Scheme) && strings.EqualFold(normalizedHostPort(l), normalizedHostPort(r))
+}
+
+func normalizedHostPort(u *url.URL) string {
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if port == "" {
+		switch u.Scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		}
+	}
+	if port == "" {
+		return host
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func requestLooksInternal(rawURL string) bool {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || u.Host == "" {
+		return false
+	}
+
+	host := strings.ToLower(u.Hostname())
+	if host == "localhost" {
+		return true
+	}
+	if strings.HasSuffix(host, ".local") || strings.HasSuffix(host, ".home") || strings.HasSuffix(host, ".lan") || strings.HasSuffix(host, ".internal") {
+		return true
+	}
+
+	addr, err := netip.ParseAddr(host)
+	if err == nil {
+		return addr.IsLoopback() || addr.IsPrivate() || addr.IsLinkLocalUnicast()
+	}
+
+	return false
 }
 
 func collaboraActionForExt(ctx context.Context, collaboraURL, ext string, canWrite bool) (collaboraDiscoveryAction, error) {

--- a/http/collabora.go
+++ b/http/collabora.go
@@ -1,0 +1,442 @@
+package fbhttp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	gopath "path"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/filebrowser/filebrowser/v2/settings"
+)
+
+const defaultCollaboraTokenTTL = 2 * time.Hour
+
+var collaboraPlaceholder = regexp.MustCompile(`<[^>]+>`)
+
+var collaboraOfficeExtensions = map[string]struct{}{
+	"doc": {}, "docx": {}, "docm": {}, "dot": {}, "dotx": {}, "odt": {}, "ott": {}, "rtf": {},
+	"xls": {}, "xlsx": {}, "xlsm": {}, "xlt": {}, "xltx": {}, "ods": {}, "ots": {}, "csv": {},
+	"ppt": {}, "pptx": {}, "pptm": {}, "pot": {}, "potx": {}, "odp": {}, "otp": {},
+	"vsd": {}, "vsdx": {}, "odg": {}, "pdf": {},
+}
+
+type collaboraOpenResponse struct {
+	URL      string `json:"url"`
+	FileID   string `json:"fileID"`
+	CanWrite bool   `json:"canWrite"`
+	Name     string `json:"name"`
+}
+
+type collaboraTestRequest struct {
+	Collabora settings.Collabora `json:"collabora"`
+}
+
+type collaboraTestResponse struct {
+	OK     bool                 `json:"ok"`
+	Checks []collaboraTestCheck `json:"checks"`
+}
+
+type collaboraTestCheck struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+type collaboraDiscovery struct {
+	Apps []collaboraDiscoveryApp `xml:"net-zone>app"`
+}
+
+type collaboraDiscoveryApp struct {
+	Name    string                     `xml:"name,attr"`
+	Actions []collaboraDiscoveryAction `xml:"action"`
+}
+
+type collaboraDiscoveryAction struct {
+	Ext      string `xml:"ext,attr"`
+	Name     string `xml:"name,attr"`
+	URLSrc   string `xml:"urlsrc,attr"`
+	Requires string `xml:"requires,attr"`
+}
+
+type wopiTokenClaims struct {
+	UserID   uint   `json:"uid"`
+	Path     string `json:"path"`
+	FileID   string `json:"fid"`
+	CanWrite bool   `json:"can_write"`
+	jwt.RegisteredClaims
+}
+
+var collaboraTestHandler = withAdmin(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	req := &collaboraTestRequest{}
+	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	cfg := req.Collabora
+	cfg.URL = strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
+	cfg.PublicURL = strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/")
+	cfg.WOPISecret = strings.TrimSpace(cfg.WOPISecret)
+	cfg.TokenTTL = strings.TrimSpace(cfg.TokenTTL)
+	if cfg.TokenTTL == "" {
+		cfg.TokenTTL = "2h"
+	}
+
+	checks := make([]collaboraTestCheck, 0, 8)
+	add := func(name, status, message string) {
+		checks = append(checks, collaboraTestCheck{Name: name, Status: status, Message: message})
+	}
+
+	if !cfg.Enabled {
+		add("enabled", "warning", "Collabora integration is disabled. Enable it before testing document editing.")
+	} else {
+		add("enabled", "success", "Collabora integration is enabled.")
+	}
+
+	collaboraURL, err := url.Parse(cfg.URL)
+	if cfg.URL == "" || err != nil || collaboraURL.Scheme == "" || collaboraURL.Host == "" {
+		add("collabora_url", "error", "Collabora URL must be a valid absolute URL, for example http://192.168.68.135:9980.")
+		return renderCollaboraTest(w, r, checks), nil
+	}
+	if collaboraURL.Scheme != "http" && collaboraURL.Scheme != "https" {
+		add("collabora_url", "error", "Collabora URL must use http or https.")
+		return renderCollaboraTest(w, r, checks), nil
+	}
+	add("collabora_url", "success", "Collabora URL format is valid: "+cfg.URL)
+
+	publicURL, err := url.Parse(cfg.PublicURL)
+	if cfg.PublicURL == "" || err != nil || publicURL.Scheme == "" || publicURL.Host == "" {
+		add("public_url", "error", "Public File Browser URL must be set and must be an absolute URL reachable by the Collabora server.")
+		return renderCollaboraTest(w, r, checks), nil
+	}
+	if publicURL.Scheme != "http" && publicURL.Scheme != "https" {
+		add("public_url", "error", "Public File Browser URL must use http or https.")
+		return renderCollaboraTest(w, r, checks), nil
+	}
+	add("public_url", "success", "Public File Browser URL format is valid: "+cfg.PublicURL)
+
+	if strings.TrimSpace(cfg.WOPISecret) == "" {
+		add("wopi_secret", "warning", "WOPI token secret is empty. File Browser will fall back to the instance key, but a dedicated long random secret is recommended.")
+	} else if len(cfg.WOPISecret) < 32 {
+		add("wopi_secret", "warning", "WOPI token secret is set but short. Use a long random value, for example openssl rand -hex 32.")
+	} else {
+		add("wopi_secret", "success", "WOPI token secret is set.")
+	}
+
+	if _, err := time.ParseDuration(cfg.TokenTTL); err != nil {
+		add("token_ttl", "error", "WOPI token lifetime is invalid. Use a Go duration such as 2h, 30m, or 1h30m.")
+	} else {
+		add("token_ttl", "success", "WOPI token lifetime is valid: "+cfg.TokenTTL)
+	}
+
+	discovery, err := fetchCollaboraDiscovery(r.Context(), cfg.URL)
+	if err != nil {
+		add("discovery", "error", err.Error())
+		return renderCollaboraTest(w, r, checks), nil
+	}
+	add("discovery", "success", "Collabora /hosting/discovery is reachable and returned valid XML.")
+
+	required := []string{"docx", "xlsx", "pptx"}
+	missing := make([]string, 0)
+	for _, ext := range required {
+		if !collaboraDiscoveryHasAction(discovery, ext) {
+			missing = append(missing, ext)
+		}
+	}
+	if len(missing) > 0 {
+		add("office_actions", "error", "Missing Collabora edit/view actions for: "+strings.Join(missing, ", "))
+	} else {
+		add("office_actions", "success", "Collabora discovery contains actions for docx, xlsx, and pptx.")
+	}
+
+	if action, ok := firstCollaboraDiscoveryAction(discovery); ok {
+		if actionURL, err := url.Parse(action.URLSrc); err == nil && actionURL.Scheme != "" && actionURL.Host != "" {
+			if actionURL.Scheme != collaboraURL.Scheme {
+				add("editor_url_scheme", "warning", "Discovery advertises editor URLs with "+actionURL.Scheme+" but the configured Collabora URL uses "+collaboraURL.Scheme+". If the browser shows 'invalid response', fix Collabora ssl.enable/ssl.termination/server_name.")
+			} else {
+				add("editor_url_scheme", "success", "Discovery editor URL scheme matches the configured Collabora URL.")
+			}
+		}
+	}
+
+	wopiProbeURL := strings.TrimRight(cfg.PublicURL, "/") + "/wopi/files/__collabora_test__?access_token=invalid"
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	probeReq, err := http.NewRequestWithContext(ctx, http.MethodGet, wopiProbeURL, nil)
+	if err != nil {
+		add("wopi_public_url", "error", "Could not build WOPI probe request: "+err.Error())
+	} else {
+		probeRes, err := http.DefaultClient.Do(probeReq)
+		if err != nil {
+			add("wopi_public_url", "warning", "Public File Browser URL was not reachable from this server: "+err.Error()+". Collabora must be able to reach this URL.")
+		} else {
+			defer probeRes.Body.Close()
+			if probeRes.StatusCode == http.StatusUnauthorized || probeRes.StatusCode == http.StatusNotFound {
+				add("wopi_public_url", "success", "Public File Browser URL reached the WOPI endpoint. Collabora should use this as aliasgroup1/allowed WOPI host.")
+			} else {
+				add("wopi_public_url", "warning", fmt.Sprintf("Public File Browser URL responded with HTTP %d during WOPI probe. Collabora may still fail if aliasgroup1/allowed WOPI host is not set to %s.", probeRes.StatusCode, cfg.PublicURL))
+			}
+		}
+	}
+
+	return renderCollaboraTest(w, r, checks), nil
+})
+
+func renderCollaboraTest(w http.ResponseWriter, r *http.Request, checks []collaboraTestCheck) int {
+	ok := true
+	for _, check := range checks {
+		if check.Status != "success" {
+			ok = false
+			break
+		}
+	}
+	_, _ = renderJSON(w, r, collaboraTestResponse{OK: ok, Checks: checks})
+	return 0
+}
+
+func collaboraDiscoveryHasAction(discovery *collaboraDiscovery, ext string) bool {
+	for _, app := range discovery.Apps {
+		for _, action := range app.Actions {
+			if strings.EqualFold(action.Ext, ext) && action.URLSrc != "" && (strings.EqualFold(action.Name, "edit") || strings.EqualFold(action.Name, "view")) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func firstCollaboraDiscoveryAction(discovery *collaboraDiscovery) (collaboraDiscoveryAction, bool) {
+	for _, app := range discovery.Apps {
+		for _, action := range app.Actions {
+			if action.URLSrc != "" {
+				return action, true
+			}
+		}
+	}
+	return collaboraDiscoveryAction{}, false
+}
+
+var collaboraOpenHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	cfg := d.collaboraConfig()
+	if !cfg.Enabled || strings.TrimSpace(cfg.URL) == "" {
+		return http.StatusNotFound, errors.New("collabora integration is disabled")
+	}
+
+	if !d.user.Perm.Download {
+		return http.StatusForbidden, nil
+	}
+
+	filePath := gopath.Clean("/" + strings.TrimPrefix(r.URL.Query().Get("path"), "/"))
+	if filePath == "/" || !d.Check(filePath) {
+		return http.StatusForbidden, nil
+	}
+
+	info, err := d.user.Fs.Stat(filePath)
+	if err != nil {
+		return errToStatus(err), err
+	}
+	if info.IsDir() {
+		return http.StatusBadRequest, errors.New("collabora can only open files")
+	}
+
+	ext := strings.TrimPrefix(strings.ToLower(gopath.Ext(filePath)), ".")
+	if !isCollaboraOfficeExtension(ext) {
+		return http.StatusBadRequest, fmt.Errorf("unsupported office extension: %s", ext)
+	}
+
+	canWrite := d.user.Perm.Modify
+	fileID := wopiFileID(d.user.ID, filePath)
+	ttl := collaboraTokenTTL(cfg.TokenTTL)
+	token, expiresAt, err := createWOPIToken(d, d.user.ID, filePath, fileID, canWrite, ttl)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	publicURL := collaboraPublicURL(d, r)
+	wopiSrc := strings.TrimRight(publicURL, "/") + "/wopi/files/" + url.PathEscape(fileID)
+
+	action, err := collaboraActionForExt(r.Context(), cfg.URL, ext, canWrite)
+	if err != nil {
+		return http.StatusBadGateway, err
+	}
+
+	editorURL := buildCollaboraActionURL(action.URLSrc, wopiSrc, token, expiresAt, canWrite)
+	return renderJSON(w, r, collaboraOpenResponse{
+		URL:      editorURL,
+		FileID:   fileID,
+		CanWrite: canWrite,
+		Name:     info.Name(),
+	})
+})
+
+func isCollaboraOfficeExtension(ext string) bool {
+	_, ok := collaboraOfficeExtensions[strings.TrimPrefix(strings.ToLower(ext), ".")]
+	return ok
+}
+
+func collaboraTokenTTL(raw string) time.Duration {
+	if strings.TrimSpace(raw) == "" {
+		return defaultCollaboraTokenTTL
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return defaultCollaboraTokenTTL
+	}
+	return d
+}
+
+func createWOPIToken(d *data, userID uint, filePath, fileID string, canWrite bool, ttl time.Duration) (string, time.Time, error) {
+	now := time.Now().UTC()
+	expiresAt := now.Add(ttl)
+	claims := wopiTokenClaims{
+		UserID:   userID,
+		Path:     filePath,
+		FileID:   fileID,
+		CanWrite: canWrite,
+		RegisteredClaims: jwt.RegisteredClaims{
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			Subject:   fmt.Sprintf("%d:%s", userID, filePath),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString(wopiSigningKey(d))
+	return signed, expiresAt, err
+}
+
+func wopiSigningKey(d *data) []byte {
+	cfg := d.collaboraConfig()
+	if strings.TrimSpace(cfg.WOPISecret) != "" {
+		return []byte(cfg.WOPISecret)
+	}
+	return d.settings.Key
+}
+
+func wopiFileID(userID uint, filePath string) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%d:%s", userID, gopath.Clean("/"+strings.TrimPrefix(filePath, "/")))))
+	return hex.EncodeToString(sum[:])
+}
+
+func collaboraPublicURL(d *data, r *http.Request) string {
+	cfg := d.collaboraConfig()
+	if strings.TrimSpace(cfg.PublicURL) != "" {
+		return strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/")
+	}
+
+	scheme := r.Header.Get("X-Forwarded-Proto")
+	if scheme == "" {
+		if r.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Host
+	}
+
+	return strings.TrimRight(scheme+"://"+host+d.server.BaseURL, "/")
+}
+
+func collaboraActionForExt(ctx context.Context, collaboraURL, ext string, canWrite bool) (collaboraDiscoveryAction, error) {
+	discovery, err := fetchCollaboraDiscovery(ctx, collaboraURL)
+	if err != nil {
+		return collaboraDiscoveryAction{}, err
+	}
+
+	wanted := []string{"view"}
+	if canWrite {
+		wanted = []string{"edit", "view"}
+	}
+
+	for _, actionName := range wanted {
+		for _, app := range discovery.Apps {
+			for _, action := range app.Actions {
+				if strings.EqualFold(action.Ext, ext) && strings.EqualFold(action.Name, actionName) && action.URLSrc != "" {
+					return action, nil
+				}
+			}
+		}
+	}
+
+	available := make([]string, 0)
+	for _, app := range discovery.Apps {
+		for _, action := range app.Actions {
+			if action.Ext != "" {
+				available = append(available, action.Ext+":"+action.Name)
+			}
+		}
+	}
+	sort.Strings(available)
+	return collaboraDiscoveryAction{}, fmt.Errorf("no Collabora action found for extension %q; available actions include: %s", ext, strings.Join(available, ", "))
+}
+
+func fetchCollaboraDiscovery(ctx context.Context, collaboraURL string) (*collaboraDiscovery, error) {
+	base := strings.TrimRight(strings.TrimSpace(collaboraURL), "/")
+	if base == "" {
+		return nil, errors.New("empty collabora.url")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/hosting/discovery", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Collabora discovery: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		return nil, fmt.Errorf("Collabora discovery returned HTTP %d", res.StatusCode)
+	}
+
+	var discovery collaboraDiscovery
+	if err := xml.NewDecoder(res.Body).Decode(&discovery); err != nil {
+		return nil, fmt.Errorf("failed to parse Collabora discovery XML: %w", err)
+	}
+	return &discovery, nil
+}
+
+func buildCollaboraActionURL(urlsrc, wopiSrc, token string, expiresAt time.Time, canWrite bool) string {
+	cleaned := collaboraPlaceholder.ReplaceAllString(urlsrc, "")
+	separator := "?"
+	if strings.Contains(cleaned, "?") {
+		if strings.HasSuffix(cleaned, "?") || strings.HasSuffix(cleaned, "&") {
+			separator = ""
+		} else {
+			separator = "&"
+		}
+	}
+
+	permission := "view"
+	if canWrite {
+		permission = "edit"
+	}
+
+	values := url.Values{}
+	values.Set("WOPISrc", wopiSrc)
+	values.Set("access_token", token)
+	values.Set("access_token_ttl", fmt.Sprintf("%d", expiresAt.UnixMilli()))
+	values.Set("permission", permission)
+
+	return cleaned + separator + values.Encode()
+}

--- a/http/collabora_config.go
+++ b/http/collabora_config.go
@@ -11,18 +11,20 @@ func effectiveCollabora(server *settings.Server, set *settings.Settings) setting
 		cfg := set.Collabora
 		cfg.URL = strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
 		cfg.PublicURL = strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/")
+		cfg.InternalURL = strings.TrimRight(strings.TrimSpace(cfg.InternalURL), "/")
 		cfg.WOPISecret = strings.TrimSpace(cfg.WOPISecret)
 		cfg.TokenTTL = strings.TrimSpace(cfg.TokenTTL)
 		return cfg
 	}
 
 	cfg := settings.Collabora{
-		Configured: true,
-		Enabled:    server.CollaboraEnabled,
-		URL:        strings.TrimRight(strings.TrimSpace(server.CollaboraURL), "/"),
-		PublicURL:  strings.TrimRight(strings.TrimSpace(server.CollaboraPublicURL), "/"),
-		WOPISecret: strings.TrimSpace(server.CollaboraWOPISecret),
-		TokenTTL:   strings.TrimSpace(server.CollaboraTokenTTL),
+		Configured:  true,
+		Enabled:     server.CollaboraEnabled,
+		URL:         strings.TrimRight(strings.TrimSpace(server.CollaboraURL), "/"),
+		PublicURL:   strings.TrimRight(strings.TrimSpace(server.CollaboraPublicURL), "/"),
+		InternalURL: strings.TrimRight(strings.TrimSpace(server.CollaboraInternalURL), "/"),
+		WOPISecret:  strings.TrimSpace(server.CollaboraWOPISecret),
+		TokenTTL:    strings.TrimSpace(server.CollaboraTokenTTL),
 	}
 	if cfg.TokenTTL == "" {
 		cfg.TokenTTL = "2h"

--- a/http/collabora_config.go
+++ b/http/collabora_config.go
@@ -1,0 +1,35 @@
+package fbhttp
+
+import (
+	"strings"
+
+	"github.com/filebrowser/filebrowser/v2/settings"
+)
+
+func effectiveCollabora(server *settings.Server, set *settings.Settings) settings.Collabora {
+	if set != nil && set.Collabora.Configured {
+		cfg := set.Collabora
+		cfg.URL = strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
+		cfg.PublicURL = strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/")
+		cfg.WOPISecret = strings.TrimSpace(cfg.WOPISecret)
+		cfg.TokenTTL = strings.TrimSpace(cfg.TokenTTL)
+		return cfg
+	}
+
+	cfg := settings.Collabora{
+		Configured: true,
+		Enabled:    server.CollaboraEnabled,
+		URL:        strings.TrimRight(strings.TrimSpace(server.CollaboraURL), "/"),
+		PublicURL:  strings.TrimRight(strings.TrimSpace(server.CollaboraPublicURL), "/"),
+		WOPISecret: strings.TrimSpace(server.CollaboraWOPISecret),
+		TokenTTL:   strings.TrimSpace(server.CollaboraTokenTTL),
+	}
+	if cfg.TokenTTL == "" {
+		cfg.TokenTTL = "2h"
+	}
+	return cfg
+}
+
+func (d *data) collaboraConfig() settings.Collabora {
+	return effectiveCollabora(d.server, d.settings)
+}

--- a/http/csp.go
+++ b/http/csp.go
@@ -1,0 +1,42 @@
+package fbhttp
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/filebrowser/filebrowser/v2/settings"
+)
+
+func contentSecurityPolicy(cfg settings.Collabora) string {
+	if !cfg.Enabled || strings.TrimSpace(cfg.URL) == "" {
+		return `default-src 'self'; style-src 'unsafe-inline';`
+	}
+
+	origins := collaboraCSPOrigins(cfg.URL)
+	parts := []string{
+		"default-src 'self'",
+		"style-src 'self' 'unsafe-inline'",
+		"script-src 'self'",
+		"img-src 'self' data: blob:",
+		"font-src 'self' data:",
+		"frame-src 'self' " + strings.Join(origins, " "),
+		"connect-src 'self' " + strings.Join(origins, " "),
+	}
+
+	return strings.Join(parts, "; ") + ";"
+}
+
+func collaboraCSPOrigins(raw string) []string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return []string{}
+	}
+
+	origin := u.Scheme + "://" + u.Host
+	wsScheme := "ws"
+	if u.Scheme == "https" {
+		wsScheme = "wss"
+	}
+
+	return []string{origin, wsScheme + "://" + u.Host}
+}

--- a/http/http.go
+++ b/http/http.go
@@ -29,7 +29,12 @@ func NewHandler(
 	r := mux.NewRouter()
 	r.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Security-Policy", `default-src 'self'; style-src 'unsafe-inline';`)
+			set, err := store.Settings.Get()
+			if err == nil {
+				w.Header().Set("Content-Security-Policy", contentSecurityPolicy(effectiveCollabora(server, set)))
+			} else {
+				w.Header().Set("Content-Security-Policy", contentSecurityPolicy(effectiveCollabora(server, nil)))
+			}
 			next.ServeHTTP(w, r)
 		})
 	})
@@ -85,6 +90,11 @@ func NewHandler(
 	api.PathPrefix("/command").Handler(monkey(commandsHandler, "/api/command")).Methods("GET")
 	api.PathPrefix("/search").Handler(monkey(searchHandler, "/api/search")).Methods("GET")
 	api.PathPrefix("/subtitle").Handler(monkey(subtitleHandler, "/api/subtitle")).Methods("GET")
+
+	api.Handle("/collabora/open", monkey(collaboraOpenHandler, "")).Methods("GET")
+	api.Handle("/collabora/test", monkey(collaboraTestHandler, "")).Methods("POST")
+	r.Handle("/wopi/files/{id}", monkey(wopiFileHandler, "")).Methods("GET", "POST")
+	r.Handle("/wopi/files/{id}/contents", monkey(wopiFileContentsHandler, "")).Methods("GET", "POST")
 
 	public := api.PathPrefix("/public").Subrouter()
 	public.PathPrefix("/dl").Handler(monkey(publicDlHandler, "/api/public/dl/")).Methods("GET")

--- a/http/settings.go
+++ b/http/settings.go
@@ -19,6 +19,7 @@ type settingsData struct {
 	Rules                 []rules.Rule          `json:"rules"`
 	Branding              settings.Branding     `json:"branding"`
 	Tus                   settings.Tus          `json:"tus"`
+	Collabora             settings.Collabora    `json:"collabora"`
 	Shell                 []string              `json:"shell"`
 	Commands              map[string][]string   `json:"commands"`
 }
@@ -35,6 +36,7 @@ var settingsGetHandler = withAdmin(func(w http.ResponseWriter, r *http.Request, 
 		Rules:                 d.settings.Rules,
 		Branding:              d.settings.Branding,
 		Tus:                   d.settings.Tus,
+		Collabora:             d.collaboraConfig(),
 		Shell:                 d.settings.Shell,
 		Commands:              d.settings.Commands,
 	}
@@ -57,6 +59,8 @@ var settingsPutHandler = withAdmin(func(_ http.ResponseWriter, r *http.Request, 
 	d.settings.Rules = req.Rules
 	d.settings.Branding = req.Branding
 	d.settings.Tus = req.Tus
+	req.Collabora.Configured = true
+	d.settings.Collabora = req.Collabora
 	d.settings.Shell = req.Shell
 	d.settings.Commands = req.Commands
 	d.settings.HideLoginButton = req.HideLoginButton

--- a/http/static.go
+++ b/http/static.go
@@ -50,6 +50,7 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, fSys 
 		"EnableExec":            d.server.EnableExec,
 		"TusSettings":           d.settings.Tus,
 		"HideLoginButton":       d.settings.HideLoginButton,
+		"CollaboraEnabled":      d.collaboraConfig().Enabled && d.collaboraConfig().URL != "",
 	}
 
 	if d.settings.Branding.Files != "" {

--- a/http/wopi.go
+++ b/http/wopi.go
@@ -1,0 +1,348 @@
+package fbhttp
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	gopath "path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/mux"
+)
+
+type wopiFileContext struct {
+	Claims wopiTokenClaims
+	Info   fileInfoStat
+}
+
+type fileInfoStat interface {
+	Name() string
+	Size() int64
+	ModTime() time.Time
+	IsDir() bool
+}
+
+type wopiCheckFileInfo struct {
+	BaseFileName         string `json:"BaseFileName"`
+	OwnerID              string `json:"OwnerId"`
+	Size                 int64  `json:"Size"`
+	UserID               string `json:"UserId"`
+	UserFriendlyName     string `json:"UserFriendlyName"`
+	UserCanWrite         bool   `json:"UserCanWrite"`
+	ReadOnly             bool   `json:"ReadOnly"`
+	SupportsLocks        bool   `json:"SupportsLocks"`
+	SupportsGetLock      bool   `json:"SupportsGetLock"`
+	SupportsUpdate       bool   `json:"SupportsUpdate"`
+	LastModifiedTime     string `json:"LastModifiedTime"`
+	Version              string `json:"Version"`
+	BreadcrumbBrandName  string `json:"BreadcrumbBrandName"`
+	BreadcrumbBrandURL   string `json:"BreadcrumbBrandUrl,omitempty"`
+	BreadcrumbFolderName string `json:"BreadcrumbFolderName,omitempty"`
+}
+
+type wopiLock struct {
+	Value     string
+	ExpiresAt time.Time
+}
+
+var wopiLockStore = struct {
+	sync.Mutex
+	locks map[string]wopiLock
+}{locks: map[string]wopiLock{}}
+
+var wopiFileHandler = func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	ctx, status, err := loadWOPIFile(r, d)
+	if status != 0 || err != nil {
+		return status, err
+	}
+
+	if r.Method == http.MethodGet {
+		return wopiCheckFileInfoHandler(w, r, d, ctx)
+	}
+
+	switch strings.ToUpper(r.Header.Get("X-WOPI-Override")) {
+	case "LOCK":
+		if r.Header.Get("X-WOPI-OldLock") != "" {
+			return wopiUnlockAndRelock(w, r, ctx.Claims.FileID)
+		}
+		return wopiLockFile(w, r, ctx.Claims.FileID)
+	case "UNLOCK":
+		return wopiUnlockFile(w, r, ctx.Claims.FileID)
+	case "REFRESH_LOCK":
+		return wopiRefreshLock(w, r, ctx.Claims.FileID)
+	case "GET_LOCK":
+		return wopiGetLock(w, ctx.Claims.FileID)
+	default:
+		return http.StatusNotImplemented, nil
+	}
+}
+
+var wopiFileContentsHandler = func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	ctx, status, err := loadWOPIFile(r, d)
+	if status != 0 || err != nil {
+		return status, err
+	}
+
+	if r.Method == http.MethodGet {
+		return wopiGetFile(w, r, d, ctx)
+	}
+
+	if strings.ToUpper(r.Header.Get("X-WOPI-Override")) != "PUT" {
+		return http.StatusNotImplemented, nil
+	}
+	return wopiPutFile(w, r, d, ctx)
+}
+
+func loadWOPIFile(r *http.Request, d *data) (*wopiFileContext, int, error) {
+	cfg := d.collaboraConfig()
+	if !cfg.Enabled {
+		return nil, http.StatusNotFound, errors.New("collabora integration is disabled")
+	}
+
+	tokenString := r.URL.Query().Get("access_token")
+	if tokenString == "" {
+		return nil, http.StatusUnauthorized, errors.New("missing WOPI access_token")
+	}
+
+	claims := wopiTokenClaims{}
+	parser := jwt.NewParser(jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}), jwt.WithExpirationRequired())
+	token, err := parser.ParseWithClaims(tokenString, &claims, func(_ *jwt.Token) (interface{}, error) {
+		return wopiSigningKey(d), nil
+	})
+	if err != nil || !token.Valid {
+		return nil, http.StatusUnauthorized, err
+	}
+
+	if claims.UserID == 0 || claims.Path == "" || claims.FileID == "" {
+		return nil, http.StatusUnauthorized, errors.New("invalid WOPI token claims")
+	}
+
+	fileID := mux.Vars(r)["id"]
+	if fileID == "" || fileID != claims.FileID || fileID != wopiFileID(claims.UserID, claims.Path) {
+		return nil, http.StatusUnauthorized, errors.New("WOPI token does not match requested file")
+	}
+
+	user, err := d.store.Users.Get(d.server.Root, claims.UserID)
+	if err != nil {
+		return nil, errToStatus(err), err
+	}
+	d.user = user
+
+	claims.Path = gopath.Clean("/" + strings.TrimPrefix(claims.Path, "/"))
+	if claims.Path == "/" || !d.Check(claims.Path) || !d.user.Perm.Download {
+		return nil, http.StatusNotFound, nil
+	}
+
+	info, err := d.user.Fs.Stat(claims.Path)
+	if err != nil {
+		return nil, errToStatus(err), err
+	}
+	if info.IsDir() {
+		return nil, http.StatusNotFound, nil
+	}
+
+	return &wopiFileContext{Claims: claims, Info: info}, 0, nil
+}
+
+func wopiCheckFileInfoHandler(w http.ResponseWriter, r *http.Request, d *data, ctx *wopiFileContext) (int, error) {
+	canWrite := ctx.Claims.CanWrite && d.user.Perm.Modify
+	folder := gopath.Base(gopath.Dir(ctx.Claims.Path))
+	if folder == "." || folder == "/" {
+		folder = "Files"
+	}
+
+	info := wopiCheckFileInfo{
+		BaseFileName:         ctx.Info.Name(),
+		OwnerID:              strconv.FormatUint(uint64(ctx.Claims.UserID), 10),
+		Size:                 ctx.Info.Size(),
+		UserID:               strconv.FormatUint(uint64(ctx.Claims.UserID), 10),
+		UserFriendlyName:     d.user.Username,
+		UserCanWrite:         canWrite,
+		ReadOnly:             !canWrite,
+		SupportsLocks:        canWrite,
+		SupportsGetLock:      true,
+		SupportsUpdate:       canWrite,
+		LastModifiedTime:     ctx.Info.ModTime().UTC().Format(time.RFC3339),
+		Version:              wopiVersion(ctx.Info),
+		BreadcrumbBrandName:  "File Browser",
+		BreadcrumbBrandURL:   strings.TrimRight(collaboraPublicURL(d, r), "/"),
+		BreadcrumbFolderName: folder,
+	}
+	return renderJSON(w, r, info)
+}
+
+func wopiGetFile(w http.ResponseWriter, _ *http.Request, d *data, ctx *wopiFileContext) (int, error) {
+	fd, err := d.user.Fs.Open(ctx.Claims.Path)
+	if err != nil {
+		return errToStatus(err), err
+	}
+	defer fd.Close()
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.PathEscape(ctx.Info.Name()))
+	w.Header().Set("X-WOPI-ItemVersion", wopiVersion(ctx.Info))
+	_, err = io.Copy(w, fd)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	return 0, nil
+}
+
+func wopiPutFile(w http.ResponseWriter, r *http.Request, d *data, ctx *wopiFileContext) (int, error) {
+	if !ctx.Claims.CanWrite || !d.user.Perm.Modify {
+		return http.StatusForbidden, nil
+	}
+
+	requestedLock := r.Header.Get("X-WOPI-Lock")
+	currentLock, locked := wopiCurrentLock(ctx.Claims.FileID)
+	if locked {
+		if requestedLock == "" || requestedLock != currentLock {
+			return wopiLockMismatch(w, currentLock, "lock mismatch")
+		}
+	} else if ctx.Info.Size() != 0 {
+		return wopiLockMismatch(w, "", "file is not locked")
+	}
+
+	err := d.RunHook(func() error {
+		_, writeErr := writeFile(d.user.Fs, ctx.Claims.Path, r.Body, d.settings.FileMode, d.settings.DirMode)
+		return writeErr
+	}, "save", ctx.Claims.Path, "", d.user)
+	if err != nil {
+		return errToStatus(err), err
+	}
+
+	info, err := d.user.Fs.Stat(ctx.Claims.Path)
+	if err == nil {
+		w.Header().Set("X-WOPI-ItemVersion", wopiVersion(info))
+	}
+	return 0, nil
+}
+
+func wopiLockFile(w http.ResponseWriter, r *http.Request, fileID string) (int, error) {
+	requestedLock := r.Header.Get("X-WOPI-Lock")
+	if requestedLock == "" {
+		return http.StatusBadRequest, errors.New("missing X-WOPI-Lock")
+	}
+
+	currentLock, locked := wopiCurrentLock(fileID)
+	if locked && currentLock != requestedLock {
+		return wopiLockMismatch(w, currentLock, "lock mismatch")
+	}
+
+	ttl, status, err := wopiLockTTL(r)
+	if status != 0 || err != nil {
+		return status, err
+	}
+	wopiSetLock(fileID, requestedLock, ttl)
+	return 0, nil
+}
+
+func wopiUnlockFile(w http.ResponseWriter, r *http.Request, fileID string) (int, error) {
+	requestedLock := r.Header.Get("X-WOPI-Lock")
+	currentLock, locked := wopiCurrentLock(fileID)
+	if !locked || currentLock != requestedLock {
+		return wopiLockMismatch(w, currentLock, "lock mismatch")
+	}
+	wopiClearLock(fileID)
+	return 0, nil
+}
+
+func wopiRefreshLock(w http.ResponseWriter, r *http.Request, fileID string) (int, error) {
+	requestedLock := r.Header.Get("X-WOPI-Lock")
+	currentLock, locked := wopiCurrentLock(fileID)
+	if !locked || currentLock != requestedLock {
+		return wopiLockMismatch(w, currentLock, "lock mismatch")
+	}
+
+	ttl, status, err := wopiLockTTL(r)
+	if status != 0 || err != nil {
+		return status, err
+	}
+	wopiSetLock(fileID, requestedLock, ttl)
+	return 0, nil
+}
+
+func wopiUnlockAndRelock(w http.ResponseWriter, r *http.Request, fileID string) (int, error) {
+	oldLock := r.Header.Get("X-WOPI-OldLock")
+	newLock := r.Header.Get("X-WOPI-Lock")
+	if newLock == "" {
+		return http.StatusBadRequest, errors.New("missing X-WOPI-Lock")
+	}
+
+	currentLock, locked := wopiCurrentLock(fileID)
+	if !locked || currentLock != oldLock {
+		return wopiLockMismatch(w, currentLock, "lock mismatch")
+	}
+
+	ttl, status, err := wopiLockTTL(r)
+	if status != 0 || err != nil {
+		return status, err
+	}
+	wopiSetLock(fileID, newLock, ttl)
+	return 0, nil
+}
+
+func wopiGetLock(w http.ResponseWriter, fileID string) (int, error) {
+	currentLock, _ := wopiCurrentLock(fileID)
+	w.Header().Set("X-WOPI-Lock", currentLock)
+	return 0, nil
+}
+
+func wopiLockTTL(r *http.Request) (time.Duration, int, error) {
+	raw := strings.TrimSpace(r.Header.Get("X-WOPI-LockExpirationTimeout"))
+	if raw == "" {
+		return 30 * time.Minute, 0, nil
+	}
+	seconds, err := strconv.Atoi(raw)
+	if err != nil || seconds < 60 || seconds > 3600 {
+		return 0, http.StatusBadRequest, errors.New("invalid X-WOPI-LockExpirationTimeout")
+	}
+	return time.Duration(seconds) * time.Second, 0, nil
+}
+
+func wopiCurrentLock(fileID string) (string, bool) {
+	wopiLockStore.Lock()
+	defer wopiLockStore.Unlock()
+
+	lock, ok := wopiLockStore.locks[fileID]
+	if !ok {
+		return "", false
+	}
+
+	if time.Now().After(lock.ExpiresAt) {
+		delete(wopiLockStore.locks, fileID)
+		return "", false
+	}
+
+	return lock.Value, true
+}
+
+func wopiSetLock(fileID, lockValue string, ttl time.Duration) {
+	wopiLockStore.Lock()
+	defer wopiLockStore.Unlock()
+	wopiLockStore.locks[fileID] = wopiLock{Value: lockValue, ExpiresAt: time.Now().Add(ttl)}
+}
+
+func wopiClearLock(fileID string) {
+	wopiLockStore.Lock()
+	defer wopiLockStore.Unlock()
+	delete(wopiLockStore.locks, fileID)
+}
+
+func wopiLockMismatch(w http.ResponseWriter, currentLock, reason string) (int, error) {
+	w.Header().Set("X-WOPI-Lock", currentLock)
+	if reason != "" {
+		w.Header().Set("X-WOPI-LockFailureReason", reason)
+	}
+	return http.StatusConflict, nil
+}
+
+func wopiVersion(info fileInfoStat) string {
+	return fmt.Sprintf("%x%x", info.ModTime().UnixNano(), info.Size())
+}

--- a/http/wopi.go
+++ b/http/wopi.go
@@ -171,7 +171,7 @@ func wopiCheckFileInfoHandler(w http.ResponseWriter, r *http.Request, d *data, c
 		LastModifiedTime:     ctx.Info.ModTime().UTC().Format(time.RFC3339),
 		Version:              wopiVersion(ctx.Info),
 		BreadcrumbBrandName:  "File Browser",
-		BreadcrumbBrandURL:   strings.TrimRight(collaboraPublicURL(d, r), "/"),
+		BreadcrumbBrandURL:   strings.TrimRight(selectCollaboraWOPIBaseURL(d.collaboraConfig(), r, d), "/"),
 		BreadcrumbFolderName: folder,
 	}
 	return renderJSON(w, r, info)

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -52,12 +52,13 @@ func (s *Settings) GetRules() []rules.Rule {
 // an old database that predates these fields. If Configured is false, the
 // server-level CLI/env configuration is used as a fallback.
 type Collabora struct {
-	Configured bool   `json:"configured"`
-	Enabled    bool   `json:"enabled"`
-	URL        string `json:"url"`
-	PublicURL  string `json:"publicURL"`
-	WOPISecret string `json:"wopiSecret"`
-	TokenTTL   string `json:"tokenTTL"`
+	Configured  bool   `json:"configured"`
+	Enabled     bool   `json:"enabled"`
+	URL         string `json:"url"`
+	PublicURL   string `json:"publicURL"`
+	InternalURL string `json:"internalURL"`
+	WOPISecret  string `json:"wopiSecret"`
+	TokenTTL    string `json:"tokenTTL"`
 }
 
 // Server specific settings.
@@ -80,6 +81,7 @@ type Server struct {
 	CollaboraEnabled      bool   `json:"collaboraEnabled"`
 	CollaboraURL          string `json:"collaboraURL"`
 	CollaboraPublicURL    string `json:"collaboraPublicURL"`
+	CollaboraInternalURL  string `json:"collaboraInternalURL"`
 	CollaboraWOPISecret   string `json:"collaboraWOPISecret"`
 	CollaboraTokenTTL     string `json:"collaboraTokenTTL"`
 }

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -31,6 +31,7 @@ type Settings struct {
 	LogoutPage            string              `json:"logoutPage"`
 	Branding              Branding            `json:"branding"`
 	Tus                   Tus                 `json:"tus"`
+	Collabora             Collabora           `json:"collabora"`
 	Commands              map[string][]string `json:"commands"`
 	Shell                 []string            `json:"shell"`
 	Rules                 []rules.Rule        `json:"rules"`
@@ -43,6 +44,20 @@ type Settings struct {
 // GetRules implements rules.Provider.
 func (s *Settings) GetRules() []rules.Rule {
 	return s.Rules
+}
+
+// Collabora stores the optional Collabora Online / WOPI integration settings.
+//
+// Configured is used to distinguish an intentionally disabled GUI setting from
+// an old database that predates these fields. If Configured is false, the
+// server-level CLI/env configuration is used as a fallback.
+type Collabora struct {
+	Configured bool   `json:"configured"`
+	Enabled    bool   `json:"enabled"`
+	URL        string `json:"url"`
+	PublicURL  string `json:"publicURL"`
+	WOPISecret string `json:"wopiSecret"`
+	TokenTTL   string `json:"tokenTTL"`
 }
 
 // Server specific settings.
@@ -62,6 +77,11 @@ type Server struct {
 	ImageResolutionCal    bool   `json:"imageResolutionCalculation"`
 	AuthHook              string `json:"authHook"`
 	TokenExpirationTime   string `json:"tokenExpirationTime"`
+	CollaboraEnabled      bool   `json:"collaboraEnabled"`
+	CollaboraURL          string `json:"collaboraURL"`
+	CollaboraPublicURL    string `json:"collaboraPublicURL"`
+	CollaboraWOPISecret   string `json:"collaboraWOPISecret"`
+	CollaboraTokenTTL     string `json:"collaboraTokenTTL"`
 }
 
 // Clean cleans any variables that might need cleaning.


### PR DESCRIPTION
# File Browser Collabora/WOPI integration

This fork adds built-in Collabora Online support by making File Browser act as a WOPI host.

## Runtime configuration

Admin users can configure Collabora from the File Browser GUI: **Settings → Global Settings → Collabora Online**. Values saved in the GUI are stored in the File Browser database. CLI flags and environment variables are still supported and are used as defaults until the GUI settings are saved.

The same options can also be configured as CLI flags, config file entries, or environment variables:

| CLI flag | Environment variable | Purpose |
|---|---|---|
| `--collabora.enabled` | `FB_COLLABORA_ENABLED` | Enables the integration. |
| `--collabora.url` | `FB_COLLABORA_URL` | Public Collabora Online URL, for example `https://collabora.example.com`. |
| `--collabora.publicURL` | `FB_COLLABORA_PUBLIC_URL` | Public File Browser base URL that Collabora can call back to. Include `baseURL` here if File Browser is mounted under a path. |
| `--collabora.wopiSecret` | `FB_COLLABORA_WOPI_SECRET` | Secret for short-lived WOPI access tokens. If empty, the existing File Browser key is used. |
| `--collabora.tokenTTL` | `FB_COLLABORA_TOKEN_TTL` | WOPI token lifetime. Default: `2h`. |

Example:

```yaml
services:
  filebrowser:
    image: collabora/code:latest
    environment:
      FB_ADDRESS: 0.0.0.0
      FB_PORT: 8080
      FB_ROOT: /srv
      FB_COLLABORA_ENABLED: "true"
      FB_COLLABORA_URL: https://collabora.url.ro
      FB_COLLABORA_PUBLIC_URL: https://filebrowser.url.ro
      FB_COLLABORA_WOPI_SECRET: change-this-long-random-secret
      FB_COLLABORA_TOKEN_TTL: 2h
    volumes:
      - ./filebrowser.db:/database/filebrowser.db
      - /mnt/data:/srv
```

## What was added

Backend:

- `/api/collabora/open?path=/file.docx`
- `/wopi/files/{id}` for `CheckFileInfo`, `LOCK`, `UNLOCK`, `REFRESH_LOCK`, `UNLOCK_AND_RELOCK`, and `GET_LOCK`
- `/wopi/files/{id}/contents` for `GetFile` and `PutFile`
- discovery lookup from `FB_COLLABORA_URL/hosting/discovery`
- short-lived JWT/HMAC WOPI tokens
- permission checks against the logged-in File Browser user
- CSP changes to allow the configured Collabora URL in frames and WebSocket connections

Frontend:

- `Open with Collabora` button for supported office files
- `/files/...?...office=true` iframe editor view
- Collabora API client
- Admin settings form for Collabora URL, public File Browser URL, WOPI secret, and token TTL

## Important Collabora-side requirement

Collabora must allow the public File Browser host as an accepted WOPI host. If Collabora logs show messages like `No acceptable WOPI hosts found`, add the File Browser hostname to Collabora's WOPI allow list / `aliasgroup` configuration.

## Current scope

This first version supports normal open/edit/save through WOPI locks and `PutFile`. Advanced WOPI operations such as `PutRelativeFile`, rename, delete, and co-authoring persistence beyond this single File Browser process are not implemented yet.

