### PR TITLE
fix: make the sidebar scrollable when content overflows

### DIFF
--- a/frontend/src/css/base.css
+++ b/frontend/src/css/base.css
@@ -56,6 +56,8 @@ nav {
   position: fixed;
   top: 4em;
   left: 0;
+  height: calc(100vh - 4em);
+  overflow-y: auto;
 }
 
 html[dir="rtl"] nav {

--- a/frontend/src/css/mobile.css
+++ b/frontend/src/css/mobile.css
@@ -113,8 +113,9 @@
     top: 0;
     z-index: 99999;
     background: var(--surfaceSecondary);
-    height: 100%;
+    height: 100vh;
     width: 16em;
+    overflow-y: auto;
     box-shadow: 0 0 5px var(--borderPrimary);
     transition: 0.1s ease left;
     left: -17em;


### PR DESCRIPTION
## Summary
Make the left sidebar `<nav>` vertically scrollable so menu items (and favorites) below the viewport remain reachable.

- Desktop: `nav` gets `height: calc(100vh - 4em)` and `overflow-y: auto`.
- Mobile: `nav` gets `height: 100vh` and `overflow-y: auto`.
- CSS-only change; no markup, script or i18n changes.