### PR TITLE
fix: return error instead of panicking on an unreadable directory during copy

### DIFF
--- a/fileutils/copy_test.go
+++ b/fileutils/copy_test.go
@@ -2,12 +2,61 @@ package fileutils
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
 	"github.com/filebrowser/filebrowser/v2/files"
 	"github.com/spf13/afero"
 )
+
+// failingOpenFs wraps an afero.Fs and makes Open fail for one specific path,
+// while every other operation (including Stat) is delegated unchanged. It
+// simulates a directory that can be stat-ed but not opened/read — for example
+// an unreadable sub-directory, or one whose permissions changed or that was
+// removed after its parent was listed (a TOCTOU race) — encountered during a
+// recursive copy.
+type failingOpenFs struct {
+	afero.Fs
+	failOpen string
+}
+
+func (f *failingOpenFs) Open(name string) (afero.File, error) {
+	if path.Clean(name) == path.Clean(f.failOpen) {
+		return nil, os.ErrPermission
+	}
+	return f.Fs.Open(name)
+}
+
+// CopyDir is documented to keep going when it hits an error and to report the
+// error afterwards. A sub-directory that cannot be opened must therefore yield
+// an error (and leave the other, readable entries copied) rather than
+// panicking on a nil directory handle.
+func TestCopyDirUnreadableSubdirReturnsError(t *testing.T) {
+	mem := afero.NewMemMapFs()
+	if err := mem.MkdirAll("/srcdir/sub", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := afero.WriteFile(mem, "/srcdir/ok.txt", []byte("readable"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	afs := &failingOpenFs{Fs: mem, failOpen: "/srcdir/sub"}
+
+	err := Copy(afs, "/srcdir", "/dstdir", 0o644, 0o755)
+	if err == nil {
+		t.Fatal("expected an error when a sub-directory cannot be opened")
+	}
+
+	// The readable sibling must still have been copied (continue-on-error).
+	data, readErr := afero.ReadFile(afs, "/dstdir/ok.txt")
+	if readErr != nil {
+		t.Fatalf("readable sibling was not copied: %v", readErr)
+	}
+	if string(data) != "readable" {
+		t.Fatalf("unexpected copied content: %q", string(data))
+	}
+}
 
 // Copying an in-scope directory that contains a symlink whose target escapes
 // the user's scope must not dereference that symlink into the destination.

--- a/fileutils/dir.go
+++ b/fileutils/dir.go
@@ -23,7 +23,12 @@ func CopyDir(afs afero.Fs, source, dest string, fileMode, dirMode fs.FileMode) e
 		return err
 	}
 
-	dir, _ := afs.Open(source)
+	dir, err := afs.Open(source)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+
 	obs, err := dir.Readdir(-1)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

`CopyDir` (`fileutils/dir.go`) discarded the error from `afs.Open(source)` and immediately called `dir.Readdir(-1)` on the returned handle:

    dir, _ := afs.Open(source)
    obs, err := dir.Readdir(-1)

When `Open` fails on a directory that was successfully `Stat`-ed — an unreadable sub-directory reached during a recursive copy, or a directory whose permissions changed / that was removed after its parent was listed (a TOCTOU race) — the handle is `nil` and `Readdir` panics with a nil-pointer dereference, crashing the copy operation. This also contradicts `CopyDir`'s documented behaviour: "It doesn't stop if it finds an error during the copy. Returns an error if any."

This mirrors #5958 (which hardened the *listing* path against inaccessible children); the recursive *copy* path had the same weakness.

## Additional Information

- Check the `Open` error and return it. The recursive caller already collects per-entry errors and continues, so a single unreadable sub-directory now yields an error while the other, readable entries are still copied — matching the function's stated contract.
- Also `defer dir.Close()` the handle, which was previously leaked.
- Adds `TestCopyDirUnreadableSubdirReturnsError`, which fault-injects an `Open` failure via an `afero.Fs` wrapper. Without the fix it panics; with the fix it returns an error and still copies the readable sibling. Deterministic and platform-independent.

> Disclosure: this change was prepared with AI assistance (Claude). The defect, fix, and test were reviewed and verified (`go test ./fileutils/` fails-before / passes-after; `go vet` and `go build ./...` clean).

## Checklist

- [x] I am aware the project is currently in maintenance-only mode (this is a bug fix, not a feature)
- [x] this PR is NOT a translation update
- [x] I am making a PR against the `master` branch.
- [x] I am sure File Browser can be successfully built.
