### PR TITLE
feat: add a refresh button to the file editor

### DIFF
--- a/frontend/src/views/files/Editor.vue
+++ b/frontend/src/views/files/Editor.vue
@@ -30,6 +30,12 @@
         @action="preview()"
         v-show="isMarkdownFile"
       />
+      <action
+        id="refresh-button"
+        icon="refresh"
+        :label="t('buttons.refresh')"
+        @action="refresh()"
+      />
     </header-bar>
 
     <!-- preview container -->
@@ -323,6 +329,39 @@ const finishClose = () => {
 
 const preview = () => {
   isPreview.value = !isPreview.value;
+};
+
+const refresh = () => {
+  if (editor.value && !editor.value.session.getUndoManager().isClean()) {
+    // Reuse the existing discard-changes confirmation flow.
+    layoutStore.showHover({
+      prompt: "discardEditorChanges",
+      confirm: () => {
+        doRefresh();
+      },
+    });
+    return;
+  }
+  doRefresh();
+};
+
+const doRefresh = async () => {
+  buttons.loading("refresh");
+  try {
+    const res = await api.fetch(route.path);
+    const newContent = res.content ?? "";
+    editor.value?.session.setValue(newContent);
+    editor.value?.session.getUndoManager().markClean();
+    if (isPreview.value && isMarkdownFile) {
+      // The preview is rendered from a buffer snapshot and only re-renders on
+      // toggle, so refresh it manually after reloading the content.
+      previewContent.value = DOMPurify.sanitize(await marked(newContent));
+    }
+  } catch (e: any) {
+    $showError(e);
+  } finally {
+    buttons.done("refresh");
+  }
 };
 </script>
 


### PR DESCRIPTION
## Summary
Add a "Refresh" action to the editor header bar that re-fetches the latest file content from the server.

- If the editor has unsaved changes, the existing discard-changes confirmation (`discardEditorChanges`) is shown before reloading.
- When a markdown preview is open, it is re-rendered after the reload.
- Reuses the existing `buttons.refresh` translation key and the `buttons` loading state, so no new i18n keys or backend changes are needed.

## Test plan
- Open a file in the editor.
- Click "Refresh"; the editor content is replaced with the latest version from the server.
- With unsaved changes, confirm the discard prompt appears first.

## Checklist
- [x] Targets `master`
- [x] Frontend-only change