### PR TITLE
[codex] Feature 2: add video thumbnails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-## Multistage build: First stage fetches dependencies
+## Multistage build: First stage fetches helper scripts
 FROM alpine:3.23 AS fetcher
 
-# install and copy ca-certificates, mailcap, and tini-static; download JSON.sh
+# download JSON.sh
 RUN apk update && \
-    apk --no-cache add ca-certificates mailcap tini-static && \
+    apk --no-cache add ca-certificates && \
     wget -O /JSON.sh https://raw.githubusercontent.com/dominictarr/JSON.sh/0d5e5c77365f63809bf6e77ef44a1f34b0e05840/JSON.sh
 
-## Second stage: Use lightweight BusyBox image for final runtime environment
-FROM busybox:1.37.0-musl
+## Second stage: Use Alpine for the final runtime environment
+FROM alpine:3.23
+
+# Install runtime dependencies. ffmpeg includes ffprobe for video thumbnails.
+RUN apk --no-cache add ca-certificates ffmpeg mailcap tini-static
 
 # Define non-root user UID and GID
 ENV UID=1000
@@ -21,12 +24,7 @@ RUN addgroup -g $GID user && \
 COPY --chown=user:user filebrowser /bin/filebrowser
 COPY --chown=user:user docker/common/ /
 COPY --chown=user:user docker/alpine/ /
-COPY --chown=user:user --from=fetcher /sbin/tini-static /bin/tini
 COPY --from=fetcher /JSON.sh /JSON.sh
-COPY --from=fetcher /etc/ca-certificates.conf /etc/ca-certificates.conf
-COPY --from=fetcher /etc/ca-certificates /etc/ca-certificates
-COPY --from=fetcher /etc/mime.types /etc/mime.types
-COPY --from=fetcher /etc/ssl /etc/ssl
 
 # Create data directories, set ownership, and ensure healthcheck script is executable
 RUN mkdir -p /config /database /srv && \
@@ -43,4 +41,4 @@ VOLUME /srv /config /database
 
 EXPOSE 80
 
-ENTRYPOINT [ "tini", "--", "/init.sh" ]
+ENTRYPOINT [ "/sbin/tini-static", "--", "/init.sh" ]

--- a/Dockerfile.s6
+++ b/Dockerfile.s6
@@ -1,7 +1,7 @@
 FROM ghcr.io/linuxserver/baseimage-alpine:3.23
 
 RUN apk update && \
-  apk --no-cache add ca-certificates mailcap jq libcap
+  apk --no-cache add ca-certificates ffmpeg mailcap jq libcap
 
 # Make user and create necessary directories
 RUN mkdir -p /config /database /srv && \

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/filebrowser/filebrowser/v2/img"
 	"github.com/filebrowser/filebrowser/v2/settings"
 	"github.com/filebrowser/filebrowser/v2/storage"
+	"github.com/filebrowser/filebrowser/v2/thumbnail"
 	"github.com/filebrowser/filebrowser/v2/users"
 )
 
@@ -106,7 +107,7 @@ func addServerFlags(flags *pflag.FlagSet) {
 	flags.String("socket", "", "socket to listen to (cannot be used with address, port, cert nor key flags)")
 	flags.StringP("baseURL", "b", "", "base url")
 	flags.String("tokenExpirationTime", "2h", "user session timeout")
-	flags.Bool("disableThumbnails", false, "disable image thumbnails")
+	flags.Bool("disableThumbnails", false, "disable thumbnails")
 	flags.Bool("disablePreviewResize", false, "disable resize of image previews")
 	flags.Bool("disableExec", true, "disables Command Runner feature")
 	flags.Bool("disableTypeDetectionByHeader", false, "disables type detection by reading file headers")
@@ -168,6 +169,7 @@ user created with the credentials from options "username" and "password".`,
 			return errors.New("image resize workers count could not be < 1")
 		}
 		imageService := img.New(imgWorkersCount)
+		videoThumbService := thumbnail.NewVideo()
 
 		var fileCache diskcache.Interface = diskcache.NewNoOp()
 		cacheDir := v.GetString("cacheDir")
@@ -235,7 +237,7 @@ user created with the credentials from options "username" and "password".`,
 			panic(err)
 		}
 
