### PR TITLE
fix: use absolute URLs for the PWA manifest icon sources

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -55,12 +55,16 @@
         short_name: window.FileBrowser.Name || "File Browser",
         icons: [
           {
-            src: window.__prependStaticUrl("/img/icons/android-chrome-192x192.png"),
+            src:
+              window.location.origin +
+              window.__prependStaticUrl("/img/icons/android-chrome-192x192.png"),
             sizes: "192x192",
             type: "image/png",
           },
           {
-            src: window.__prependStaticUrl("/img/icons/android-chrome-512x512.png"),
+            src:
+              window.location.origin +
+              window.__prependStaticUrl("/img/icons/android-chrome-512x512.png"),
             sizes: "512x512",
             type: "image/png",
           },


### PR DESCRIPTION
## Summary
The web app manifest is resolved relative to the manifest URL, not the document. When File Browser is served under a subpath or behind a reverse proxy, the relative icon `src` can 404. Prefix the static URLs with `window.location.origin` so the PWA icons resolve correctly in all deployments.

- Updates `frontend/public/index.html` (the Vite entry template).

## Test plan
- Serve File Browser under a subpath (e.g. `/filebrowser`).
- Install as PWA; confirm the icons load instead of 404-ing.