### PR TITLE
fix: restore ScopedFs RealPath

### DIFF
--- a/files/file_test.go
+++ b/files/file_test.go
@@ -212,3 +212,17 @@ func TestReadListingSkipsInaccessibleChildren(t *testing.T) {
 		t.Fatalf("expected one listed directory, got %d", got)
 	}
 }
+
+func TestFileInfoRealPathUsesScopedFsRealPath(t *testing.T) {
+	root := t.TempDir()
+	file := &FileInfo{
+		Fs:   NewScopedFs(afero.NewOsFs(), root),
+		Path: "/root/downloads",
+	}
+
+	got := file.RealPath()
+	want := filepath.Join(root, "root", "downloads")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/files/scoped.go
+++ b/files/scoped.go
@@ -35,6 +35,13 @@ func NewScopedFs(source afero.Fs, path string) *ScopedFs {
 // Base returns the underlying *afero.BasePathFs.
 func (s *ScopedFs) Base() *afero.BasePathFs { return s.base }
 
+// RealPath resolves a scoped path to the real on-disk path by delegating to
+// the underlying BasePathFs. This is needed by callers that need the actual
+// filesystem path (e.g. disk.UsageWithContext).
+func (s *ScopedFs) RealPath(name string) (string, error) {
+	return s.base.RealPath(name)
+}
+
 // guard returns an error if name's on-disk target resolves outside the scope.
 func (s *ScopedFs) guard(name string) error {
 	ok, err := s.within(name)


### PR DESCRIPTION
Fixes #5985.

The ScopedFs refactor in 7c2c0a11 replaced BasePathFs at the user FS layer but stopped exposing RealPath(). FileInfo.RealPath() then fell back to the scoped File Browser path instead of the real on-disk path, which caused /api/usage to pass a non-existent path to disk usage collection and return 404.

Restore ScopedFs.RealPath() by delegating to the underlying BasePathFs and add a focused regression test for FileInfo.RealPath().