-		handler, err := fbhttp.NewHandler(imageService, fileCache, uploadCache, st.Storage, server, assetsFs)
+		handler, err := fbhttp.NewHandler(imageService, videoThumbService, fileCache, uploadCache, st.Storage, server, assetsFs)
 		if err != nil {
 			return err
 		}

--- a/frontend/src/components/files/ListingItem.vue
+++ b/frontend/src/components/files/ListingItem.vue
@@ -23,9 +23,12 @@
     @contextmenu="contextMenu"
   >
     <div>
+      <img v-if="showLazyThumbnail" v-lazy="thumbnailUrl" />
       <img
-        v-if="!readOnly && type === 'image' && isThumbsEnabled"
-        v-lazy="thumbnailUrl"
+        v-else-if="showDirectThumbnail"
+        :src="thumbnailUrl"
+        loading="lazy"
+        @error="thumbnailFailed = true"
       />
       <i v-else class="material-icons"></i>
     </div>
@@ -53,7 +56,7 @@ import { filesize } from "@/utils";
 import dayjs from "dayjs";
 import { files as api } from "@/api";
 import * as upload from "@/utils/upload";
-import { computed, inject, ref } from "vue";
+import { computed, inject, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 
 const touches = ref<number>(0);
@@ -63,6 +66,7 @@ const longPressTriggered = ref<boolean>(false);
 const longPressDelay = ref<number>(500);
 const startPosition = ref<{ x: number; y: number } | null>(null);
 const moveThreshold = ref<number>(10);
+const thumbnailFailed = ref<boolean>(false);
 
 const $showError = inject<IToastError>("$showError")!;
 const router = useRouter();
@@ -117,6 +121,34 @@ const thumbnailUrl = computed(() => {
 const isThumbsEnabled = computed(() => {
   return enableThumbs;
 });
+
+const supportsThumbnail = computed(() => {
+  return props.type === "image" || props.type === "video";
+});
+
+const showThumbnail = computed(() => {
+  return (
+    !props.readOnly &&
+    isThumbsEnabled.value &&
+    supportsThumbnail.value &&
+    !thumbnailFailed.value
+  );
+});
+
+const showLazyThumbnail = computed(() => {
+  return showThumbnail.value && props.type === "image";
+});
+
+const showDirectThumbnail = computed(() => {
+  return showThumbnail.value && props.type === "video";
+});
+
+watch(
+  () => [props.path, props.modified, props.type],
+  () => {
+    thumbnailFailed.value = false;
+  }
+);
 
 const humanSize = () => {
   return props.type == "invalid_link" ? "invalid link" : filesize(props.size);

--- a/frontend/src/css/listing.css
+++ b/frontend/src/css/listing.css
@@ -130,7 +130,8 @@ html[dir="rtl"] #listing {
   text-align: center;
 }
 
-#listing.mosaic.gallery .item[data-type="image"] div:last-of-type {
+#listing.mosaic.gallery .item[data-type="image"] div:last-of-type,
+#listing.mosaic.gallery .item[data-type="video"] div:last-of-type {
   color: white;
   background: linear-gradient(#0000, #0009);
 }

--- a/http/http.go
+++ b/http/http.go
@@ -18,6 +18,7 @@ type modifyRequest struct {
 
 func NewHandler(
 	imgSvc ImgService,
+	videoSvc VideoThumbService,
 	fileCache FileCache,
 	uploadCache UploadCache,
 	store *storage.Storage,
@@ -81,7 +82,7 @@ func NewHandler(
 
 	api.PathPrefix("/raw").Handler(monkey(rawHandler, "/api/raw")).Methods("GET")
 	api.PathPrefix("/preview/{size}/{path:.*}").
-		Handler(monkey(previewHandler(imgSvc, fileCache, server.EnableThumbnails, server.ResizePreview), "/api/preview")).Methods("GET")
+		Handler(monkey(previewHandler(imgSvc, videoSvc, fileCache, server.EnableThumbnails, server.ResizePreview), "/api/preview")).Methods("GET")
 	api.PathPrefix("/command").Handler(monkey(commandsHandler, "/api/command")).Methods("GET")
 	api.PathPrefix("/search").Handler(monkey(searchHandler, "/api/search")).Methods("GET")
 	api.PathPrefix("/subtitle").Handler(monkey(subtitleHandler, "/api/subtitle")).Methods("GET")

--- a/http/preview.go
+++ b/http/preview.go
@@ -28,13 +28,17 @@ type ImgService interface {
 	Resize(ctx context.Context, in io.Reader, width, height int, out io.Writer, options ...img.Option) error
 }
 
+type VideoThumbService interface {
+	Thumbnail(ctx context.Context, input string, out io.Writer) error
+}
+
 type FileCache interface {
 	Store(ctx context.Context, key string, value []byte) error
 	Load(ctx context.Context, key string) ([]byte, bool, error)
 	Delete(ctx context.Context, key string) error
 }
 
-func previewHandler(imgSvc ImgService, fileCache FileCache, enableThumbnails, resizePreview bool) handleFunc {
+func previewHandler(imgSvc ImgService, videoSvc VideoThumbService, fileCache FileCache, enableThumbnails, resizePreview bool) handleFunc {
 	return withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
 		if !d.user.Perm.Download {
 			return http.StatusAccepted, nil
@@ -63,6 +67,8 @@ func previewHandler(imgSvc ImgService, fileCache FileCache, enableThumbnails, re
 		switch file.Type {
 		case "image":
 			return handleImagePreview(w, r, imgSvc, fileCache, file, previewSize, enableThumbnails, resizePreview)
+		case "video":
+			return handleVideoPreview(w, r, videoSvc, fileCache, file, previewSize, enableThumbnails)
 		default:
 			return http.StatusNotImplemented, fmt.Errorf("can't create preview for %s type", file.Type)
 		}
@@ -110,6 +116,41 @@ func handleImagePreview(
 	return 0, nil
 }
 
+func handleVideoPreview(
+	w http.ResponseWriter,
+	r *http.Request,
+	videoSvc VideoThumbService,
+	fileCache FileCache,
+	file *files.FileInfo,
+	previewSize PreviewSize,
+	enableThumbnails bool,
+) (int, error) {
+	if previewSize != PreviewSizeThumb {
+		return http.StatusNotImplemented, fmt.Errorf("can't create %s preview for video", previewSize)
+	}
+	if !enableThumbnails || videoSvc == nil {
+		return http.StatusNotImplemented, fmt.Errorf("video thumbnails are disabled")
+	}
+
+	cacheKey := previewCacheKey(file, previewSize)
+	thumbnail, ok, err := fileCache.Load(r.Context(), cacheKey)
+	if err != nil {
+		return errToStatus(err), err
+	}
+	if !ok {
+		thumbnail, err = createVideoPreview(r.Context(), videoSvc, fileCache, file, previewSize)
+		if err != nil {
+			return http.StatusNotImplemented, err
+		}
+	}
+
+	w.Header().Set("Cache-Control", "private")
+	w.Header().Set("Content-Type", "image/jpeg")
+	http.ServeContent(w, r, file.Name, file.ModTime, bytes.NewReader(thumbnail))
+
+	return 0, nil
+}
+
 func createPreview(imgSvc ImgService, fileCache FileCache,
 	file *files.FileInfo, previewSize PreviewSize) ([]byte, error) {
 	fd, err := file.Fs.Open(file.Path)
@@ -146,6 +187,23 @@ func createPreview(imgSvc ImgService, fileCache FileCache,
 		cacheKey := previewCacheKey(file, previewSize)
 		if err := fileCache.Store(context.Background(), cacheKey, buf.Bytes()); err != nil {
 			fmt.Printf("failed to cache resized image: %v", err)
+		}
+	}()
+
+	return buf.Bytes(), nil
+}
+
+func createVideoPreview(ctx context.Context, videoSvc VideoThumbService, fileCache FileCache,
+	file *files.FileInfo, previewSize PreviewSize) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	if err := videoSvc.Thumbnail(ctx, file.RealPath(), buf); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		cacheKey := previewCacheKey(file, previewSize)
+		if err := fileCache.Store(context.Background(), cacheKey, buf.Bytes()); err != nil {
+			fmt.Printf("failed to cache video thumbnail: %v", err)
 		}
 	}()
 

--- a/http/preview_test.go
+++ b/http/preview_test.go
@@ -1,0 +1,133 @@
+package fbhttp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+
+	"github.com/filebrowser/filebrowser/v2/files"
+)
+
+type fakeVideoThumbService struct {
+	output []byte
+	err    error
+	input  string
+	calls  int
+}
+
+func (s *fakeVideoThumbService) Thumbnail(_ context.Context, input string, out io.Writer) error {
+	s.calls++
+	s.input = input
+	if s.err != nil {
+		return s.err
+	}
+	_, err := out.Write(s.output)
+	return err
+}
+
+type memoryFileCache struct {
+	values map[string][]byte
+}
+
+func (c *memoryFileCache) Store(_ context.Context, key string, value []byte) error {
+	c.values[key] = value
+	return nil
+}
+
+func (c *memoryFileCache) Load(_ context.Context, key string) ([]byte, bool, error) {
+	value, ok := c.values[key]
+	return value, ok, nil
+}
+
+func (c *memoryFileCache) Delete(_ context.Context, key string) error {
+	delete(c.values, key)
+	return nil
+}
+
+func TestHandleVideoPreviewCreatesThumbnail(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/preview/thumb/movie.mp4", nil)
+	rec := httptest.NewRecorder()
+	cache := &memoryFileCache{values: map[string][]byte{}}
+	svc := &fakeVideoThumbService{output: []byte("jpeg")}
+	file := &files.FileInfo{
+		Fs:      afero.NewMemMapFs(),
+		Path:    "/movie.mp4",
+		Name:    "movie.mp4",
+		ModTime: time.Now(),
+	}
+
+	status, err := handleVideoPreview(rec, req, svc, cache, file, PreviewSizeThumb, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != 0 {
+		t.Fatalf("expected handled status 0, got %d", status)
+	}
+	if svc.calls != 1 {
+		t.Fatalf("expected thumbnail service to be called once, got %d", svc.calls)
+	}
+	if rec.Body.String() != "jpeg" {
+		t.Fatalf("expected thumbnail body, got %q", rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "image/jpeg" {
+		t.Fatalf("expected image/jpeg content type, got %q", got)
+	}
+}
+
+func TestHandleVideoPreviewUsesCache(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/preview/thumb/movie.mp4", nil)
+	rec := httptest.NewRecorder()
+	file := &files.FileInfo{
+		Fs:      afero.NewMemMapFs(),
+		Path:    "/movie.mp4",
+		Name:    "movie.mp4",
+		ModTime: time.Now(),
+	}
+	cache := &memoryFileCache{
+		values: map[string][]byte{
+			previewCacheKey(file, PreviewSizeThumb): []byte("cached"),
+		},
+	}
+	svc := &fakeVideoThumbService{output: []byte("generated")}
+
+	status, err := handleVideoPreview(rec, req, svc, cache, file, PreviewSizeThumb, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != 0 {
+		t.Fatalf("expected handled status 0, got %d", status)
+	}
+	if svc.calls != 0 {
+		t.Fatalf("expected thumbnail service not to be called, got %d", svc.calls)
+	}
+	if rec.Body.String() != "cached" {
+		t.Fatalf("expected cached thumbnail body, got %q", rec.Body.String())
+	}
+}
+
+func TestHandleVideoPreviewReportsUnavailable(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/preview/thumb/movie.mp4", nil)
+	rec := httptest.NewRecorder()
+	cache := &memoryFileCache{values: map[string][]byte{}}
+	svc := &fakeVideoThumbService{err: errors.New("missing ffmpeg")}
+	file := &files.FileInfo{
+		Fs:      afero.NewMemMapFs(),
+		Path:    "/movie.mp4",
+		Name:    "movie.mp4",
+		ModTime: time.Now(),
+	}
+
+	status, err := handleVideoPreview(rec, req, svc, cache, file, PreviewSizeThumb, true)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if status != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", status)
+	}
+}

--- a/thumbnail/video.go
+++ b/thumbnail/video.go
@@ -1,0 +1,119 @@
+package thumbnail
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+var ErrUnavailable = errors.New("thumbnail generator unavailable")
+
+type Video struct {
+	ffmpeg  string
+	ffprobe string
+}
+
+func NewVideo() *Video {
+	ffmpeg, _ := exec.LookPath("ffmpeg")
+	ffprobe, _ := exec.LookPath("ffprobe")
+	return NewVideoWithTools(ffmpeg, ffprobe)
+}
+
+func NewVideoWithTools(ffmpeg, ffprobe string) *Video {
+	return &Video{
+		ffmpeg:  ffmpeg,
+		ffprobe: ffprobe,
+	}
+}
+
+func (v *Video) Thumbnail(ctx context.Context, input string, out io.Writer) error {
+	if v == nil || v.ffmpeg == "" || v.ffprobe == "" {
+		return ErrUnavailable
+	}
+
+	duration, err := v.duration(ctx, input)
+	if err != nil {
+		if ctx.Err() != nil {
+			return err
+		}
+		duration = 0
+	}
+
+	args := []string{
+		"-nostdin",
+		"-hide_banner",
+		"-loglevel", "error",
+		"-ss", seekOffset(duration),
+		"-i", input,
+		"-frames:v", "1",
+		"-vf", "scale=256:256:force_original_aspect_ratio=increase,crop=256:256",
+		"-f", "image2pipe",
+		"-vcodec", "mjpeg",
+		"pipe:1",
+	}
+
+	cmd := exec.CommandContext(ctx, v.ffmpeg, args...)
+	cmd.Stdout = out
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	_, readErr := io.ReadAll(stderr)
+	waitErr := cmd.Wait()
+	if waitErr != nil {
+		return fmt.Errorf("ffmpeg thumbnail failed: %w", waitErr)
+	}
+
+	return readErr
+}
+
+func (v *Video) duration(ctx context.Context, input string) (float64, error) {
+	args := []string{
+		"-v", "error",
+		"-show_entries", "format=duration",
+		"-of", "default=noprint_wrappers=1:nokey=1",
+		input,
+	}
+
+	out, err := exec.CommandContext(ctx, v.ffprobe, args...).Output()
+	if err != nil {
+		return 0, err
+	}
+
+	duration, err := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)
+	if err != nil {
+		return 0, err
+	}
+	return duration, nil
+}
+
+func seekOffset(duration float64) string {
+	if duration <= 0 {
+		return "0.100"
+	}
+	if duration < 1 {
+		return fmt.Sprintf("%.3f", duration/2)
+	}
+
+	seek := duration * 0.1
+	if seek < 0.1 {
+		seek = 0.1
+	}
+	if seek > 10 {
+		seek = 10
+	}
+	if seek >= duration {
+		seek = duration / 2
+	}
+
+	return fmt.Sprintf("%.3f", seek)
+}

--- a/thumbnail/video_test.go
+++ b/thumbnail/video_test.go
@@ -1,0 +1,97 @@
+package thumbnail
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestVideoThumbnailUnavailable(t *testing.T) {
+	err := NewVideoWithTools("", "").Thumbnail(context.Background(), "video.mp4", &bytes.Buffer{})
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("expected ErrUnavailable, got %v", err)
+	}
+}
+
+func TestVideoThumbnailUsesFfmpegOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell test helper is unix-only")
+	}
+
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "ffmpeg.args")
+	ffprobe := writeScript(t, dir, "ffprobe", "printf '12.5\\n'\n")
+	ffmpeg := writeScript(t, dir, "ffmpeg", "printf '%s\\n' \"$@\" > \"$FFMPEG_ARGS_FILE\"\nprintf 'jpeg-bytes'\n")
+
+	t.Setenv("FFMPEG_ARGS_FILE", argsFile)
+	buf := &bytes.Buffer{}
+	err := NewVideoWithTools(ffmpeg, ffprobe).Thumbnail(context.Background(), filepath.Join(dir, "video.mp4"), buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := buf.String(); got != "jpeg-bytes" {
+		t.Fatalf("got output %q", got)
+	}
+
+	args, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotArgs := string(args)
+	for _, want := range []string{"-nostdin", "-ss", "1.250", "-frames:v", "1", "pipe:1"} {
+		if !strings.Contains(gotArgs, want) {
+			t.Fatalf("expected ffmpeg args to contain %q, got:\n%s", want, gotArgs)
+		}
+	}
+}
+
+func TestVideoThumbnailFallsBackWhenDurationIsUnavailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell test helper is unix-only")
+	}
+
+	dir := t.TempDir()
+	ffprobe := writeScript(t, dir, "ffprobe", "printf 'N/A\\n'\n")
+	ffmpeg := writeScript(t, dir, "ffmpeg", "printf 'jpeg-bytes'\n")
+
+	buf := &bytes.Buffer{}
+	err := NewVideoWithTools(ffmpeg, ffprobe).Thumbnail(context.Background(), filepath.Join(dir, "video.mp4"), buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "jpeg-bytes" {
+		t.Fatalf("got output %q", got)
+	}
+}
+
+func TestSeekOffset(t *testing.T) {
+	tests := map[float64]string{
+		0:     "0.100",
+		0.5:   "0.250",
+		12.5:  "1.250",
+		300.0: "10.000",
+	}
+
+	for duration, want := range tests {
+		if got := seekOffset(duration); got != want {
+			t.Fatalf("seekOffset(%f) = %s, want %s", duration, got, want)
+		}
+	}
+}
+
+func writeScript(t *testing.T, dir, name, body string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	content := "#!/bin/sh\nset -eu\n" + body
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/www/docs/cli/filebrowser-config-init.md
+++ b/www/docs/cli/filebrowser-config-init.md
@@ -38,7 +38,7 @@ filebrowser config init [flags]
       --disableExec                      disables Command Runner feature (default true)
       --disableImageResolutionCalc       disables image resolution calculation by reading image files
       --disablePreviewResize             disable resize of image previews
-      --disableThumbnails                disable image thumbnails
+      --disableThumbnails                disable thumbnails
       --disableTypeDetectionByHeader     disables type detection by reading file headers
       --fileMode string                  mode bits that new files are created with (default "0o640")
   -h, --help                             help for init
@@ -86,4 +86,3 @@ filebrowser config init [flags]
 ## See Also
 
 * [filebrowser config](filebrowser-config.md)	 - Configuration management utility
-

--- a/www/docs/cli/filebrowser-config-set.md
+++ b/www/docs/cli/filebrowser-config-set.md
@@ -35,7 +35,7 @@ filebrowser config set [flags]
       --disableExec                      disables Command Runner feature (default true)
       --disableImageResolutionCalc       disables image resolution calculation by reading image files
       --disablePreviewResize             disable resize of image previews
-      --disableThumbnails                disable image thumbnails
+      --disableThumbnails                disable thumbnails
       --disableTypeDetectionByHeader     disables type detection by reading file headers
       --fileMode string                  mode bits that new files are created with (default "0o640")
   -h, --help                             help for set
@@ -83,4 +83,3 @@ filebrowser config set [flags]
 ## See Also
 
 * [filebrowser config](filebrowser-config.md)	 - Configuration management utility
-

--- a/www/docs/cli/filebrowser.md
+++ b/www/docs/cli/filebrowser.md
@@ -59,7 +59,7 @@ filebrowser [flags]
       --disableExec                    disables Command Runner feature (default true)
       --disableImageResolutionCalc     disables image resolution calculation by reading image files
       --disablePreviewResize           disable resize of image previews
-      --disableThumbnails              disable image thumbnails
+      --disableThumbnails              disable thumbnails
       --disableTypeDetectionByHeader   disables type detection by reading file headers
   -h, --help                           help for filebrowser
       --imageProcessors int            image processors count (default 4)
@@ -85,4 +85,3 @@ filebrowser [flags]
 * [filebrowser rules](filebrowser-rules.md)	 - Rules management utility
 * [filebrowser users](filebrowser-users.md)	 - Users management utility
 * [filebrowser version](filebrowser-version.md)	 - Print the version number
-

--- a/www/docs/installation.md
+++ b/www/docs/installation.md
@@ -80,6 +80,48 @@ Both `settings.json` and `filebrowser.db` will automatically be initialized if t
 
 File Browser is now up and running. Read the ["First Boot"](#first-boot) section for more information.
 
+## Video Thumbnails
+
+Video thumbnails are generated when thumbnails are enabled and both `ffmpeg`
+and `ffprobe` are available. The Docker images include these tools, so video
+thumbnails work without adding packages to the container.
+
+For Docker-based setups, keep thumbnails enabled and mount persistent
+configuration, database, and file volumes. Named volumes work well for
+File Browser's own state:
+
+```sh
+docker volume create filebrowser-config
+docker volume create filebrowser-database
+
+docker run \
+  --name filebrowser \
+  -p 8000:80 \
+  -v /path/to/files:/srv \
+  -v filebrowser-config:/config \
+  -v filebrowser-database:/database \
+  filebrowser/filebrowser:latest
+```
+
+If you bind-mount host directories for `/srv`, `/config`, or `/database`, make
+sure they are writable by the container user. The standard image runs as UID
+1000 and GID 1000.
+
+Thumbnails are enabled by default. If a persisted database was previously
+configured with thumbnails disabled, re-enable them with:
+
+```sh
+docker run --rm \
+  -v filebrowser-config:/config \
+  -v filebrowser-database:/database \
+  filebrowser/filebrowser:latest \
+  config set --disableThumbnails=false
+```
+
+For non-Docker deployments, install `ffmpeg` and `ffprobe` on the host. If
+either command is missing, video files continue to work normally and the
+interface falls back to the video file icon.
+
 ## First Boot
 
 Your instance is now up and running. File Browser will automatically bootstrap a database, in which the configuration and the users are stored. You can find the address in which your instance is running, as well as the randomly generated password for the user `admin`, in the console logs.


### PR DESCRIPTION
## Summary

- add an `ffmpeg`/`ffprobe` backed video thumbnail service
- serve cached JPEG thumbnails for video files through the existing preview endpoint
- render video thumbnails in the listing UI with fallback behavior when unavailable
- install video thumbnail runtime dependencies in the standard and s6 Docker images
- document Docker-based video thumbnail setup

## Why

Video thumbnails are generated on demand and cached, so Docker deployments get useful previews without changing the existing image thumbnail path or requiring a separate configuration profile.

## Validation

- `go test ./thumbnail ./http ./cmd`
- `npx -y pnpm@10.33.4 --dir frontend run lint`
- `npx -y pnpm@10.33.4 --dir frontend run test`
- `npx -y pnpm@10.33.4 --dir frontend run build`
- `docker build -t filebrowser-video-thumb:test .`
- `docker build -f Dockerfile.s6 -t filebrowser-video-thumb-s6:test .`
