### PR TITLE
chore: Antivirus support for Filebrowser

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,7 +9,15 @@
     />
 
     [{[ if .ReCaptcha -]}]
-    <script src="[{[ .ReCaptchaHost ]}]/recaptcha/api.js?render=explicit"></script>
+    <script>
+      (() => {
+        const script = document.createElement("script");
+        script.src = "[{[ .ReCaptchaHost ]}]/recaptcha/api.js?render=explicit";
+        script.async = true;
+        script.defer = true;
+        document.head.appendChild(script);
+      })();
+    </script>
     [{[ end ]}]
 
     <title>

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -10,3 +10,11 @@ export async function update(settings: ISettings) {
     body: JSON.stringify(settings),
   });
 }
+
+
+export async function testClamAV(config: SettingsClamAV) {
+  return fetchJSON<ClamAVTestResponse>(`/api/settings/clamav/test`, {
+    method: "POST",
+    body: JSON.stringify(config),
+  });
+}

--- a/frontend/src/api/tus.ts
+++ b/frontend/src/api/tus.ts
@@ -42,8 +42,9 @@ export async function upload(
           ? err.originalResponse.getStatus()
           : 0;
 
-        // Do not retry for file conflict.
-        if (status === 409) {
+        // Do not retry client-side failures such as file conflict,
+        // permission errors, or antivirus blocks.
+        if (status >= 400 && status < 500) {
           return false;
         }
 

--- a/frontend/src/components/CustomToast.vue
+++ b/frontend/src/components/CustomToast.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="t-container">
-    <span>{{ message }}</span>
+    <span class="toast-message-text">{{ message }}</span>
     <button v-if="isReport" class="action" @click.stop="clicked">
       {{ reportText }}
     </button>
@@ -27,6 +27,19 @@ const clicked = () => {
   justify-content: space-between;
   align-items: center;
 }
+.toast-message-text {
+  white-space: normal;
+  line-height: 1.25;
+  font-size: 1rem;
+  text-align: left;
+  margin: 0;
+  display: inline;
+  width: auto;
+  color: inherit;
+  font-weight: inherit;
+}
+
+
 .action {
   text-align: center;
   height: 40px;

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -278,7 +278,16 @@
     "userUpdated": "تم تعديل المستخدم",
     "username": "إسم المستخدم",
     "users": "المستخدمين",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "مساعدة",

--- a/frontend/src/i18n/bg.json
+++ b/frontend/src/i18n/bg.json
@@ -278,7 +278,16 @@
     "userUpdated": "Потребителя е обновен!",
     "username": "Потребителско име",
     "users": "Потребители",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Помощ",

--- a/frontend/src/i18n/ca.json
+++ b/frontend/src/i18n/ca.json
@@ -278,7 +278,16 @@
     "userUpdated": "Usuari actualitzat!",
     "username": "Usuari",
     "users": "Usuaris",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Ajuda",

--- a/frontend/src/i18n/cs.json
+++ b/frontend/src/i18n/cs.json
@@ -278,7 +278,16 @@
     "userUpdated": "Uživatel aktualizován!",
     "username": "Uživatelské jméno",
     "users": "Uživatelé",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Nápověda",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -280,7 +280,16 @@
     "userUpdated": "Benutzer aktualisiert!",
     "username": "Benutzername",
     "users": "Benutzer",
-    "currentPassword": "Dein aktuelles Passwort"
+    "currentPassword": "Dein aktuelles Passwort",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "diskUsed": "{used} of {total} used",

--- a/frontend/src/i18n/el.json
+++ b/frontend/src/i18n/el.json
@@ -278,7 +278,16 @@
     "userUpdated": "Ο χρήστης ενημερώθηκε!",
     "username": "Όνομα χρήστη",
     "users": "Χρήστες",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Βοήθεια",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -280,7 +280,16 @@
     "userUpdated": "User updated!",
     "username": "Username",
     "users": "Users",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "diskUsed": "{used} of {total} used",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -278,7 +278,16 @@
     "userUpdated": "¡Usuario actualizado!",
     "username": "Usuario",
     "users": "Usuarios",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Ayuda",

--- a/frontend/src/i18n/fa.json
+++ b/frontend/src/i18n/fa.json
@@ -278,7 +278,16 @@
     "userUpdated": "کاربر به روز شد!",
     "username": "نام کاربری",
     "users": "کاربران",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "راهنما",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -280,7 +280,16 @@
     "userUpdated": "Utilisateur mis à jour !",
     "username": "Nom d'utilisateur",
     "users": "Utilisateurs",
-    "currentPassword": "Mot de Passe Actuel"
+    "currentPassword": "Mot de Passe Actuel",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "diskUsed": "{used} of {total} used",

--- a/frontend/src/i18n/he.json
+++ b/frontend/src/i18n/he.json
@@ -278,7 +278,16 @@
     "userUpdated": "המשתמש עודכן!",
     "username": "שם משתמש",
     "users": "משתמשים",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "עזרה",

--- a/frontend/src/i18n/hr.json
+++ b/frontend/src/i18n/hr.json
@@ -280,7 +280,16 @@
     "userUpdated": "Korisnik ažuriran!",
     "username": "Korisničko ime",
     "users": "Korisnici",
-    "currentPassword": "Vaša trenutna lozinka"
+    "currentPassword": "Vaša trenutna lozinka",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "diskUsed": "{used} of {total} used",

--- a/frontend/src/i18n/hu.json
+++ b/frontend/src/i18n/hu.json
@@ -278,7 +278,16 @@
     "userUpdated": "Felhasználó frissítve!",
     "username": "Felhasználói név",
     "users": "Felhasználók",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Súgó",

--- a/frontend/src/i18n/is.json
+++ b/frontend/src/i18n/is.json
@@ -278,7 +278,16 @@
     "userUpdated": "Notandastillingar vistaðar!",
     "username": "Notendanafn",
     "users": "Notendur",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Hjálp",

--- a/frontend/src/i18n/it.json
+++ b/frontend/src/i18n/it.json
@@ -278,7 +278,16 @@
     "userUpdated": "Utente aggiornato!",
     "username": "Nome utente",
     "users": "Utenti",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Aiuto",

--- a/frontend/src/i18n/ja.json
+++ b/frontend/src/i18n/ja.json
@@ -278,7 +278,16 @@
     "userUpdated": "ユーザーを更新しました！",
     "username": "ユーザー名",
     "users": "ユーザー",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "ヘルプ",

--- a/frontend/src/i18n/ko.json
+++ b/frontend/src/i18n/ko.json
@@ -280,7 +280,16 @@
     "userUpdated": "사용자 수정됨!",
     "username": "사용자 이름",
     "users": "사용자",
-    "currentPassword": "현재 비밀번호"
+    "currentPassword": "현재 비밀번호",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "diskUsed": "{used} of {total} used",

--- a/frontend/src/i18n/lv.json
+++ b/frontend/src/i18n/lv.json
@@ -280,7 +280,16 @@
     "userUpdated": "Lietotājs atjaunināts!",
     "username": "Lietotājvārds",
     "users": "Lietotāji",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "diskUsed": "{used} of {total} used",

--- a/frontend/src/i18n/nl-be.json
+++ b/frontend/src/i18n/nl-be.json
@@ -278,7 +278,16 @@
     "userUpdated": "Gebruiker bijgewerkt!",
     "username": "Gebruikersnaam",
     "users": "Gebruikers",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Help",

--- a/frontend/src/i18n/nl.json
+++ b/frontend/src/i18n/nl.json
@@ -280,7 +280,16 @@
     "userUpdated": "Gebruiker bijgewerkt!",
     "username": "Gebruikersnaam",
     "users": "Gebruikers",
-    "currentPassword": "Uw huidige wachtwoord"
+    "currentPassword": "Uw huidige wachtwoord",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "diskUsed": "{used} van {total} gebruikt",

--- a/frontend/src/i18n/no.json
+++ b/frontend/src/i18n/no.json
@@ -278,7 +278,16 @@
     "userUpdated": "Bruker opprettet!",
     "username": "Brukernavn",
     "users": "Bruker",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Hjelp",

--- a/frontend/src/i18n/pl.json
+++ b/frontend/src/i18n/pl.json
@@ -280,7 +280,16 @@
     "userUpdated": "Użytkownik zapisany!",
     "username": "Nazwa użytkownika",
     "users": "Użytkownicy",
-    "currentPassword": "Twoje aktualne hasło"
+    "currentPassword": "Twoje aktualne hasło",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "diskUsed": "Wykorzystano {used} z {total}",

--- a/frontend/src/i18n/pt-br.json
+++ b/frontend/src/i18n/pt-br.json
@@ -278,7 +278,16 @@
     "userUpdated": "Usuário atualizado!",
     "username": "Nome do usuário",
     "users": "Usuários",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Ajuda",

--- a/frontend/src/i18n/pt-pt.json
+++ b/frontend/src/i18n/pt-pt.json
@@ -280,7 +280,16 @@
     "userUpdated": "Utilizador actualizado!",
     "username": "Nome de utilizador",
     "users": "Utilizadores",
-    "currentPassword": "A Sua Palavra-passe Actual"
+    "currentPassword": "A Sua Palavra-passe Actual",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "diskUsed": "{used} of {total} used",

--- a/frontend/src/i18n/pt.json
+++ b/frontend/src/i18n/pt.json
@@ -280,7 +280,16 @@
     "userUpdated": "Utilizador atualizado!",
     "username": "Nome de utilizador",
     "users": "Utilizadores",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "diskUsed": "{used} of {total} used",

--- a/frontend/src/i18n/ro.json
+++ b/frontend/src/i18n/ro.json
@@ -278,7 +278,16 @@
     "userUpdated": "Utilizator actualizat!",
     "username": "Utilizator",
     "users": "Utilizatori",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Ajutor",

--- a/frontend/src/i18n/ru.json
+++ b/frontend/src/i18n/ru.json
@@ -280,7 +280,16 @@
     "userUpdated": "Пользователь изменен!",
     "username": "Имя пользователя",
     "users": "Пользователи",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "diskUsed": "{used} of {total} used",

--- a/frontend/src/i18n/sk.json
+++ b/frontend/src/i18n/sk.json
@@ -278,7 +278,16 @@
     "userUpdated": "Používateľ upravený!",
     "username": "Meno používateľa",
     "users": "Používatelia",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Pomoc",

--- a/frontend/src/i18n/sv-se.json
+++ b/frontend/src/i18n/sv-se.json
@@ -278,7 +278,16 @@
     "userUpdated": "Användare uppdaterad!",
     "username": "Användarnamn",
     "users": "Användare",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Hjälp",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -278,7 +278,16 @@
     "userUpdated": "Kullanıcı güncellendi!",
     "username": "Kullanıcı adı",
     "users": "Kullanıcılar",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Yardım",

--- a/frontend/src/i18n/uk.json
+++ b/frontend/src/i18n/uk.json
@@ -278,7 +278,16 @@
     "userUpdated": "Користувача змінено!",
     "username": "Ім'я користувача",
     "users": "Користувачі",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Допомога",

--- a/frontend/src/i18n/vi.json
+++ b/frontend/src/i18n/vi.json
@@ -278,7 +278,16 @@
     "userUpdated": "Người dùng đã được cập nhật!",
     "username": "Tên người dùng",
     "users": "Người dùng",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "Trợ giúp",

--- a/frontend/src/i18n/zh-cn.json
+++ b/frontend/src/i18n/zh-cn.json
@@ -280,7 +280,16 @@
     "userUpdated": "用户已更新！",
     "username": "用户名",
     "users": "用户",
-    "currentPassword": "您当前的密码"
+    "currentPassword": "您当前的密码",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "diskUsed": "{used} of {total} used",

--- a/frontend/src/i18n/zh-tw.json
+++ b/frontend/src/i18n/zh-tw.json
@@ -278,7 +278,16 @@
     "userUpdated": "使用者已更新！",
     "username": "使用者名稱",
     "users": "使用者",
-    "currentPassword": "Your Current Password"
+    "currentPassword": "Your Current Password",
+    "clamavScanning": "ClamAV scanning",
+    "clamavScanningHelp": "Scan every uploaded file with a ClamAV HTTP scanning service before the upload is accepted. The scanner endpoint receives the uploaded file as multipart form field FILES.",
+    "clamavEnable": "Enable ClamAV scanning for uploads",
+    "clamavUrl": "ClamAV scan URL",
+    "clamavScanDepth": "Scan depth",
+    "clamavScanDepthHelp": "Optional. File Browser sends this as X-ClamAV-Scan-Depth. Most ClamAV services control archive recursion on the scanner server through MaxRecursion, so leave this as 0 unless your scan API supports this header.",
+    "clamavTestConnection": "Test connection",
+    "clamavTesting": "Testing...",
+    "clamavConnectionSuccessful": "ClamAV connection successful"
   },
   "sidebar": {
     "help": "幫助",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -83,14 +83,36 @@ app.provide("$showSuccess", (message: string) => {
   );
 });
 
+const normalizeErrorToast = (error: Error | string, displayReport: boolean) => {
+  let message = String((error as Error).message || error || "");
+
+  const statusWrappedMessage = message.match(
+    /^\s*\d{3}\s+[^()]*\(([\s\S]*Security scan blocked the upload[\s\S]*)\)\s*$/
+  );
+  if (statusWrappedMessage?.[1]) {
+    message = statusWrappedMessage[1].trim();
+  }
+
+  const isSecurityScanBlock = message.includes(
+    "Security scan blocked the upload"
+  );
+
+  return {
+    message,
+    isReport: !disableExternal && displayReport && !isSecurityScanBlock,
+  };
+};
+
 app.provide("$showError", (error: Error | string, displayReport = true) => {
   const $toast = useToast();
+  const normalized = normalizeErrorToast(error, displayReport);
+
   $toast.error(
     {
       component: CustomToast,
       props: {
-        message: (error as Error).message || error,
-        isReport: !disableExternal && displayReport,
+        message: normalized.message,
+        isReport: normalized.isReport,
         // TODO: could you add this to the component itself?
         reportText: i18n.global.t("buttons.reportIssue"),
       },

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -9,6 +9,7 @@ interface ISettings {
   rules: any[];
   branding: SettingsBranding;
   tus: SettingsTus;
+  clamav: SettingsClamAV;
   shell: string[];
   commands: SettingsCommand;
 }
@@ -39,6 +40,17 @@ interface SettingsBranding {
 interface SettingsTus {
   chunkSize: number;
   retryCount: number;
+}
+
+interface SettingsClamAV {
+  enabled: boolean;
+  url: string;
+  scanDepth: number;
+}
+
+interface ClamAVTestResponse {
+  status: string;
+  message: string;
 }
 
 interface SettingsCommand {

--- a/frontend/src/views/settings/Global.vue
+++ b/frontend/src/views/settings/Global.vue
@@ -153,6 +153,62 @@
               />
             </p>
           </div>
+
+
+
+          <h3>{{ t("settings.clamavScanning") }}</h3>
+
+          <p class="small">{{ t("settings.clamavScanningHelp") }}</p>
+
+          <p>
+            <input
+              type="checkbox"
+              v-model="settings.clamav.enabled"
+              id="clamav-enabled"
+            />
+            {{ t("settings.clamavEnable") }}
+          </p>
+
+          <p>
+            <label for="clamav-url">{{ t("settings.clamavUrl") }}</label>
+            <input
+              class="input input--block"
+              type="text"
+              v-model.trim="settings.clamav.url"
+              id="clamav-url"
+              placeholder="http://192.168.68.144:3000/api/v1/scan"
+            />
+          </p>
+
+          <p>
+            <label for="clamav-scan-depth">{{
+              t("settings.clamavScanDepth")
+            }}</label>
+            <vue-number-input
+              controls
+              v-model.number="settings.clamav.scanDepth"
+              id="clamav-scan-depth"
+              :min="0"
+            />
+          </p>
+
+          <p class="small">{{ t("settings.clamavScanDepthHelp") }}</p>
+
+          <p>
+            <button
+              class="button button--flat"
+              type="button"
+              @click.prevent="testClamAV"
+              :disabled="clamAVTesting || !settings.clamav.url"
+            >
+              {{
+                clamAVTesting
+                  ? t("settings.clamavTesting")
+                  : t("settings.clamavTestConnection")
+              }}
+            </button>
+          </p>
+
         </div>
 
         <div class="card-action">
@@ -262,6 +318,7 @@ const error = ref<StatusError | null>(null);
 const originalSettings = ref<ISettings | null>(null);
 const settings = ref<ISettings | null>(null);
 const debounceTimeout = ref<number | null>(null);
+const clamAVTesting = ref(false);
 
 const commandObject = ref<{
   [key: string]: string[] | string;
@@ -307,6 +364,23 @@ const capitalize = (name: string, where: string | RegExp = "_") => {
   }
 
   return name.slice(0, -1);
+};
+
+
+const testClamAV = async () => {
+  if (settings.value === null) return false;
+
+  try {
+    clamAVTesting.value = true;
+    const result = await api.testClamAV(settings.value.clamav);
+    $showSuccess(result.message || t("settings.clamavConnectionSuccessful"));
+  } catch (e: any) {
+    $showError(e);
+  } finally {
+    clamAVTesting.value = false;
+  }
+
+  return true;
 };
 
 const save = async () => {
@@ -397,6 +471,9 @@ onMounted(async () => {
     layoutStore.loading = true;
     const original: ISettings = await api.get();
     const newSettings: ISettings = { ...original, commands: {} };
+    if (!newSettings.clamav) {
+      newSettings.clamav = { enabled: false, url: "", scanDepth: 0 };
+    }
 
     const keys = Object.keys(original.commands) as Array<keyof SettingsCommand>;
     for (const key of keys) {

--- a/http/clamav.go
+++ b/http/clamav.go
@@ -1,0 +1,386 @@
+package fbhttp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/afero"
+
+	"github.com/filebrowser/filebrowser/v2/settings"
+)
+
+const (
+	clamAVUploadField = "FILES"
+	clamAVTimeout     = 10 * time.Minute
+)
+
+type clamAVThreatError struct {
+	FileName string
+	Threat   string
+	Details  string
+}
+
+func (e *clamAVThreatError) Error() string {
+	fileName := strings.TrimSpace(e.FileName)
+	if fileName == "" {
+		fileName = "uploaded file"
+	}
+
+	threat := cleanClamAVMessage(e.Threat, fileName)
+	details := cleanClamAVMessage(e.Details, fileName)
+
+	switch {
+	case threat != "":
+		return fmt.Sprintf("Security scan blocked the upload. Malware was detected in %q. Threat: %s. The file was removed and was not saved.", fileName, threat)
+	case details != "":
+		return fmt.Sprintf("Security scan blocked the upload. Malware was detected in %q. Scanner details: %s. The file was removed and was not saved.", fileName, details)
+	default:
+		return fmt.Sprintf("Security scan blocked the upload. Malware was detected in %q. The file was removed and was not saved.", fileName)
+	}
+}
+
+type clamAVServiceError struct {
+	Message string
+}
+
+func (e *clamAVServiceError) Error() string {
+	return "ClamAV scan failed: " + e.Message
+}
+
+func clamAVHTTPStatus(err error) int {
+	var threat *clamAVThreatError
+	if errors.As(err, &threat) {
+		return http.StatusBadRequest
+	}
+
+	var svc *clamAVServiceError
+	if errors.As(err, &svc) {
+		return http.StatusBadGateway
+	}
+
+	return errToStatus(err)
+}
+
+func scanUploadedFile(ctx context.Context, fs afero.Fs, filePath string, cfg settings.ClamAV) error {
+	if !cfg.Enabled {
+		return nil
+	}
+
+	if strings.TrimSpace(cfg.URL) == "" {
+		return &clamAVServiceError{Message: "scanner is enabled but no ClamAV URL is configured"}
+	}
+
+	file, err := fs.Open(filePath)
+	if err != nil {
+		return &clamAVServiceError{Message: fmt.Sprintf("could not open uploaded file for scanning: %v", err)}
+	}
+	defer file.Close()
+
+	return scanWithClamAV(ctx, cfg, filepath.Base(filePath), file)
+}
+
+func testClamAVConnection(ctx context.Context, cfg settings.ClamAV) error {
+	if strings.TrimSpace(cfg.URL) == "" {
+		return &clamAVServiceError{Message: "no ClamAV URL is configured"}
+	}
+
+	return scanWithClamAV(ctx, cfg, "filebrowser-clamav-test.txt", strings.NewReader("filebrowser ClamAV connectivity test\n"))
+}
+
+func scanWithClamAV(ctx context.Context, cfg settings.ClamAV, filename string, reader io.Reader) error {
+	endpoint := strings.TrimSpace(cfg.URL)
+	if endpoint == "" {
+		return &clamAVServiceError{Message: "no ClamAV URL is configured"}
+	}
+
+	bodyReader, bodyWriter := io.Pipe()
+	multipartWriter := multipart.NewWriter(bodyWriter)
+
+	go func() {
+		defer bodyWriter.Close()
+
+		part, err := multipartWriter.CreateFormFile(clamAVUploadField, filename)
+		if err != nil {
+			_ = bodyWriter.CloseWithError(err)
+			return
+		}
+
+		if _, err = io.Copy(part, reader); err != nil {
+			_ = bodyWriter.CloseWithError(err)
+			return
+		}
+
+		if err = multipartWriter.Close(); err != nil {
+			_ = bodyWriter.CloseWithError(err)
+			return
+		}
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bodyReader)
+	if err != nil {
+		return &clamAVServiceError{Message: err.Error()}
+	}
+
+	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+	req.Header.Set("Accept", "application/json, text/plain;q=0.9, */*;q=0.8")
+	if cfg.ScanDepth > 0 {
+		// Most HTTP ClamAV wrappers ignore per-request recursion settings because
+		// ClamAV normally controls archive recursion server-side through MaxRecursion.
+		// Sending this as a header keeps compatibility with APIs that reject extra
+		// multipart fields while still allowing wrappers that support scan depth to use it.
+		req.Header.Set("X-ClamAV-Scan-Depth", strconv.Itoa(cfg.ScanDepth))
+	}
+
+	client := &http.Client{Timeout: clamAVTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return &clamAVServiceError{Message: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return &clamAVServiceError{Message: fmt.Sprintf("could not read scanner response: %v", err)}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		if threat := evaluateClamAVResponse(filename, body); threat != nil {
+			return threat
+		}
+
+		message := strings.TrimSpace(string(body))
+		if message == "" {
+			message = resp.Status
+		} else {
+			message = resp.Status + ": " + message
+		}
+		return &clamAVServiceError{Message: message}
+	}
+
+	return evaluateClamAVResponse(filename, body)
+}
+
+func evaluateClamAVResponse(filename string, body []byte) error {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return nil
+	}
+
+	var parsed any
+	if err := json.Unmarshal(trimmed, &parsed); err == nil {
+		if infected, threat, details := jsonContainsInfection(parsed); infected {
+			return &clamAVThreatError{FileName: filename, Threat: threat, Details: details}
+		}
+
+		if success, ok := jsonBoolField(parsed, "success"); ok && !success {
+			message := firstJSONString(parsed, "message", "error", "detail")
+			if message == "" {
+				message = string(trimmed)
+			}
+			return &clamAVServiceError{Message: message}
+		}
+
+		return nil
+	}
+
+	upper := strings.ToUpper(string(trimmed))
+	if strings.Contains(upper, "FOUND") || strings.Contains(upper, "INFECTED") {
+		return &clamAVThreatError{FileName: filename, Threat: extractClamAVTextThreat(string(trimmed)), Details: string(trimmed)}
+	}
+
+	return nil
+}
+
+func jsonContainsInfection(value any) (bool, string, string) {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, raw := range v {
+			normalized := normalizeClamAVKey(key)
+			if isInfectionBoolKey(normalized) {
+				if infected, ok := raw.(bool); ok && infected {
+					return true, bestJSONThreat(v), firstJSONString(v, "message", "error", "detail", "details", "result", "scan_result")
+				}
+			}
+
+			if isThreatFieldKey(normalized) {
+				if threat := stringFromJSONValue(raw); threat != "" {
+					return true, threat, firstJSONString(v, "message", "error", "detail", "details", "result", "scan_result")
+				}
+			}
+
+			if infected, threat, details := jsonContainsInfection(raw); infected {
+				if threat == "" {
+					threat = bestJSONThreat(v)
+				}
+				if details == "" {
+					details = firstJSONString(v, "message", "error", "detail", "details", "result", "scan_result")
+				}
+				return true, threat, details
+			}
+		}
+	case []any:
+		for _, item := range v {
+			if infected, threat, details := jsonContainsInfection(item); infected {
+				return true, threat, details
+			}
+		}
+	}
+
+	return false, "", ""
+}
+
+func isInfectionBoolKey(key string) bool {
+	switch key {
+	case "is_infected", "infected", "virus_found", "malware_found", "malicious", "found":
+		return true
+	default:
+		return false
+	}
+}
+
+func isThreatFieldKey(key string) bool {
+	switch key {
+	case "virus", "viruses", "signature", "signatures", "threat", "threats", "malware", "malwares", "virus_name", "threat_name":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeClamAVKey(key string) string {
+	key = strings.ToLower(strings.TrimSpace(key))
+	key = strings.ReplaceAll(key, "-", "_")
+	key = strings.ReplaceAll(key, " ", "_")
+	return key
+}
+
+func bestJSONThreat(value any) string {
+	return firstJSONString(value, "virus", "viruses", "signature", "signatures", "threat", "threats", "malware", "malwares", "virus_name", "threat_name")
+}
+
+func stringFromJSONValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case []any:
+		items := make([]string, 0, len(v))
+		for _, item := range v {
+			if itemString := stringFromJSONValue(item); itemString != "" {
+				items = append(items, itemString)
+			}
+		}
+		return strings.Join(items, ", ")
+	case map[string]any:
+		return bestJSONThreat(v)
+	default:
+		return ""
+	}
+}
+
+func cleanClamAVMessage(message string, fileName string) string {
+	message = strings.TrimSpace(message)
+	message = strings.Trim(message, "\r\n\t ")
+	message = strings.Trim(message, "\"'")
+	message = strings.TrimSpace(message)
+
+	if message == "" {
+		return ""
+	}
+
+	if fileName != "" {
+		trimmedFile := strings.TrimSpace(fileName)
+		if strings.EqualFold(message, trimmedFile) || strings.EqualFold(message, trimmedFile+":"+trimmedFile) {
+			return ""
+		}
+	}
+
+	return message
+}
+
+func extractClamAVTextThreat(message string) string {
+	message = strings.TrimSpace(message)
+	upper := strings.ToUpper(message)
+	idx := strings.LastIndex(upper, " FOUND")
+	if idx < 0 {
+		return ""
+	}
+
+	prefix := strings.TrimSpace(message[:idx])
+	if prefix == "" {
+		return ""
+	}
+
+	if colon := strings.LastIndex(prefix, ":"); colon >= 0 && colon+1 < len(prefix) {
+		return strings.TrimSpace(prefix[colon+1:])
+	}
+
+	fields := strings.Fields(prefix)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[len(fields)-1]
+}
+
+func jsonBoolField(value any, field string) (bool, bool) {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, raw := range v {
+			if strings.EqualFold(key, field) {
+				b, ok := raw.(bool)
+				return b, ok
+			}
+			if b, ok := jsonBoolField(raw, field); ok {
+				return b, ok
+			}
+		}
+	case []any:
+		for _, item := range v {
+			if b, ok := jsonBoolField(item, field); ok {
+				return b, ok
+			}
+		}
+	}
+
+	return false, false
+}
+
+func firstJSONString(value any, fields ...string) string {
+	fieldSet := map[string]struct{}{}
+	for _, field := range fields {
+		fieldSet[normalizeClamAVKey(field)] = struct{}{}
+	}
+
+	switch v := value.(type) {
+	case map[string]any:
+		for key, raw := range v {
+			if _, ok := fieldSet[normalizeClamAVKey(key)]; ok {
+				if message := stringFromJSONValue(raw); message != "" {
+					return message
+				}
+			}
+		}
+		for _, raw := range v {
+			if s := firstJSONString(raw, fields...); s != "" {
+				return s
+			}
+		}
+	case []any:
+		for _, item := range v {
+			if s := firstJSONString(item, fields...); s != "" {
+				return s
+			}
+		}
+	}
+
+	return ""
+}

--- a/http/http.go
+++ b/http/http.go
@@ -78,6 +78,7 @@ func NewHandler(
 
 	api.Handle("/settings", monkey(settingsGetHandler, "")).Methods("GET")
 	api.Handle("/settings", monkey(settingsPutHandler, "")).Methods("PUT")
+	api.Handle("/settings/clamav/test", monkey(settingsClamAVTestHandler, "")).Methods("POST")
 
 	api.PathPrefix("/raw").Handler(monkey(rawHandler, "/api/raw")).Methods("GET")
 	api.PathPrefix("/preview/{size}/{path:.*}").

--- a/http/resource.go
+++ b/http/resource.go
@@ -165,6 +165,10 @@ func resourcePostHandler(fileCache FileCache) handleFunc {
 				return writeErr
 			}
 
+			if scanErr := scanUploadedFile(r.Context(), d.user.Fs, r.URL.Path, d.settings.ClamAV); scanErr != nil {
+				return scanErr
+			}
+
 			etag := fmt.Sprintf(`"%x%x"`, info.ModTime().UnixNano(), info.Size())
 			w.Header().Set("ETag", etag)
 			return nil
@@ -174,7 +178,7 @@ func resourcePostHandler(fileCache FileCache) handleFunc {
 			_ = d.user.Fs.RemoveAll(r.URL.Path)
 		}
 
-		return errToStatus(err), err
+		return clamAVHTTPStatus(err), err
 	})
 }
 

--- a/http/settings.go
+++ b/http/settings.go
@@ -2,6 +2,8 @@ package fbhttp
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 
 	"github.com/filebrowser/filebrowser/v2/rules"
@@ -19,6 +21,7 @@ type settingsData struct {
 	Rules                 []rules.Rule          `json:"rules"`
 	Branding              settings.Branding     `json:"branding"`
 	Tus                   settings.Tus          `json:"tus"`
+	ClamAV                settings.ClamAV       `json:"clamav"`
 	Shell                 []string              `json:"shell"`
 	Commands              map[string][]string   `json:"commands"`
 }
@@ -35,6 +38,7 @@ var settingsGetHandler = withAdmin(func(w http.ResponseWriter, r *http.Request, 
 		Rules:                 d.settings.Rules,
 		Branding:              d.settings.Branding,
 		Tus:                   d.settings.Tus,
+		ClamAV:                d.settings.ClamAV,
 		Shell:                 d.settings.Shell,
 		Commands:              d.settings.Commands,
 	}
@@ -57,10 +61,32 @@ var settingsPutHandler = withAdmin(func(_ http.ResponseWriter, r *http.Request, 
 	d.settings.Rules = req.Rules
 	d.settings.Branding = req.Branding
 	d.settings.Tus = req.Tus
+	d.settings.ClamAV = req.ClamAV
 	d.settings.Shell = req.Shell
 	d.settings.Commands = req.Commands
 	d.settings.HideLoginButton = req.HideLoginButton
 
 	err = d.store.Settings.Save(d.settings)
 	return errToStatus(err), err
+})
+
+var settingsClamAVTestHandler = withAdmin(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
+	cfg := d.settings.ClamAV
+
+	if r.Body != nil {
+		defer r.Body.Close()
+		decoder := json.NewDecoder(r.Body)
+		if err := decoder.Decode(&cfg); err != nil && !errors.Is(err, io.EOF) {
+			return http.StatusBadRequest, err
+		}
+	}
+
+	if err := testClamAVConnection(r.Context(), cfg); err != nil {
+		return clamAVHTTPStatus(err), err
+	}
+
+	return renderJSON(w, r, map[string]string{
+		"status":  "OK",
+		"message": "ClamAV connection successful",
+	})
 })

--- a/http/static.go
+++ b/http/static.go
@@ -49,6 +49,7 @@ func handleWithStaticData(w http.ResponseWriter, _ *http.Request, d *data, fSys 
 		"ResizePreview":         d.server.ResizePreview,
 		"EnableExec":            d.server.EnableExec,
 		"TusSettings":           d.settings.Tus,
+		"ClamAVSettings":        d.settings.ClamAV,
 		"HideLoginButton":       d.settings.HideLoginButton,
 	}
 

--- a/http/tus_handlers.go
+++ b/http/tus_handlers.go
@@ -207,7 +207,12 @@ func tusPatchHandler(cache UploadCache) handleFunc {
 		if err != nil {
 			return http.StatusInternalServerError, fmt.Errorf("could not open file: %w", err)
 		}
-		defer openFile.Close()
+		fileClosed := false
+		defer func() {
+			if !fileClosed {
+				_ = openFile.Close()
+			}
+		}()
 
 		_, err = openFile.Seek(uploadOffset, 0)
 		if err != nil {
@@ -230,6 +235,17 @@ func tusPatchHandler(cache UploadCache) handleFunc {
 		w.Header().Set("Upload-Offset", strconv.FormatInt(newOffset, 10))
 
 		if newOffset >= uploadLength {
+			if err := openFile.Close(); err != nil {
+				return http.StatusInternalServerError, fmt.Errorf("could not close uploaded file: %w", err)
+			}
+			fileClosed = true
+
+			if scanErr := scanUploadedFile(r.Context(), d.user.Fs, r.URL.Path, d.settings.ClamAV); scanErr != nil {
+				cache.Complete(file.RealPath())
+				_ = d.user.Fs.RemoveAll(r.URL.Path)
+				return clamAVHTTPStatus(scanErr), scanErr
+			}
+
 			cache.Complete(file.RealPath())
 			_ = d.RunHook(func() error { return nil }, "upload", r.URL.Path, "", d.user)
 		}

--- a/settings/clamav.go
+++ b/settings/clamav.go
@@ -1,0 +1,8 @@
+package settings
+
+// ClamAV contains upload antivirus scanning settings.
+type ClamAV struct {
+	Enabled   bool   `json:"enabled"`
+	URL       string `json:"url"`
+	ScanDepth int    `json:"scanDepth"`
+}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -31,6 +31,7 @@ type Settings struct {
 	LogoutPage            string              `json:"logoutPage"`
 	Branding              Branding            `json:"branding"`
 	Tus                   Tus                 `json:"tus"`
+	ClamAV                ClamAV              `json:"clamav"`
 	Commands              map[string][]string `json:"commands"`
 	Shell                 []string            `json:"shell"`
 	Rules                 []rules.Rule        `json:"rules"`

--- a/settings/storage.go
+++ b/settings/storage.go
@@ -1,6 +1,10 @@
 package settings
 
 import (
+	"os"
+	"strconv"
+	"strings"
+
 	fberrors "github.com/filebrowser/filebrowser/v2/errors"
 	"github.com/filebrowser/filebrowser/v2/rules"
 	"github.com/filebrowser/filebrowser/v2/users"
@@ -56,6 +60,15 @@ func (s *Storage) Get() (*Settings, error) {
 
 	if set.DirMode == 0 {
 		set.DirMode = DefaultDirMode
+	}
+
+	if set.ClamAV.URL == "" {
+		set.ClamAV.URL = strings.TrimSpace(os.Getenv("CLAMAV_URL"))
+	}
+	if set.ClamAV.ScanDepth == 0 {
+		if depth, err := strconv.Atoi(strings.TrimSpace(os.Getenv("CLAMAV_SCAN_DEPTH"))); err == nil && depth > 0 {
+			set.ClamAV.ScanDepth = depth
+		}
 	}
 
 	return set, nil


### PR DESCRIPTION
# File Browser ClamAV Upload Scanning

## Summary

This change adds optional ClamAV-based malware scanning for uploaded files in File Browser.

When enabled, every uploaded file is sent to a configured ClamAV HTTP scanning service before the upload is accepted. If the scanner reports malware, File Browser blocks the upload, removes the temporary file, and shows a clear security message to the user.

The feature is configurable from **Settings → Global Settings → Chunked Uploads → ClamAV scanning**.

## What the feature does

- Adds a global **ClamAV scanning** settings section.
- Allows an administrator to enable or disable upload scanning.
- Allows an administrator to configure the ClamAV HTTP scan endpoint.
- Adds a **Test connection** button in the settings UI.
- Supports optional scan depth through the `X-ClamAV-Scan-Depth` request header.
- Scans normal uploads before accepting them.
- Scans chunked/TUS uploads after the upload is complete and before final acceptance.
- Blocks infected uploads with a clear user-facing message.
- Prevents TUS/chunked uploads from retrying forever after a security block.
- Keeps upload scanning disabled by default unless explicitly enabled.

## User-facing behavior

If an uploaded file is clean, the upload continues normally.

If malware is detected, File Browser blocks the upload and displays a message similar to:

```text
Security scan blocked the upload. Malware was detected in "test.txt". Threat: Eicar-Test-Signature. The file was removed and was not saved.
```

If no threat name is returned by the scanner, the message is still clear:

```text
Security scan blocked the upload. Malware was detected in "test.txt". The file was removed and was not saved.
```

## Settings

The new global setting is stored as:

```json
{
  "clamav": {
    "enabled": true,
    "url": "http://clamav-api:3000/api/v1/scan",
    "scanDepth": 0
  }
}
```

### Environment defaults

The backend also supports environment defaults:

```yaml
CLAMAV_URL: "http://clamav-api:3000/api/v1/scan"
CLAMAV_SCAN_DEPTH: "0"
```

`CLAMAV_URL` provides the default scanner URL.

`CLAMAV_SCAN_DEPTH` provides the default scan depth value.

A scan depth value of `0` means File Browser does not request a custom recursion depth. In that case, recursion/depth behavior should be controlled by the ClamAV server configuration, for example through ClamAV settings such as `MaxRecursion`.

## Scanner API contract

File Browser sends the uploaded file to the configured scanner URL as a multipart HTTP request.

The multipart field name is:

```text
FILES
```

The scan depth is sent as an optional HTTP header:

```text
X-ClamAV-Scan-Depth: 5
```

The scanner API should return JSON indicating whether the file is infected. The implementation accepts common response styles such as:

```json
{
  "success": true,
  "is_infected": true,
  "filename": "test.txt",
  "viruses": ["Eicar-Test-Signature"]
}
```

or:

```json
{
  "success": true,
  "infected": true,
  "threat": "Eicar-Test-Signature"
}
```

A clean response can look like:

```json
{
  "success": true,
  "is_infected": false,
  "filename": "document.pdf"
}
```

## Example `docker-compose.yml`

The example below runs File Browser together with a ClamAV daemon and a ClamAV HTTP API wrapper.

Replace `your-clamav-api-image:latest` with the HTTP API image used in your environment. The important part is that the API accepts multipart uploads on `/api/v1/scan` using the `FILES` field and forwards the scan to `clamd`.

```yaml
services:
  filebrowser:
    image: filebrowser/filebrowser:latest
    container_name: filebrowser
    restart: unless-stopped
    ports:
      - "8080:80"
    volumes:
      - ./filebrowser-data:/database
      - ./filebrowser-config:/config
      - ./srv:/srv
    environment:
      # Default value shown in Settings → ClamAV scanning.
      # Can also be changed from the File Browser settings UI.
      CLAMAV_URL: "http://clamav-api:3000/api/v1/scan"

      # Optional. 0 means do not request custom scan depth.
      # ClamAV server-side defaults will be used.
      CLAMAV_SCAN_DEPTH: "0"
    depends_on:
      - clamav-api

  clamav:
    image: clamav/clamav:stable
    container_name: clamav
    restart: unless-stopped
    expose:
      - "3310"
    volumes:
      - clamav-db:/var/lib/clamav
    healthcheck:
      test: ["CMD-SHELL", "clamdscan --version || exit 1"]
      interval: 60s
      timeout: 10s
      retries: 5

  clamav-api:
    image: benzino77/clamav-rest-api:latest
    container_name: clamav-api
    restart: unless-stopped
    ports:
      - "3000:3000"
    environment:
      CLAMD_HOST: "clamav"
      CLAMD_PORT: "3310"
    depends_on:
      - clamav

volumes:
  clamav-db:
```

## Example external ClamAV API configuration


Inside File Browser, the same URL can also be configured from:

```text
Settings → Global Settings → Chunked Uploads → ClamAV scanning → ClamAV scan URL
```

## Test connection endpoint

A new backend endpoint is available for testing the scanner configuration from the UI:

```http
POST /api/settings/clamav/test
```

The UI calls this endpoint when the administrator presses **Test connection**.

The test verifies that File Browser can reach the configured ClamAV HTTP API and receives a valid scanner response.

## Upload flow

### Normal uploads

1. File Browser receives the uploaded file.
2. File Browser writes the upload to a temporary location.
3. If ClamAV scanning is enabled, File Browser sends the file to the configured scanner API.
4. If the file is clean, the upload is accepted.
5. If the file is infected, the upload is rejected and the temporary file is removed.

### Chunked/TUS uploads

1. File Browser receives chunks through the TUS upload flow.
2. After the upload is complete, File Browser scans the assembled file.
3. If the file is clean, the upload is finalized.
4. If the file is infected, the upload is rejected, temporary data is removed, and the frontend stops retrying the upload.

## Security notes

- Upload scanning is disabled by default.
- When enabled, infected files are blocked before being made available through File Browser.
- File Browser does not try to implement ClamAV itself. It delegates scanning to a dedicated ClamAV HTTP service.
- The HTTP scanner should be deployed on a trusted internal network.
- The scanner endpoint should not be exposed publicly unless it has its own authentication and rate limiting.
- ClamAV archive recursion/depth is normally controlled server-side by the ClamAV daemon configuration. File Browser only sends `X-ClamAV-Scan-Depth` as an optional hint for scanner APIs that support per-request depth.

