### PR TITLE
feat: Archive support for Filebrowser

### DIFF
--- a/files/file.go
+++ b/files/file.go
@@ -35,22 +35,25 @@ var (
 // FileInfo describes a file.
 type FileInfo struct {
 	*Listing
-	Fs         afero.Fs          `json:"-"`
-	Path       string            `json:"path"`
-	Name       string            `json:"name"`
-	Size       int64             `json:"size"`
-	Extension  string            `json:"extension"`
-	ModTime    time.Time         `json:"modified"`
-	Mode       os.FileMode       `json:"mode"`
-	IsDir      bool              `json:"isDir"`
-	IsSymlink  bool              `json:"isSymlink"`
-	Type       string            `json:"type"`
-	Subtitles  []string          `json:"subtitles,omitempty"`
-	Content    string            `json:"content,omitempty"`
-	Checksums  map[string]string `json:"checksums,omitempty"`
-	Token      string            `json:"token,omitempty"`
-	currentDir []os.FileInfo     `json:"-"`
-	Resolution *ImageResolution  `json:"resolution,omitempty"`
+	Fs               afero.Fs          `json:"-"`
+	Path             string            `json:"path"`
+	Name             string            `json:"name"`
+	Size             int64             `json:"size"`
+	Extension        string            `json:"extension"`
+	ModTime          time.Time         `json:"modified"`
+	Mode             os.FileMode       `json:"mode"`
+	IsDir            bool              `json:"isDir"`
+	IsSymlink        bool              `json:"isSymlink"`
+	Type             string            `json:"type"`
+	Subtitles        []string          `json:"subtitles,omitempty"`
+	Content          string            `json:"content,omitempty"`
+	Checksums        map[string]string `json:"checksums,omitempty"`
+	Token            string            `json:"token,omitempty"`
+	currentDir       []os.FileInfo     `json:"-"`
+	Resolution       *ImageResolution  `json:"resolution,omitempty"`
+	Archive          bool              `json:"archive,omitempty"`
+	ArchivePath      string            `json:"archivePath,omitempty"`
+	ArchiveInnerPath string            `json:"archiveInnerPath,omitempty"`
 }
 
 // FileOptions are the options when getting a file info.
@@ -241,6 +244,9 @@ func (i *FileInfo) detectType(modify, saveContent, readHeader bool, calcImgRes b
 	}
 
 	switch {
+	case IsArchiveName(i.Name):
+		i.Type = "archive"
+		return nil
 	case strings.HasPrefix(mimetype, "video"):
 		i.Type = "video"
 		i.detectSubtitles()

--- a/files/utils.go
+++ b/files/utils.go
@@ -2,6 +2,7 @@ package files
 
 import (
 	"os"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -56,4 +57,19 @@ func IsNamedPipe(mode os.FileMode) bool {
 
 func IsSymlink(mode os.FileMode) bool {
 	return mode&os.ModeSymlink != 0
+}
+
+func IsArchiveName(name string) bool {
+	lower := strings.ToLower(name)
+	archiveExts := []string{
+		".zip", ".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2",
+		".tar.xz", ".txz", ".tar.zst", ".tzst", ".tar.lz4", ".tlz4",
+		".tar.br", ".tar.sz", ".rar", ".7z",
+	}
+	for _, ext := range archiveExts {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
 }

--- a/frontend/src/api/files.ts
+++ b/frontend/src/api/files.ts
@@ -49,6 +49,62 @@ export async function fetch(url: string, signal?: AbortSignal) {
   return data;
 }
 
+
+function archiveRoute(archivePath: string, innerPath: string) {
+  const inner = innerPath || "/";
+  return `${archivePath}?archive=${encodeURIComponent(inner)}`;
+}
+
+function normalizeArchiveInner(innerPath: string) {
+  if (!innerPath || innerPath === ".") return "/";
+  if (!innerPath.startsWith("/")) return `/${innerPath}`;
+  return innerPath;
+}
+
+export async function fetchArchive(
+  archiveURL: string,
+  innerPath = "/",
+  signal?: AbortSignal
+) {
+  const archivePath = removePrefix(archiveURL);
+  const archiveViewPath = `/files${archivePath}`;
+  const inner = normalizeArchiveInner(innerPath);
+  const params = new URLSearchParams({ inner });
+  const res = await fetchURL(`/api/archive/resources${archivePath}?${params}`, {
+    signal,
+  });
+
+  let data: Resource;
+  try {
+    data = (await res.json()) as Resource;
+  } catch (e) {
+    if (e instanceof Error && e.name === "AbortError") {
+      throw new StatusError("000 No connection", 0, true);
+    }
+    throw e;
+  }
+
+  data.archive = true;
+  data.archivePath = archiveViewPath;
+  data.archiveInnerPath = normalizeArchiveInner(data.archiveInnerPath || inner);
+  data.url = archiveRoute(archiveViewPath, data.archiveInnerPath);
+
+  if (data.isDir) {
+    data.items = data.items.map((item: any, index: any) => {
+      item.index = index;
+      item.archive = true;
+      item.archivePath = archiveViewPath;
+      item.archiveInnerPath = normalizeArchiveInner(
+        item.archiveInnerPath || item.path
+      );
+      item.url = archiveRoute(archiveViewPath, item.archiveInnerPath);
+      return item;
+    });
+  }
+
+  return data;
+}
+
 export async function fetchAll(url: string): Promise<RecursiveEntry[]> {
   url = removePrefix(url);
   const res = await fetchURL(`/api/resources/recursive${url}`, {});
@@ -209,20 +265,53 @@ export async function checksum(url: string, algo: ChecksumAlg) {
 }
 
 export function getDownloadURL(file: ResourceItem, inline: any) {
-  const params = {
+  const params: Record<string, string> = {
     ...(inline && { inline: "true" }),
   };
+
+  if (file.archivePath && file.archiveInnerPath) {
+    params.inner = file.archiveInnerPath;
+    return createURL("api/archive/raw" + removePrefix(file.archivePath), params);
+  }
 
   return createURL("api/raw" + file.path, params);
 }
 
 export function getPreviewURL(file: ResourceItem, size: string) {
+  if (file.archivePath && file.archiveInnerPath) {
+    return getDownloadURL(file, true);
+  }
+
   const params = {
     inline: "true",
     key: Date.parse(file.modified),
   };
 
   return createURL("api/preview/" + size + file.path, params);
+}
+
+
+export async function extractArchive(
+  archiveURL: string,
+  innerPath = "/",
+  destination = "",
+  rename = true,
+  overwrite = false
+): Promise<{ destination: string; extracted: number }> {
+  const archivePath = removePrefix(archiveURL);
+  const params = new URLSearchParams({
+    inner: normalizeArchiveInner(innerPath),
+    rename: String(rename),
+    override: String(overwrite),
+  });
+  if (destination) {
+    params.set("destination", removePrefix(destination));
+  }
+
+  const res = await fetchURL(`/api/archive/extract${archivePath}?${params}`, {
+    method: "POST",
+  });
+  return (await res.json()) as { destination: string; extracted: number };
 }
 
 export function getSubtitlesURL(file: ResourceItem) {

--- a/frontend/src/components/Breadcrumbs.vue
+++ b/frontend/src/components/Breadcrumbs.vue
@@ -32,7 +32,7 @@ const props = defineProps<{
   noLink?: boolean;
 }>();
 
-const items = computed(() => {
+const buildPathBreadcrumbs = () => {
   const relativePath = route.path.replace(props.base, "");
   const parts = relativePath.split("/");
 
@@ -47,15 +47,48 @@ const items = computed(() => {
   const breadcrumbs: BreadCrumb[] = [];
 
   for (let i = 0; i < parts.length; i++) {
-    if (i === 0) {
+    const url =
+      i === 0
+        ? props.base + "/" + parts[i]
+        : String(breadcrumbs[i - 1].url).replace(/\/$/, "") + "/" + parts[i];
+
+    breadcrumbs.push({
+      name: decodeURIComponent(parts[i]),
+      url: url + "/",
+    });
+  }
+
+  return breadcrumbs;
+};
+
+const items = computed(() => {
+  const breadcrumbs = buildPathBreadcrumbs();
+  const archiveQuery = Array.isArray(route.query.archive)
+    ? route.query.archive[0]
+    : route.query.archive;
+
+  if (typeof archiveQuery === "string") {
+    if (breadcrumbs.length > 0) {
+      breadcrumbs[breadcrumbs.length - 1].url = {
+        path: route.path,
+        query: { archive: "/" },
+      } as any;
+    }
+
+    const inner = archiveQuery.startsWith("/")
+      ? archiveQuery.substring(1)
+      : archiveQuery;
+    const archiveParts = inner.split("/").filter(Boolean);
+    let currentInner = "";
+
+    for (const part of archiveParts) {
+      currentInner += "/" + part;
       breadcrumbs.push({
-        name: decodeURIComponent(parts[i]),
-        url: props.base + "/" + parts[i] + "/",
-      });
-    } else {
-      breadcrumbs.push({
-        name: decodeURIComponent(parts[i]),
-        url: breadcrumbs[i - 1].url + parts[i] + "/",
+        name: decodeURIComponent(part),
+        url: {
+          path: route.path,
+          query: { archive: currentInner },
+        } as any,
       });
     }
   }

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -77,6 +77,9 @@ const props = defineProps<{
   index: number;
   readOnly?: boolean;
   path?: string;
+  archive?: boolean;
+  archivePath?: string;
+  archiveInnerPath?: string;
 }>();
 
 const authStore = useAuthStore();
@@ -84,8 +87,9 @@ const fileStore = useFileStore();
 const layoutStore = useLayoutStore();
 
 const singleClick = computed(
-  () => !props.readOnly && authStore.user?.singleClick
+  () => (props.archive || !props.readOnly) && authStore.user?.singleClick
 );
+const isArchiveItem = computed(() => props.type === "archive" && !props.archive);
 const isSelected = computed(
   () => fileStore.selected.indexOf(props.index) !== -1
 );
@@ -324,6 +328,19 @@ const click = (event: Event | KeyboardEvent) => {
 };
 
 const open = () => {
+  if (props.archive && props.archivePath && props.archiveInnerPath) {
+    router.push({
+      path: props.archivePath,
+      query: { archive: props.archiveInnerPath },
+    });
+    return;
+  }
+
+  if (isArchiveItem.value) {
+    router.push({ path: props.url, query: { archive: "/" } });
+    return;
+  }
+
   router.push({ path: props.url });
 };
 

--- a/frontend/src/css/listing-icons.css
+++ b/frontend/src/css/listing-icons.css
@@ -15,6 +15,9 @@
 .file-icons [data-type="blob"] i::before {
   content: "insert_drive_file";
 }
+.file-icons [data-type="archive"] i::before {
+  content: "folder_zip";
+}
 .file-icons [data-type="image"] i::before {
   content: "image";
 }

--- a/frontend/src/types/file.d.ts
+++ b/frontend/src/types/file.d.ts
@@ -9,6 +9,9 @@ interface ResourceBase {
   isSymlink: boolean;
   type: ResourceType;
   url: string;
+  archive?: boolean;
+  archivePath?: string;
+  archiveInnerPath?: string;
 }
 
 interface Resource extends ResourceBase {
@@ -31,6 +34,7 @@ interface ResourceItem extends ResourceBase {
 
 type ResourceType =
   | "dir"
+  | "archive"
   | "video"
   | "audio"
   | "image"
@@ -58,7 +62,7 @@ interface ClipItem {
 
 interface BreadCrumb {
   name: string;
-  url: string;
+  url: string | Record<string, any>;
 }
 
 interface ConflictingItem {

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -158,7 +158,13 @@ const fetchData = async () => {
   fetchDataController.abort();
   fetchDataController = new AbortController();
   try {
-    const res = await api.fetch(url, fetchDataController.signal);
+    const archiveInner = Array.isArray(route.query.archive)
+      ? route.query.archive[0]
+      : route.query.archive;
+    const res =
+      typeof archiveInner === "string"
+        ? await api.fetchArchive(url, archiveInner, fetchDataController.signal)
+        : await api.fetch(url, fetchDataController.signal);
     fileStore.updateRequest(res);
     document.title = `${res.name || t("sidebar.myFiles")} - ${t("files.files")} - ${name}`;
     layoutStore.loading = false;

--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -17,7 +17,7 @@
       />
 
       <action
-        v-if="authStore.user?.perm.modify"
+        v-if="authStore.user?.perm.modify && !fileStore.req?.archive"
         id="save-button"
         icon="save"
         :label="t('buttons.save')"
@@ -267,6 +267,7 @@ const handlePageChange = (event: BeforeUnloadEvent) => {
 };
 
 const save = async (throwError?: boolean) => {
+  if (fileStore.req?.archive) return;
   const button = "save";
   buttons.loading("save");
 
@@ -316,7 +317,21 @@ const close = () => {
   finishClose();
 };
 
+const archiveParentPath = (innerPath: string) => {
+  const parts = innerPath.split("/").filter(Boolean);
+  parts.pop();
+  return parts.length === 0 ? "/" : `/${parts.join("/")}`;
+};
+
 const finishClose = () => {
+  if (fileStore.req?.archivePath && fileStore.req?.archiveInnerPath) {
+    router.push({
+      path: fileStore.req.archivePath,
+      query: { archive: archiveParentPath(fileStore.req.archiveInnerPath) },
+    });
+    return;
+  }
+
   const uri = url.removeLastDir(route.path) + "/";
   router.push({ path: uri });
 };

--- a/frontend/src/views/files/FileListing.vue
+++ b/frontend/src/views/files/FileListing.vue
@@ -66,6 +66,13 @@
           :counter="fileStore.selectedCount"
         />
         <action
+          v-if="headerButtons.extract"
+          id="extract-button"
+          icon="folder_zip"
+          :label="archiveExtractLabel"
+          @action="extractArchive"
+        />
+        <action
           v-if="headerButtons.upload"
           icon="file_upload"
           id="upload-button"
@@ -120,6 +127,12 @@
         icon="delete"
         :label="t('buttons.delete')"
         show="delete"
+      />
+      <action
+        v-if="headerButtons.extract"
+        icon="folder_zip"
+        :label="archiveExtractLabel"
+        @action="extractArchive"
       />
     </div>
 
@@ -231,6 +244,10 @@
             v-bind:type="item.type"
             v-bind:size="item.size"
             v-bind:path="item.path"
+            v-bind:archive="item.archive"
+            v-bind:archivePath="item.archivePath"
+            v-bind:archiveInnerPath="item.archiveInnerPath"
+            v-bind:readOnly="isArchiveView"
           >
           </item>
         </div>
@@ -254,6 +271,10 @@
             v-bind:type="item.type"
             v-bind:size="item.size"
             v-bind:path="item.path"
+            v-bind:archive="item.archive"
+            v-bind:archivePath="item.archivePath"
+            v-bind:archiveInnerPath="item.archiveInnerPath"
+            v-bind:readOnly="isArchiveView"
           >
           </item>
         </div>
@@ -301,6 +322,13 @@
             :label="t('buttons.download')"
             @action="download"
             :counter="fileStore.selectedCount"
+          />
+          <action
+            v-if="headerButtons.extract"
+            id="context-extract-button"
+            icon="folder_zip"
+            :label="archiveExtractLabel"
+            @action="extractArchive"
           />
           <action icon="info" :label="t('buttons.info')" show="info" />
         </context-menu>
@@ -366,7 +394,7 @@ import {
   ref,
   watch,
 } from "vue";
-import { useRoute, onBeforeRouteUpdate } from "vue-router";
+import { useRoute, useRouter, onBeforeRouteUpdate } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { storeToRefs } from "pinia";
 import { removePrefix } from "@/api/utils";
@@ -380,6 +408,7 @@ const isContextMenuVisible = ref<boolean>(false);
 const contextMenuPos = ref<{ x: number; y: number }>({ x: 0, y: 0 });
 
 const $showError = inject<IToastError>("$showError")!;
+const $showSuccess = inject<IToastSuccess>("$showSuccess")!;
 
 const clipboardStore = useClipboardStore();
 const authStore = useAuthStore();
@@ -389,6 +418,7 @@ const layoutStore = useLayoutStore();
 const { req } = storeToRefs(fileStore);
 
 const route = useRoute();
+const router = useRouter();
 onBeforeRouteUpdate(() => {
   hideContextMenu();
 });
@@ -462,6 +492,8 @@ const modifiedIcon = computed(() => {
   return "arrow_upward";
 });
 
+const isArchiveView = computed(() => Boolean(fileStore.req?.archivePath));
+
 const viewIcon = computed(() => {
   const icons = {
     list: "view_module",
@@ -473,19 +505,72 @@ const viewIcon = computed(() => {
     : icons[authStore.user.viewMode];
 });
 
+const selectedItem = computed(() =>
+  fileStore.selectedCount === 1 && fileStore.req
+    ? fileStore.req.items[fileStore.selected[0]]
+    : null
+);
+
+const isSelectedArchiveFile = computed(
+  () =>
+    !isArchiveView.value &&
+    fileStore.selectedCount === 1 &&
+    selectedItem.value?.type === "archive"
+);
+
+const archiveExtractLabel = computed(() => {
+  if (isSelectedArchiveFile.value) {
+    return "Extract this archive";
+  }
+
+  if (isArchiveView.value) {
+    if (selectedItem.value) {
+      return selectedItem.value.isDir
+        ? "Extract this folder"
+        : "Extract this file";
+    }
+
+    const currentInner = fileStore.req?.archiveInnerPath || "/";
+    return currentInner === "/" ? "Extract archive" : "Extract current folder";
+  }
+
+  return "Extract archive";
+});
+
 const headerButtons = computed(() => {
+  const selected = selectedItem.value;
+
   return {
-    upload: authStore.user?.perm.create,
-    download: authStore.user?.perm.download,
-    shell: authStore.user?.perm.execute && enableExec,
-    delete: fileStore.selectedCount > 0 && authStore.user?.perm.delete,
-    rename: fileStore.selectedCount === 1 && authStore.user?.perm.rename,
+    upload: !isArchiveView.value && authStore.user?.perm.create,
+    download:
+      authStore.user?.perm.download &&
+      (!isArchiveView.value || (selected !== null && !selected.isDir)),
+    extract:
+      authStore.user?.perm.create &&
+      ((isArchiveView.value && fileStore.selectedCount <= 1) ||
+        isSelectedArchiveFile.value),
+    shell: !isArchiveView.value && authStore.user?.perm.execute && enableExec,
+    delete:
+      !isArchiveView.value &&
+      fileStore.selectedCount > 0 &&
+      authStore.user?.perm.delete,
+    rename:
+      !isArchiveView.value &&
+      fileStore.selectedCount === 1 &&
+      authStore.user?.perm.rename,
     share:
+      !isArchiveView.value &&
       fileStore.selectedCount === 1 &&
       authStore.user?.perm.share &&
       authStore.user?.perm.download,
-    move: fileStore.selectedCount > 0 && authStore.user?.perm.rename,
-    copy: fileStore.selectedCount > 0 && authStore.user?.perm.create,
+    move:
+      !isArchiveView.value &&
+      fileStore.selectedCount > 0 &&
+      authStore.user?.perm.rename,
+    copy:
+      !isArchiveView.value &&
+      fileStore.selectedCount > 0 &&
+      authStore.user?.perm.create,
   };
 });
 
@@ -528,11 +613,9 @@ onMounted(() => {
   window.addEventListener("scroll", scrollEvent);
   window.addEventListener("resize", windowsResize);
 
-  if (!authStore.user?.perm.create) return;
-  document.addEventListener("dragover", preventDefault);
-  document.addEventListener("dragenter", dragEnter);
-  document.addEventListener("dragleave", dragLeave);
-  document.addEventListener("drop", drop);
+  if (authStore.user?.perm.create && !isArchiveView.value) {
+    addDropListeners();
+  }
 });
 
 onBeforeUnmount(() => {
@@ -541,11 +624,7 @@ onBeforeUnmount(() => {
   window.removeEventListener("scroll", scrollEvent);
   window.removeEventListener("resize", windowsResize);
 
-  if (authStore.user && !authStore.user?.perm.create) return;
-  document.removeEventListener("dragover", preventDefault);
-  document.removeEventListener("dragenter", dragEnter);
-  document.removeEventListener("dragleave", dragLeave);
-  document.removeEventListener("drop", drop);
+  removeDropListeners();
 });
 
 const base64 = (name: string) => Base64.encodeURI(name);
@@ -559,6 +638,10 @@ const keyEvent = (event: KeyboardEvent) => {
   if (event.key === "Escape") {
     // Reset files selection.
     fileStore.selected = [];
+  }
+
+  if (isArchiveView.value) {
+    return;
   }
 
   if (event.key === "Delete") {
@@ -619,6 +702,29 @@ const preventDefault = (event: Event) => {
   // Wrapper around prevent default.
   event.preventDefault();
 };
+const addDropListeners = () => {
+  document.addEventListener("dragover", preventDefault);
+  document.addEventListener("dragenter", dragEnter);
+  document.addEventListener("dragleave", dragLeave);
+  document.addEventListener("drop", drop);
+};
+
+const removeDropListeners = () => {
+  document.removeEventListener("dragover", preventDefault);
+  document.removeEventListener("dragenter", dragEnter);
+  document.removeEventListener("dragleave", dragLeave);
+  document.removeEventListener("drop", drop);
+};
+
+watch(isArchiveView, (archiveView) => {
+  if (!authStore.user?.perm.create) return;
+  if (archiveView) {
+    removeDropListeners();
+  } else {
+    addDropListeners();
+  }
+});
+
 
 const copyCut = (event: Event | KeyboardEvent): void => {
   if ((event.target as HTMLElement).tagName?.toLowerCase() === "input") return;
@@ -785,6 +891,7 @@ const dragLeave = () => {
 
 const drop = async (event: DragEvent) => {
   event.preventDefault();
+  if (isArchiveView.value) return;
   dragCounter.value = 0;
   resetOpacity();
 
@@ -858,6 +965,7 @@ const drop = async (event: DragEvent) => {
 };
 
 const uploadInput = async (event: Event) => {
+  if (isArchiveView.value) return;
   const files = (event.currentTarget as HTMLInputElement)?.files;
   if (files === null) return;
 
@@ -975,6 +1083,14 @@ const windowsResize = throttle(() => {
 const download = () => {
   if (fileStore.req === null) return;
 
+  if (isArchiveView.value) {
+    if (fileStore.selectedCount !== 1) return;
+    const selected = fileStore.req.items[fileStore.selected[0]];
+    if (selected.isDir) return;
+    window.open(api.getDownloadURL(selected, false));
+    return;
+  }
+
   if (
     fileStore.selectedCount === 1 &&
     !fileStore.req.items[fileStore.selected[0]].isDir
@@ -1001,6 +1117,45 @@ const download = () => {
       api.download(format, ...files);
     },
   });
+};
+
+
+const extractArchive = async () => {
+  const item = selectedItem.value;
+  let archivePath = "";
+  let innerPath = "/";
+  let successMessage = "";
+
+  if (isArchiveView.value && fileStore.req?.archivePath) {
+    archivePath = fileStore.req.archivePath;
+    innerPath = item?.archiveInnerPath || fileStore.req.archiveInnerPath || "/";
+
+    if (item) {
+      successMessage = item.isDir
+        ? "Folder extracted to"
+        : "File extracted to";
+    } else {
+      successMessage =
+        innerPath === "/" ? "Archive extracted to" : "Folder extracted to";
+    }
+  } else if (isSelectedArchiveFile.value && item?.url) {
+    archivePath = item.url;
+    innerPath = "/";
+    successMessage = "Archive extracted to";
+  } else {
+    return;
+  }
+
+  try {
+    layoutStore.loading = true;
+    const result = await api.extractArchive(archivePath, innerPath);
+    $showSuccess(`${successMessage} ${result.destination}`);
+    router.push({ path: `/files${result.destination}` });
+  } catch (e: any) {
+    $showError(e);
+  } finally {
+    layoutStore.loading = false;
+  }
 };
 
 const switchView = async () => {

--- a/frontend/src/views/files/Preview.vue
+++ b/frontend/src/views/files/Preview.vue
@@ -19,7 +19,7 @@
       <template #actions>
         <action
           :disabled="layoutStore.loading"
-          v-if="authStore.user?.perm.rename"
+          v-if="authStore.user?.perm.rename && !fileStore.req?.archive"
           icon="mode_edit"
           :label="$t('buttons.rename')"
           show="rename"
@@ -33,7 +33,7 @@
         />
         <action
           :disabled="layoutStore.loading"
-          v-if="authStore.user?.perm.delete"
+          v-if="authStore.user?.perm.delete && !fileStore.req?.archive"
           icon="delete"
           :label="$t('buttons.delete')"
           @action="deleteFile"
@@ -45,6 +45,13 @@
           icon="file_download"
           :label="$t('buttons.download')"
           @action="download"
+        />
+        <action
+          :disabled="layoutStore.loading"
+          v-if="canExtractArchiveFile"
+          icon="folder_zip"
+          label="Extract this file"
+          @action="extractArchiveFile"
         />
         <action
           :disabled="layoutStore.loading"
@@ -185,7 +192,6 @@ import { useFileStore } from "@/stores/file";
 import { useLayoutStore } from "@/stores/layout";
 
 import { files as api } from "@/api";
-import { createURL } from "@/api/utils";
 import { resizePreview } from "@/utils/constants";
 import url from "@/utils/url";
 import { throttle } from "lodash-es";
@@ -268,6 +274,7 @@ const csvError = ref<string>("");
 const player = ref<HTMLVideoElement | HTMLAudioElement | null>(null);
 
 const $showError = inject<IToastError>("$showError")!;
+const $showSuccess = inject<IToastSuccess>("$showSuccess")!;
 
 const authStore = useAuthStore();
 const fileStore = useFileStore();
@@ -290,6 +297,14 @@ const directUrl = computed(() =>
   fileStore.req ? api.getDownloadURL(fileStore.req, true) : ""
 );
 
+const canExtractArchiveFile = computed(() =>
+  Boolean(
+    fileStore.req?.archivePath &&
+      fileStore.req?.archiveInnerPath &&
+      authStore.user?.perm.create
+  )
+);
+
 const previewUrl = computed(() => {
   if (!fileStore.req) {
     return "";
@@ -300,7 +315,7 @@ const previewUrl = computed(() => {
   }
 
   if (isEpub.value) {
-    return createURL("api/raw" + fileStore.req.path, {});
+    return api.getDownloadURL(fileStore.req, true);
   }
 
   return api.getDownloadURL(fileStore.req, true);
@@ -371,12 +386,12 @@ const deleteFile = () => {
 
 const prev = () => {
   hoverNav.value = false;
-  router.replace({ path: previousLink.value });
+  router.replace(previousLink.value);
 };
 
 const next = () => {
   hoverNav.value = false;
-  router.replace({ path: nextLink.value });
+  router.replace(nextLink.value);
 };
 
 const key = (event: KeyboardEvent) => {
@@ -407,8 +422,13 @@ const updatePreview = async () => {
     autoPlay.value = false;
   }
 
-  const dirs = route.fullPath.split("/");
-  name.value = decodeURIComponent(dirs[dirs.length - 1]);
+  if (fileStore.req?.archiveInnerPath) {
+    const innerParts = fileStore.req.archiveInnerPath.split("/").filter(Boolean);
+    name.value = decodeURIComponent(innerParts[innerParts.length - 1] || fileStore.req.name);
+  } else {
+    const dirs = route.fullPath.split("/");
+    name.value = decodeURIComponent(dirs[dirs.length - 1]);
+  }
 
   // Load CSV content if it's a CSV file
   if (isCsv.value && fileStore.req) {
@@ -428,8 +448,10 @@ const updatePreview = async () => {
 
   if (!listing.value) {
     try {
-      const path = url.removeLastDir(route.path);
-      const res = await api.fetch(path);
+      const archiveInner = fileStore.req?.archiveInnerPath;
+      const res = fileStore.req?.archivePath && archiveInner
+        ? await api.fetchArchive(fileStore.req.archivePath, archiveParentPath(archiveInner))
+        : await api.fetch(url.removeLastDir(route.path));
       listing.value = res.items;
     } catch (e: any) {
       $showError(e);
@@ -489,13 +511,45 @@ const toggleNavigation = throttle(function () {
   }, 1500);
 }, 500);
 
+const archiveParentPath = (innerPath: string) => {
+  const parts = innerPath.split("/").filter(Boolean);
+  parts.pop();
+  return parts.length === 0 ? "/" : `/${parts.join("/")}`;
+};
+
 const close = () => {
+  if (fileStore.req?.archivePath && fileStore.req?.archiveInnerPath) {
+    router.push({
+      path: fileStore.req.archivePath,
+      query: { archive: archiveParentPath(fileStore.req.archiveInnerPath) },
+    });
+    return;
+  }
+
   const uri = url.removeLastDir(route.path) + "/";
   router.push({ path: uri });
 };
 
 const download = () => window.open(downloadUrl.value);
 const openDirect = () => window.open(directUrl.value);
+
+const extractArchiveFile = async () => {
+  if (!fileStore.req?.archivePath || !fileStore.req.archiveInnerPath) return;
+
+  try {
+    layoutStore.loading = true;
+    const result = await api.extractArchive(
+      fileStore.req.archivePath,
+      fileStore.req.archiveInnerPath
+    );
+    $showSuccess(`File extracted to ${result.destination}`);
+    router.push({ path: `/files${result.destination}` });
+  } catch (e: any) {
+    $showError(e);
+  } finally {
+    layoutStore.loading = false;
+  }
+};
 
 const editAsText = () => {
   router.push({ path: route.path, query: { edit: "true" } });

--- a/http/archive.go
+++ b/http/archive.go
@@ -1,0 +1,593 @@
+package fbhttp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	gopath "path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mholt/archives"
+
+	fberrors "github.com/filebrowser/filebrowser/v2/errors"
+	"github.com/filebrowser/filebrowser/v2/files"
+)
+
+const archiveTextPreviewLimit int64 = 10 * 1024 * 1024
+
+var errArchiveEntryFound = errors.New("archive entry found")
+
+type archiveExtractResponse struct {
+	Destination string `json:"destination"`
+	Extracted   int    `json:"extracted"`
+}
+
+type archiveOpenResult struct {
+	extractor archives.Extractor
+	stream    io.Reader
+	close     func() error
+}
+
+func cleanArchiveInnerPath(inner string) (string, error) {
+	inner = strings.TrimSpace(strings.ReplaceAll(inner, "\\", "/"))
+	inner = strings.TrimPrefix(inner, "/")
+
+	if inner == "" || inner == "." {
+		return ".", nil
+	}
+
+	cleaned := gopath.Clean(inner)
+	if cleaned == "." {
+		return ".", nil
+	}
+
+	if gopath.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, "../") || strings.Contains(cleaned, "/../") {
+		return "", fmt.Errorf("unsafe archive path: %w", fberrors.ErrInvalidRequestParams)
+	}
+
+	return cleaned, nil
+}
+
+func archiveAPIDisplayPath(inner string) string {
+	if inner == "." || inner == "" {
+		return "/"
+	}
+	return "/" + inner
+}
+
+func archiveEntryPath(entry string) (string, error) {
+	entry = strings.ReplaceAll(entry, "\\", "/")
+	entry = strings.TrimPrefix(entry, "/")
+	entry = strings.TrimSuffix(entry, "/")
+	return cleanArchiveInnerPath(entry)
+}
+
+func stripKnownArchiveExtension(name string) string {
+	lower := strings.ToLower(name)
+	multi := []string{
+		".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz", ".txz",
+		".tar.zst", ".tzst", ".tar.lz4", ".tlz4", ".tar.br", ".tar.sz",
+	}
+	for _, ext := range multi {
+		if strings.HasSuffix(lower, ext) {
+			return name[:len(name)-len(ext)]
+		}
+	}
+	if ext := filepath.Ext(name); ext != "" {
+		return strings.TrimSuffix(name, ext)
+	}
+	return name + "-extracted"
+}
+
+func openArchive(ctx context.Context, archivePath string, d *data) (*archiveOpenResult, error) {
+	archivePath = gopath.Clean("/" + archivePath)
+	if !d.Check(archivePath) {
+		return nil, fberrors.ErrPermissionDenied
+	}
+
+	file, err := files.NewFileInfo(&files.FileOptions{
+		Fs:         d.user.Fs,
+		Path:       archivePath,
+		Modify:     false,
+		Expand:     true,
+		ReadHeader: d.server.TypeDetectionByHeader,
+		Checker:    d,
+		Content:    false,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if file.IsDir || file.Type != "archive" {
+		return nil, fmt.Errorf("resource is not a supported archive: %w", fberrors.ErrInvalidRequestParams)
+	}
+
+	f, err := d.user.Fs.Open(archivePath)
+	if err != nil {
+		return nil, err
+	}
+
+	format, stream, err := archives.Identify(ctx, file.Name, f)
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+
+	extractor, ok := format.(archives.Extractor)
+	if !ok {
+		_ = f.Close()
+		return nil, fmt.Errorf("archive format is not extractable: %w", fberrors.ErrInvalidRequestParams)
+	}
+
+	return &archiveOpenResult{
+		extractor: extractor,
+		stream:    stream,
+		close:     f.Close,
+	}, nil
+}
+
+func detectArchiveResourceType(name string, size int64, opener func() (fs.File, error), readHeader bool) string {
+	extension := strings.ToLower(filepath.Ext(name))
+	if files.IsArchiveName(name) {
+		return "archive"
+	}
+
+	mimetype := mime.TypeByExtension(extension)
+	var buffer []byte
+	if readHeader && mimetype == "" && opener != nil {
+		f, err := opener()
+		if err == nil {
+			defer f.Close()
+			buffer = make([]byte, 512)
+			n, _ := f.Read(buffer)
+			buffer = buffer[:n]
+			mimetype = http.DetectContentType(buffer)
+		}
+	}
+
+	switch {
+	case strings.HasPrefix(mimetype, "video"):
+		return "video"
+	case strings.HasPrefix(mimetype, "audio"):
+		return "audio"
+	case strings.HasPrefix(mimetype, "image"):
+		return "image"
+	case strings.HasSuffix(mimetype, "pdf"):
+		return "pdf"
+	case size <= archiveTextPreviewLimit && isArchiveTextMIME(mimetype, extension):
+		return "textImmutable"
+	default:
+		return "blob"
+	}
+}
+
+func isArchiveTextMIME(mimetype, extension string) bool {
+	if strings.HasPrefix(mimetype, "text") {
+		return true
+	}
+	switch mimetype {
+	case "application/json", "application/xml", "application/javascript", "application/x-javascript", "application/x-yaml", "text/yaml":
+		return true
+	}
+	switch extension {
+	case ".json", ".yaml", ".yml", ".toml", ".xml", ".js", ".ts", ".tsx", ".jsx", ".vue", ".css", ".scss", ".md", ".markdown", ".go", ".py", ".sh", ".bash", ".zsh", ".txt", ".log", ".conf", ".ini", ".env", ".sql", ".csv":
+		return true
+	}
+	return false
+}
+
+func newArchiveFileInfo(archivePath, inner string, info fs.FileInfo, isDir bool, typ string) *files.FileInfo {
+	displayPath := archiveAPIDisplayPath(inner)
+	name := ""
+	if inner != "." {
+		name = gopath.Base(inner)
+	} else {
+		name = gopath.Base(archivePath)
+	}
+	if info != nil && name == "" {
+		name = info.Name()
+	}
+
+	size := int64(0)
+	modTime := time.Time{}
+	mode := os.FileMode(0)
+	if info != nil {
+		size = info.Size()
+		modTime = info.ModTime()
+		mode = info.Mode()
+	}
+	if isDir {
+		mode |= os.ModeDir
+		typ = "dir"
+	}
+
+	return &files.FileInfo{
+		Path:             displayPath,
+		Name:             name,
+		Size:             size,
+		Extension:        filepath.Ext(name),
+		ModTime:          modTime,
+		Mode:             mode,
+		IsDir:            isDir,
+		Type:             typ,
+		Archive:          true,
+		ArchivePath:      archivePath,
+		ArchiveInnerPath: displayPath,
+	}
+}
+
+func buildArchiveResource(ctx context.Context, archivePath, inner string, d *data, includeContent bool) (*files.FileInfo, error) {
+	opened, err := openArchive(ctx, archivePath, d)
+	if err != nil {
+		return nil, err
+	}
+	defer opened.close()
+
+	target, err := cleanArchiveInnerPath(inner)
+	if err != nil {
+		return nil, err
+	}
+
+	children := map[string]*files.FileInfo{}
+	var exact *files.FileInfo
+	hasChildren := target == "."
+
+	err = opened.extractor.Extract(ctx, opened.stream, func(ctx context.Context, entry archives.FileInfo) error {
+		entryPath, cleanErr := archiveEntryPath(entry.NameInArchive)
+		if cleanErr != nil || entryPath == "." {
+			return nil
+		}
+
+		info := entry.FileInfo
+		entryIsDir := false
+		if info != nil {
+			entryIsDir = info.IsDir()
+		}
+		if strings.HasSuffix(strings.ReplaceAll(entry.NameInArchive, "\\", "/"), "/") {
+			entryIsDir = true
+		}
+
+		if entryPath == target {
+			typ := detectArchiveResourceType(entryPath, 0, entry.Open, false)
+			if info != nil {
+				typ = detectArchiveResourceType(entryPath, info.Size(), entry.Open, false)
+			}
+			exact = newArchiveFileInfo(archivePath, entryPath, info, entryIsDir, typ)
+
+			if !entryIsDir && includeContent && exact.Type == "textImmutable" && exact.Size <= archiveTextPreviewLimit && entry.Open != nil {
+				f, openErr := entry.Open()
+				if openErr != nil {
+					return openErr
+				}
+				defer f.Close()
+				data, readErr := io.ReadAll(io.LimitReader(f, archiveTextPreviewLimit+1))
+				if readErr != nil {
+					return readErr
+				}
+				if int64(len(data)) <= archiveTextPreviewLimit {
+					exact.Content = string(data)
+				}
+			}
+			return nil
+		}
+
+		var rest string
+		if target == "." {
+			rest = entryPath
+		} else {
+			prefix := target + "/"
+			if !strings.HasPrefix(entryPath, prefix) {
+				return nil
+			}
+			hasChildren = true
+			rest = strings.TrimPrefix(entryPath, prefix)
+		}
+
+		if rest == "" {
+			return nil
+		}
+
+		parts := strings.Split(rest, "/")
+		childInner := parts[0]
+		if target != "." {
+			childInner = target + "/" + parts[0]
+		}
+
+		if len(parts) > 1 {
+			if _, ok := children[childInner]; !ok {
+				children[childInner] = newArchiveFileInfo(archivePath, childInner, nil, true, "dir")
+			}
+			return nil
+		}
+
+		typ := detectArchiveResourceType(entryPath, 0, entry.Open, false)
+		if info != nil {
+			typ = detectArchiveResourceType(entryPath, info.Size(), entry.Open, false)
+		}
+		children[childInner] = newArchiveFileInfo(archivePath, childInner, info, entryIsDir, typ)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if exact != nil && !exact.IsDir {
+		return exact, nil
+	}
+
+	if exact == nil && !hasChildren {
+		return nil, os.ErrNotExist
+	}
+
+	root := exact
+	if root == nil {
+		root = newArchiveFileInfo(archivePath, target, nil, true, "dir")
+	}
+	root.IsDir = true
+	root.Type = "dir"
+	root.Listing = &files.Listing{Items: []*files.FileInfo{}}
+
+	keys := make([]string, 0, len(children))
+	for key := range children {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		child := children[key]
+		child.Archive = true
+		child.ArchivePath = archivePath
+		child.ArchiveInnerPath = child.Path
+		if child.IsDir {
+			root.Listing.NumDirs++
+		} else {
+			root.Listing.NumFiles++
+		}
+		root.Listing.Items = append(root.Listing.Items, child)
+	}
+
+	root.Sorting = d.user.Sorting
+	root.ApplySort()
+	return root, nil
+}
+
+var archiveResourceHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	if !d.user.Perm.Download {
+		return http.StatusAccepted, nil
+	}
+
+	archivePath := gopath.Clean("/" + r.URL.Path)
+	inner := r.URL.Query().Get("inner")
+
+	resource, err := buildArchiveResource(r.Context(), archivePath, inner, d, true)
+	if err != nil {
+		return errToStatus(err), err
+	}
+
+	return renderJSON(w, r, resource)
+})
+
+var archiveRawHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	if !d.user.Perm.Download {
+		return http.StatusAccepted, nil
+	}
+
+	archivePath := gopath.Clean("/" + r.URL.Path)
+	inner, err := cleanArchiveInnerPath(r.URL.Query().Get("inner"))
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+	if inner == "." {
+		return http.StatusBadRequest, fmt.Errorf("archive raw path must be a file: %w", fberrors.ErrInvalidRequestParams)
+	}
+
+	opened, err := openArchive(r.Context(), archivePath, d)
+	if err != nil {
+		return errToStatus(err), err
+	}
+	defer opened.close()
+
+	err = opened.extractor.Extract(r.Context(), opened.stream, func(ctx context.Context, entry archives.FileInfo) error {
+		entryPath, cleanErr := archiveEntryPath(entry.NameInArchive)
+		if cleanErr != nil || entryPath != inner {
+			return nil
+		}
+
+		if entry.FileInfo != nil && entry.FileInfo.IsDir() {
+			return fberrors.ErrIsDirectory
+		}
+		if entry.Open == nil {
+			return os.ErrNotExist
+		}
+
+		f, openErr := entry.Open()
+		if openErr != nil {
+			return openErr
+		}
+		defer f.Close()
+
+		name := gopath.Base(entryPath)
+		if r.URL.Query().Get("inline") == "true" {
+			w.Header().Set("Content-Disposition", "inline; filename*=utf-8''"+url.PathEscape(name))
+		} else {
+			w.Header().Set("Content-Disposition", "attachment; filename*=utf-8''"+url.PathEscape(name))
+		}
+		if contentType := mime.TypeByExtension(filepath.Ext(name)); contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		} else {
+			w.Header().Set("Content-Type", "application/octet-stream")
+		}
+		w.Header().Add("Content-Security-Policy", `script-src 'none';`)
+		w.Header().Set("Cache-Control", "private")
+
+		if entry.FileInfo != nil && entry.FileInfo.Size() >= 0 {
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", entry.FileInfo.Size()))
+		}
+
+		if _, copyErr := io.Copy(w, f); copyErr != nil {
+			return copyErr
+		}
+		return errArchiveEntryFound
+	})
+	if errors.Is(err, errArchiveEntryFound) {
+		return 0, nil
+	}
+	if err != nil {
+		return errToStatus(err), err
+	}
+
+	return http.StatusNotFound, os.ErrNotExist
+})
+
+var archiveExtractHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	if !d.user.Perm.Create {
+		return http.StatusForbidden, nil
+	}
+	if r.URL.Query().Get("override") == "true" && !d.user.Perm.Modify {
+		return http.StatusForbidden, nil
+	}
+
+	archivePath := gopath.Clean("/" + r.URL.Path)
+	inner, err := cleanArchiveInnerPath(r.URL.Query().Get("inner"))
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	destination := r.URL.Query().Get("destination")
+	if destination == "" {
+		baseName := stripKnownArchiveExtension(gopath.Base(archivePath))
+		destination = gopath.Join(gopath.Dir(archivePath), baseName)
+	}
+	destination, err = url.QueryUnescape(strings.ReplaceAll(destination, "+", "%2B"))
+	if err != nil {
+		return http.StatusBadRequest, err
+	}
+	destination = gopath.Clean("/" + destination)
+	if destination == "/" || !d.Check(destination) {
+		return http.StatusForbidden, nil
+	}
+
+	if r.URL.Query().Get("rename") == "true" {
+		destination = addVersionSuffix(destination, d.user.Fs)
+	} else if r.URL.Query().Get("override") != "true" {
+		if _, statErr := d.user.Fs.Stat(destination); statErr == nil {
+			return http.StatusConflict, os.ErrExist
+		}
+	}
+
+	response := archiveExtractResponse{Destination: destination}
+	err = d.RunHook(func() error {
+		extracted, extractErr := extractArchiveTo(r.Context(), d, archivePath, inner, destination, r.URL.Query().Get("override") == "true")
+		response.Extracted = extracted
+		return extractErr
+	}, "upload", archivePath, destination, d.user)
+	if err != nil {
+		return errToStatus(err), err
+	}
+
+	return renderJSON(w, r, response)
+})
+
+func extractArchiveTo(ctx context.Context, d *data, archivePath, inner, destination string, override bool) (int, error) {
+	opened, err := openArchive(ctx, archivePath, d)
+	if err != nil {
+		return 0, err
+	}
+	defer opened.close()
+
+	extracted := 0
+	found := inner == "."
+
+	err = opened.extractor.Extract(ctx, opened.stream, func(ctx context.Context, entry archives.FileInfo) error {
+		entryPath, cleanErr := archiveEntryPath(entry.NameInArchive)
+		if cleanErr != nil || entryPath == "." {
+			return nil
+		}
+
+		rel := ""
+		if inner == "." {
+			rel = entryPath
+		} else if entryPath == inner {
+			found = true
+			rel = gopath.Base(entryPath)
+		} else {
+			prefix := inner + "/"
+			if !strings.HasPrefix(entryPath, prefix) {
+				return nil
+			}
+			found = true
+			rel = strings.TrimPrefix(entryPath, prefix)
+		}
+		if rel == "" || rel == "." {
+			return nil
+		}
+
+		rel, cleanErr = cleanArchiveInnerPath(rel)
+		if cleanErr != nil || rel == "." {
+			return nil
+		}
+
+		target := gopath.Clean(gopath.Join(destination, rel))
+		if target == destination || !strings.HasPrefix(target, destination+"/") {
+			return fmt.Errorf("unsafe extraction target: %w", fberrors.ErrInvalidRequestParams)
+		}
+		if !d.Check(target) {
+			return fberrors.ErrPermissionDenied
+		}
+
+		mode := os.FileMode(0)
+		entryIsDir := strings.HasSuffix(strings.ReplaceAll(entry.NameInArchive, "\\", "/"), "/")
+		if entry.FileInfo != nil {
+			mode = entry.FileInfo.Mode()
+			entryIsDir = entryIsDir || entry.FileInfo.IsDir()
+		}
+		if mode&os.ModeSymlink != 0 || mode&os.ModeIrregular != 0 || mode&os.ModeNamedPipe != 0 || mode&os.ModeDevice != 0 {
+			return nil
+		}
+
+		if entryIsDir {
+			if err := d.user.Fs.MkdirAll(target, d.settings.DirMode); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		if !override {
+			if _, err := d.user.Fs.Stat(target); err == nil {
+				return os.ErrExist
+			}
+		}
+		if err := d.user.Fs.MkdirAll(gopath.Dir(target), d.settings.DirMode); err != nil {
+			return err
+		}
+		if entry.Open == nil {
+			return nil
+		}
+		f, err := entry.Open()
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		if _, err := writeFile(d.user.Fs, target, f, d.settings.FileMode, d.settings.DirMode); err != nil {
+			return err
+		}
+		extracted++
+		return nil
+	})
+	if err != nil {
+		return extracted, err
+	}
+	if !found {
+		return extracted, os.ErrNotExist
+	}
+	return extracted, nil
+}

--- a/http/http.go
+++ b/http/http.go
@@ -57,6 +57,10 @@ func NewHandler(
 	users.Handle("/{id:[0-9]+}", monkey(userGetHandler, "")).Methods("GET")
 	users.Handle("/{id:[0-9]+}", monkey(userDeleteHandler, "")).Methods("DELETE")
 
+	api.PathPrefix("/archive/resources").Handler(monkey(archiveResourceHandler, "/api/archive/resources")).Methods("GET")
+	api.PathPrefix("/archive/raw").Handler(monkey(archiveRawHandler, "/api/archive/raw")).Methods("GET")
+	api.PathPrefix("/archive/extract").Handler(monkey(archiveExtractHandler, "/api/archive/extract")).Methods("POST")
+
 	api.PathPrefix("/resources/recursive").Handler(monkey(resourceGetRecursiveHandler, "/api/resources/recursive")).Methods("GET")
 	api.PathPrefix("/resources").Handler(monkey(resourceGetHandler, "/api/resources")).Methods("GET")
 	api.PathPrefix("/resources").Handler(monkey(resourceDeleteHandler(fileCache), "/api/resources")).Methods("DELETE")


### PR DESCRIPTION
# Changelog: Archive Browsing and Extraction Support

## Summary

This pull request adds archive support to File Browser so users can open supported archive files directly in the web UI, browse their contents like a virtual read-only folder, preview supported files inside the archive, download individual files from inside the archive, and explicitly extract archives or selected archive entries.

The implementation uses the existing `github.com/mholt/archives` dependency already present in the project, avoiding shelling out to external tools such as `unzip`, `tar`, `7z`, or `rar`.

## Added

### Archive browsing

Users can now open supported archive files from the normal file listing. When an archive is opened, File Browser displays its contents as a virtual folder structure.

Supported first-pass archive formats include:

- `.zip`
- `.tar`
- `.tar.gz`
- `.tgz`
- `.tar.bz2`
- `.tbz2`
- `.tar.xz`
- `.txz`
- `.tar.zst`
- `.tzst`
- `.7z`
- `.rar`

Archive browsing uses URL query state instead of treating archive entries as real filesystem paths. Example:

```text
/files/frontend.zip?archive=/frontend/src/
```

This keeps archive paths separate from real filesystem paths and avoids ambiguity between a real folder and a file inside an archive.

### Virtual archive API

A new archive API layer was added for listing, streaming, and extracting archive contents.

New API behavior:

```text
GET  /api/archive/list/<archive-path>?inner=<archive-inner-path>
GET  /api/archive/raw/<archive-path>?inner=<archive-inner-file>
POST /api/archive/extract/<archive-path>
```

The list endpoint returns archive contents in a resource-like shape so the existing frontend listing components can render archive folders and files with minimal changes.

The raw endpoint streams a single file from inside an archive so existing preview and download flows can work with archive entries.

The extract endpoint extracts either:

- the full selected archive when the user selects an archive file outside archive view
- a selected file or folder from inside an already-opened archive

### Preview support inside archives

Supported file types can now be previewed directly from inside archives, including:

- images
- audio/video
- PDF files
- CSV files
- text files
- source/config files

Preview URLs are routed through the new archive raw endpoint when the current view is inside an archive.

### Download support inside archives

Users can download individual files from inside an archive without extracting the full archive first.

When the selected item is inside an archive, the download action now targets the archive raw endpoint with the selected inner path.

### Extraction actions

The UI now exposes extraction actions in both toolbar and context-menu flows.

Outside an archive:

- selecting an archive file shows **Extract this archive**
- right-clicking an archive file shows **Extract this archive**

Inside an archive:

- selecting a file shows **Extract this file**
- selecting a folder shows **Extract this folder**
- right-clicking an archive entry shows the matching extract action
- previewing a file inside an archive also exposes **Extract this file**

Extraction is explicit. Opening or browsing an archive never writes files to disk.

## Changed

### Frontend routing

Archive state is represented by the `archive` query parameter.

Example:

```text
/files/frontend.zip?archive=/frontend/
```

This allows the existing file browser route to remain the main navigation entry point while distinguishing normal filesystem browsing from virtual archive browsing.

### Read-only behavior inside archives

Archive contents are treated as read-only.

The following write actions are disabled while browsing inside an archive:

- upload
- edit/save
- rename
- move
- copy into archive
- delete from archive

This prevents File Browser from implying that archive contents can be modified in place.

### Toolbar behavior

The toolbar now adapts depending on context:

- normal selected archive file: shows archive extraction action
- selected file inside archive: shows file extraction action
- selected folder inside archive: shows folder extraction action
- archive entries keep download behavior where valid

### Context menu behavior

The right-click menu now includes extraction actions for:

- archive files selected outside archive view
- files selected inside archive view
- folders selected inside archive view

### Breadcrumb behavior

Breadcrumbs now understand archive navigation and keep the archive file as the root of the virtual archive path.

## Security and safety

The archive implementation includes safeguards to reduce archive-related risks.

Implemented protections:

- archive browsing is read-only
- inner archive paths are normalized
- path traversal attempts are rejected
- unsafe `../` paths are blocked
- extraction validates output paths before writing
- extracted entries must remain inside the selected destination
- symlinks, device files, named pipes, sockets, and irregular files are skipped during extraction
- preview size is capped for text-like files
- archive file access still goes through File Browser's existing user permission model

Archive browsing and file streaming require the user to have permission to access/download the archive file itself.

## Files added

```text
http/archive.go
```

## Files modified

```text
files/file.go
files/utils.go
http/http.go

frontend/src/api/files.ts
frontend/src/types/file.d.ts
frontend/src/views/Files.vue
frontend/src/views/files/FileListing.vue
frontend/src/views/files/Preview.vue
frontend/src/views/files/Editor.vue
frontend/src/components/Breadcrumbs.vue
frontend/src/components/files/ListingItem.vue
frontend/src/css/listing-icons.css
```

## Implementation notes

The implementation reuses `github.com/mholt/archives`, which was already present in the project for archive creation/download functionality.

This keeps archive support inside the Go application and avoids relying on system-level binaries that may not be available in all deployments or containers.

Archive browsing is implemented as a virtual filesystem layer. Archive entries are not extracted during navigation.

Extraction remains a separate user-triggered operation.

## Validation performed

The following validation was performed during patch preparation:

- Go files were formatted with `gofmt`
- the generated source archive was checked for ZIP integrity
- the full patch applies cleanly to the original source tree
- the incremental UI patch applies cleanly to the previous archive-support version

## Validation not performed

A full local build/test run was not completed in the sandbox environment because this File Browser source requires Go `>= 1.25.0`, while the available sandbox Go version is older and external toolchain download is blocked.

Recommended maintainer-side validation:

```bash
go test ./...
npm install
npm run build
```

or the equivalent frontend package-manager commands used by the project.

## User-facing result

After this change, users can:

1. click an archive file to open it
2. browse folders inside the archive
3. preview supported files inside the archive
4. download individual files from inside the archive
5. extract a full archive from the normal file list
6. extract a selected file or folder while browsing inside an archive
