### PR TITLE
fix: parse csv files with uneven columns in their rows

### DIFF
--- a/frontend/src/components/files/CsvViewer.vue
+++ b/frontend/src/components/files/CsvViewer.vue
@@ -138,7 +138,11 @@ watchEffect(() => {
       : props.content;
     parse(
       content as string,
-      { delimiter: columnSeparator.value, skip_empty_lines: true },
+      {
+        delimiter: columnSeparator.value,
+        skip_empty_lines: true,
+        relax_column_count: true,
+      },
       (error, output) => {
         if (error) {
           console.error("Failed to parse CSV:", error);


### PR DESCRIPTION
## Description
The `relax_column_count: true` option was added to prevent the function from failing when reading rows with different column numbers.

Now, rows with missing columns will be displayed with empty content in the CSV file viewer table instead of showing an error when reading the file.

Rows with extra columns will also be displayed in the table.

## Additional Information
Closes https://github.com/filebrowser/filebrowser/issues/5952

## Checklist

Before submitting your PR, please indicate which issues are either fixed or closed by this PR. See [GitHub Help: Closing issues using keywords](https://help.github.com/articles/closing-issues-via-commit-messages/).

- [x] I am aware the project is currently in **maintenance-only** mode and new feature requests won't be accepted. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).
