### PR TITLE
feat: add a refresh button to the folder listing header

### DIFF
--- a/frontend/src/views/files/FileListing.vue
+++ b/frontend/src/views/files/FileListing.vue
@@ -59,6 +59,12 @@
           @action="switchView"
         />
         <action
+          id="refresh-folder-button"
+          icon="refresh"
+          :label="t('buttons.refresh')"
+          @action="refreshFolder()"
+        />
+        <action
           v-if="headerButtons.download"
           icon="file_download"
           :label="t('buttons.download')"
@@ -1026,6 +1032,10 @@ const switchView = async () => {
 
   setItemWeight();
   fillWindow();
+};
+
+const refreshFolder = () => {
+  fileStore.reload = true;
 };
 
 const uploadFunc = () => {


### PR DESCRIPTION
## Summary
Add a "Refresh" action to the folder listing header so users can manually reload the current directory.

- Reuses the existing `fileStore.reload` pipeline (the same mechanism used after an upload), so no new state or API call is introduced.
- Uses the existing `buttons.refresh` translation key and the `refresh` icon.

## Test plan
- Open any directory in the file listing.
- Click the new refresh button in the header; the current directory is reloaded.

## Checklist
- [x] Targets `master`
- [x] Frontend-only change, no backend/i18n additions needed (`buttons.refresh` already exists)