### PR TITLE
feat: add an "Open" button to open the selected file

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -22,6 +22,7 @@
     "new": "New",
     "next": "Next",
     "ok": "OK",
+    "open": "Open",
     "permalink": "Get Permanent Link",
     "previous": "Previous",
     "preview": "Preview",

--- a/frontend/src/views/files/FileListing.vue
+++ b/frontend/src/views/files/FileListing.vue
@@ -13,6 +13,13 @@
       <template #actions>
         <template v-if="!isMobile">
           <action
+            v-if="headerButtons.open"
+            id="open-button"
+            icon="open_in_browser"
+            :label="t('buttons.open')"
+            @action="openSelected"
+          />
+          <action
             v-if="headerButtons.share"
             icon="share"
             :label="t('buttons.share')"
@@ -91,6 +98,12 @@
       <span v-if="fileStore.selectedCount > 0">
         {{ t("prompts.filesSelected", fileStore.selectedCount) }}
       </span>
+      <action
+        v-if="headerButtons.open"
+        icon="open_in_browser"
+        :label="t('buttons.open')"
+        @action="openSelected"
+      />
       <action
         v-if="headerButtons.share"
         icon="share"
@@ -263,6 +276,12 @@
           @hide="hideContextMenu"
         >
           <action
+            v-if="fileStore.selectedCount === 1"
+            icon="open_in_browser"
+            :label="t('buttons.open')"
+            @action="openSelected"
+          />
+          <action
             v-if="headerButtons.share"
             icon="share"
             :label="t('buttons.share')"
@@ -366,7 +385,7 @@ import {
   ref,
   watch,
 } from "vue";
-import { useRoute, onBeforeRouteUpdate } from "vue-router";
+import { useRoute, useRouter, onBeforeRouteUpdate } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { storeToRefs } from "pinia";
 import { removePrefix } from "@/api/utils";
@@ -389,6 +408,7 @@ const layoutStore = useLayoutStore();
 const { req } = storeToRefs(fileStore);
 
 const route = useRoute();
+const router = useRouter();
 onBeforeRouteUpdate(() => {
   hideContextMenu();
 });
@@ -475,6 +495,7 @@ const viewIcon = computed(() => {
 
 const headerButtons = computed(() => {
   return {
+    open: fileStore.selectedCount === 1,
     upload: authStore.user?.perm.create,
     download: authStore.user?.perm.download,
     shell: authStore.user?.perm.execute && enableExec,
@@ -1100,6 +1121,12 @@ const showContextMenu = (event: MouseEvent) => {
 
 const hideContextMenu = () => {
   isContextMenuVisible.value = false;
+};
+
+const openSelected = () => {
+  if (fileStore.selectedCount !== 1 || fileStore.req === null) return;
+  const item = fileStore.req.items[fileStore.selected[0]];
+  router.push({ path: item.url });
 };
 
 const handleEmptyAreaClick = (e: MouseEvent) => {


### PR DESCRIPTION
## Summary
Add an "Open" button so users can open the selected file directly.

- Shown in the toolbar, the mobile selection bar and the context menu when exactly one item is selected.
- Navigates to the item via its existing `url` (reuses `router.push`), so no new API or backend change is needed.
- Adds the `buttons.open` translation key (English source string). Other languages are handled by Transifex.

## Test plan
- Select a single file in the listing (desktop or mobile).
- Click "Open" in the toolbar / mobile bar / context menu; the app navigates to that file.

## Checklist
- [x] Targets `master`
- [x] Frontend-only change; no backend or `zh-cn.json` modifications (Transifex-managed)