### PR TITLE
[codex] Feature 1: optimize runtime performance

### DIFF
--- a/files/file.go
+++ b/files/file.go
@@ -232,10 +232,15 @@ func (i *FileInfo) detectType(modify, saveContent, readHeader bool, calcImgRes b
 	mimetype := mime.TypeByExtension(i.Extension)
 
 	var buffer []byte
-	if readHeader {
-		buffer = i.readFirstBytes()
-
-		if mimetype == "" {
+	readBuffer := func() []byte {
+		if buffer == nil {
+			buffer = i.readFirstBytes()
+		}
+		return buffer
+	}
+	if readHeader && mimetype == "" {
+		buffer = readBuffer()
+		if len(buffer) > 0 {
 			mimetype = http.DetectContentType(buffer)
 		}
 	}
@@ -262,7 +267,24 @@ func (i *FileInfo) detectType(modify, saveContent, readHeader bool, calcImgRes b
 	case strings.HasSuffix(mimetype, "pdf"):
 		i.Type = "pdf"
 		return nil
-	case (strings.HasPrefix(mimetype, "text") || !isBinary(buffer)) && i.Size <= 10*1024*1024: // 10 MB
+	case strings.HasPrefix(mimetype, "text") && i.Size <= 10*1024*1024: // 10 MB
+		i.Type = "text"
+
+		if !modify {
+			i.Type = "textImmutable"
+		}
+
+		if saveContent {
+			afs := &afero.Afero{Fs: i.Fs}
+			content, err := afs.ReadFile(i.Path)
+			if err != nil {
+				return err
+			}
+
+			i.Content = string(content)
+		}
+		return nil
+	case i.Size <= 10*1024*1024 && (!readHeader || !isBinary(readBuffer())): // 10 MB
 		i.Type = "text"
 
 		if !modify {
@@ -441,15 +463,6 @@ func (i *FileInfo) readListing(checker rules.Checker, readHeader bool, calcImgRe
 			Extension:  filepath.Ext(name),
 			Path:       fPath,
 			currentDir: dir,
-		}
-
-		if !file.IsDir && strings.HasPrefix(mime.TypeByExtension(file.Extension), "image/") && calcImgRes {
-			resolution, err := calculateImageResolution(file.Fs, file.Path)
-			if err != nil {
-				log.Printf("Error calculating resolution for image %s: %v", file.Path, err)
-			} else {
-				file.Resolution = resolution
-			}
 		}
 
 		if file.IsDir {

--- a/files/file_test.go
+++ b/files/file_test.go
@@ -1,6 +1,9 @@
 package files
 
 import (
+	"image"
+	"image/color"
+	"image/jpeg"
 	"os"
 	"path"
 	"path/filepath"
@@ -224,5 +227,107 @@ func TestFileInfoRealPathUsesScopedFsRealPath(t *testing.T) {
 	want := filepath.Join(root, "root", "downloads")
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+type openCountingFs struct {
+	afero.Fs
+	opens map[string]int
+}
+
+func (fs *openCountingFs) Open(name string) (afero.File, error) {
+	fs.opens[path.Clean(name)]++
+	return fs.Fs.Open(name)
+}
+
+func TestDetectTypeSkipsHeaderReadForKnownImageExtension(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+	if err := afero.WriteFile(memFs, "/photo.jpg", []byte("header not needed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	countingFs := &openCountingFs{Fs: memFs, opens: map[string]int{}}
+	file, err := NewFileInfo(&FileOptions{
+		Fs:         countingFs,
+		Path:       "/photo.jpg",
+		Expand:     true,
+		ReadHeader: true,
+		Checker:    allowAllChecker{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if file.Type != "image" {
+		t.Fatalf("expected image type, got %q", file.Type)
+	}
+	if got := countingFs.opens["/photo.jpg"]; got != 0 {
+		t.Fatalf("expected known image extension to avoid header reads, got %d opens", got)
+	}
+}
+
+func TestDetectTypeStillReadsHeaderForUnknownExtension(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+	if err := afero.WriteFile(memFs, "/file.unknown", []byte("plain text"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	countingFs := &openCountingFs{Fs: memFs, opens: map[string]int{}}
+	file, err := NewFileInfo(&FileOptions{
+		Fs:         countingFs,
+		Path:       "/file.unknown",
+		Modify:     true,
+		Expand:     true,
+		ReadHeader: true,
+		Checker:    allowAllChecker{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if file.Type != "text" {
+		t.Fatalf("expected text type, got %q", file.Type)
+	}
+	if got := countingFs.opens["/file.unknown"]; got != 1 {
+		t.Fatalf("expected unknown extension to read one header, got %d opens", got)
+	}
+}
+
+func TestReadListingCalculatesImageResolutionOnce(t *testing.T) {
+	memFs := afero.NewMemMapFs()
+	file, err := memFs.Create("/photo.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+	img.Set(0, 0, color.White)
+	if err := jpeg.Encode(file, img, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	countingFs := &openCountingFs{Fs: memFs, opens: map[string]int{}}
+	listing, err := NewFileInfo(&FileOptions{
+		Fs:         countingFs,
+		Path:       "/",
+		Expand:     true,
+		ReadHeader: true,
+		CalcImgRes: true,
+		Checker:    allowAllChecker{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(listing.Items) != 1 {
+		t.Fatalf("expected one listing item, got %d", len(listing.Items))
+	}
+	if listing.Items[0].Resolution == nil {
+		t.Fatal("expected image resolution to be populated")
+	}
+	if got := countingFs.opens["/photo.jpg"]; got != 1 {
+		t.Fatalf("expected one image open for resolution calculation, got %d", got)
 	}
 }

--- a/http/preview.go
+++ b/http/preview.go
@@ -98,7 +98,7 @@ func handleImagePreview(
 		return errToStatus(err), err
 	}
 	if !ok {
-		resizedImage, err = createPreview(imgSvc, fileCache, file, previewSize)
+		resizedImage, err = createPreview(r.Context(), imgSvc, fileCache, file, previewSize)
 		if err != nil {
 			return errToStatus(err), err
 		}
@@ -110,7 +110,7 @@ func handleImagePreview(
 	return 0, nil
 }
 
-func createPreview(imgSvc ImgService, fileCache FileCache,
+func createPreview(ctx context.Context, imgSvc ImgService, fileCache FileCache,
 	file *files.FileInfo, previewSize PreviewSize) ([]byte, error) {
 	fd, err := file.Fs.Open(file.Path)
 	if err != nil {
@@ -138,7 +138,7 @@ func createPreview(imgSvc ImgService, fileCache FileCache,
 	}
 
 	buf := &bytes.Buffer{}
-	if err := imgSvc.Resize(context.Background(), fd, width, height, buf, options...); err != nil {
+	if err := imgSvc.Resize(ctx, fd, width, height, buf, options...); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

- avoid file header reads for known extensions in file type detection
- avoid duplicate image resolution work while building directory listings
- pass request context into preview resizing so canceled requests stop resize work

## Why

These are hot paths on low-resource deployments such as Raspberry Pi 5 systems. The changes keep existing functionality intact while reducing repeated disk I/O, image decode work, and wasted CPU after clients disconnect.

## Validation

- `go test ./files ./http`
