### PR TITLE
fix(preview): keep the EPUB table-of-contents button clear of the header

### DIFF
--- a/frontend/src/css/epubReader.css
+++ b/frontend/src/css/epubReader.css
@@ -29,6 +29,13 @@
 
 .epub-reader .tocButton {
   color: var(--text);
+  /*
+   * vue-reader positions the TOC toggle at top: 10px, which lands under the
+   * fixed 4em header bar (see .header) — so clicks hit the header's Close
+   * button instead of opening the table of contents. Push it just below the
+   * header, tracking the header's height so it stays clear if that changes.
+   */
+  top: calc(4em + 10px);
 }
 
 .epub-reader .tocButton.tocButtonExpanded {


### PR DESCRIPTION
## Description

Fixes #5974.

In the EPUB viewer, the table-of-contents button overlaps the viewer's Close (X) button, so clicking the TOC button closes the preview instead of opening the table of contents.

## Additional Information

`vue-reader` positions its `.tocButton` at `position: absolute; top: 10px; left: 10px`. That lands underneath File Browser's fixed `4em` header bar (`.header`), whose Close button sits in the same top-left corner with a higher stacking context — so the click hits Close.

The fix moves the TOC button just below the header with `top: calc(4em + 10px)`, tracking the header height so it stays clear if that ever changes. It's a CSS-only change scoped to `.epub-reader .tocButton`, whose higher specificity overrides the library's own rule (no `!important` needed).

Verified by reproducing the header + `.tocButton` geometry against `vue-reader`'s actual positioning: before, the TOC button sits under the Close (X); after, it sits below the header and is clickable.

## Checklist

- [x] I am aware the project is currently in **maintenance-only** mode and new feature requests won't be accepted — this is a bug fix, not a feature.
- [x] I am aware that translations MUST be made through Transifex and that this PR is NOT a translation update.
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built — this is a CSS-only change and touches no build logic.
