### PR TITLE
fix: keep mobile file sort controls visible

### DIFF
--- a/frontend/src/css/__tests__/mobile.test.ts
+++ b/frontend/src/css/__tests__/mobile.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const mobileCss = readFileSync(resolve(__dirname, "../mobile.css"), "utf8");
+
+const normalizedCss = mobileCss.replace(/\s+/g, " ");
+
+describe("mobile file listing styles", () => {
+  it("hides file row metadata without hiding list header sort controls", () => {
+    expect(normalizedCss).toContain(
+      "#listing.list .item:not(.header) .size { display: none;"
+    );
+    expect(normalizedCss).toContain(
+      "#listing.list .item:not(.header) .modified { display: none;"
+    );
+
+    expect(normalizedCss).not.toMatch(
+      /#listing\.list \.item \.(size|modified) \{ display: none;/
+    );
+  });
+});

--- a/frontend/src/css/mobile.css
+++ b/frontend/src/css/mobile.css
@@ -14,11 +14,26 @@
   body {
     padding-bottom: 5em;
   }
-  #listing.list .item .size {
+  #listing.list .item:not(.header) .size {
     display: none;
   }
-  #listing.list .item .name {
+  #listing.list .item:not(.header) .name {
     width: 60%;
+  }
+  #listing.list .item.header .name {
+    margin-right: 0;
+    width: 45%;
+  }
+  #listing.list .item.header .size {
+    width: 25%;
+  }
+  #listing.list .item.header .modified {
+    width: 30%;
+  }
+  #listing.list .item.header p {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   #more {
     display: inherit;
@@ -162,10 +177,22 @@
 }
 
 @media (max-width: 450px) {
-  #listing.list .item .modified {
+  #listing.list .item:not(.header) .modified {
     display: none;
   }
-  #listing.list .item .name {
+  #listing.list .item:not(.header) .name {
     width: 100%;
+  }
+  #listing.list .item.header {
+    padding: 0.75em 0.5em;
+  }
+  #listing.list .item.header .name {
+    width: 34%;
+  }
+  #listing.list .item.header .size {
+    width: 24%;
+  }
+  #listing.list .item.header .modified {
+    width: 42%;
   }
 }


### PR DESCRIPTION
## What changed

- Keep the list header sort controls visible on mobile by hiding size/modified metadata only on file rows, not the header row.
- Add a focused frontend regression test for the mobile stylesheet so the sort controls do not get hidden again.

Fixes #5976.

## Verification

- Red before the CSS fix: `pnpm --dir frontend test -- src/css/__tests__/mobile.test.ts` failed because the mobile stylesheet still hid `#listing.list .item .size` and `.modified` globally.
- `pnpm --dir frontend test -- src/css/__tests__/mobile.test.ts`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend lint`
- `pnpm --dir frontend build`
- `git diff --check`

## Checklist

- [x] I am aware the project is currently in **maintenance-only** mode and new feature requests won't be accepted. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am making a PR against the `master` branch.
