### PR TITLE
fix: preserve SRT subtitle line breaks

### DIFF
--- a/http/subtitle.go
+++ b/http/subtitle.go
@@ -2,13 +2,17 @@ package fbhttp
 
 import (
 	"bytes"
+	"io"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/asticode/go-astisub"
 
 	"github.com/filebrowser/filebrowser/v2/files"
 )
+
+var srtLineBreakTag = regexp.MustCompile(`(?i)<br(?:\s+[^>]*)?\s*/?>`)
 
 var subtitleHandler = withUser(func(w http.ResponseWriter, r *http.Request, d *data) (int, error) {
 	if !d.user.Perm.Download {
@@ -49,7 +53,11 @@ func subtitleFileHandler(w http.ResponseWriter, r *http.Request, file *files.Fil
 	// load subtitle for conversion to vtt
 	var sub *astisub.Subtitles
 	if strings.HasSuffix(file.Name, ".srt") {
-		sub, err = astisub.ReadFromSRT(fd)
+		content, readErr := io.ReadAll(fd)
+		if readErr != nil {
+			return http.StatusInternalServerError, readErr
+		}
+		sub, err = astisub.ReadFromSRT(bytes.NewReader(normalizeSRTLineBreaks(content)))
 	} else if strings.HasSuffix(file.Name, ".ass") || strings.HasSuffix(file.Name, ".ssa") {
 		sub, err = astisub.ReadFromSSA(fd)
 	}
@@ -77,4 +85,8 @@ func subtitleFileHandler(w http.ResponseWriter, r *http.Request, file *files.Fil
 	}
 	http.ServeContent(w, r, file.Name, file.ModTime, bytes.NewReader(buf.Bytes()))
 	return 0, nil
+}
+
+func normalizeSRTLineBreaks(content []byte) []byte {
+	return srtLineBreakTag.ReplaceAll(content, []byte("\n"))
 }

--- a/http/subtitle_test.go
+++ b/http/subtitle_test.go
@@ -1,0 +1,62 @@
+package fbhttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"github.com/filebrowser/filebrowser/v2/files"
+)
+
+func TestNormalizeSRTLineBreaks(t *testing.T) {
+	input := []byte("first<br>second<BR/>third<br />fourth<br class=\"x\">fifth")
+	got := string(normalizeSRTLineBreaks(input))
+	want := "first\nsecond\nthird\nfourth\nfifth"
+	if got != want {
+		t.Fatalf("normalizeSRTLineBreaks() = %q, want %q", got, want)
+	}
+}
+
+func TestSubtitleFileHandlerConvertsSRTBreakTags(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	const path = "/sample.srt"
+	const content = "1\n" +
+		"00:00:01,000 --> 00:00:02,000\n" +
+		"First<br>Second<BR/>Third<br />Fourth\n\n"
+
+	if err := afero.WriteFile(fs, path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write subtitle: %v", err)
+	}
+	info, err := fs.Stat(path)
+	if err != nil {
+		t.Fatalf("failed to stat subtitle: %v", err)
+	}
+
+	file := &files.FileInfo{
+		Fs:      fs,
+		Path:    path,
+		Name:    "sample.srt",
+		ModTime: info.ModTime(),
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/subtitle/sample.srt?inline=true", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	status, err := subtitleFileHandler(rec, req, file)
+	if err != nil {
+		t.Fatalf("subtitleFileHandler returned error: %v", err)
+	}
+	if status != 0 {
+		t.Fatalf("subtitleFileHandler status = %d, want 0", status)
+	}
+
+	body := rec.Body.String()
+	if strings.Contains(body, "FirstSecond") {
+		t.Fatalf("WebVTT output collapsed SRT <br> tags: %q", body)
+	}
+	if !strings.Contains(body, "First\nSecond\nThird\nFourth") {
+		t.Fatalf("WebVTT output = %q, want converted SRT <br> tags as line breaks", body)
+	}
+}


### PR DESCRIPTION
## Description

Normalize SRT HTML line break tags before converting subtitles to WebVTT, so `<br>`, `<br/>`, and `<br />` are preserved as actual subtitle line breaks instead of being collapsed by the parser.

Refs #5979.

## Additional Information

Added regression coverage for the SRT line break normalization and subtitle handler output.

## Checklist

- [x] I am aware the project is currently in **maintenance-only** mode and new feature requests won't be accepted. See [README](https://github.com/filebrowser/community/blob/master/README.md)
- [x] I am aware that translations MUST be made through [Transifex](https://app.transifex.com/file-browser/file-browser/) and that this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built. See [builds](https://github.com/filebrowser/community/blob/master/builds.md) and [development](https://github.com/filebrowser/community/blob/master/development.md).

Tests:
- `go test ./...`
- `go test --race ./http`
- `go build ./...`
