### PR TITLE
fix(http): run upload hooks for directories

### DIFF
--- a/http/resource.go
+++ b/http/resource.go
@@ -130,7 +130,9 @@ func resourcePostHandler(fileCache FileCache) handleFunc {
 
 		// Directories creation on POST.
 		if strings.HasSuffix(r.URL.Path, "/") {
-			err := d.user.Fs.MkdirAll(r.URL.Path, d.settings.DirMode)
+			err := d.RunHook(func() error {
+				return d.user.Fs.MkdirAll(r.URL.Path, d.settings.DirMode)
+			}, "upload", r.URL.Path, "", d.user)
 			return errToStatus(err), err
 		}
 

--- a/http/resource_test.go
+++ b/http/resource_test.go
@@ -222,3 +222,38 @@ func TestResourcePostCleanupDoesNotDeleteThroughSymlink(t *testing.T) {
 		t.Fatalf("VULNERABLE: out-of-scope victim.txt deleted by cleanup RemoveAll (status=%d): %v", rec.Code, statErr)
 	}
 }
+
+func TestResourcePostRunsUploadHooksForDirectories(t *testing.T) {
+	root := t.TempDir()
+	userScope := filepath.Join(root, "user")
+	if err := os.MkdirAll(userScope, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	key := []byte("test-signing-key")
+	perm := users.Permissions{Create: true}
+	st := scopedUserStorage(t, userScope, perm, key)
+	if err := st.Settings.Save(&settings.Settings{
+		Key: key,
+		Commands: map[string][]string{
+			"after_upload": {"filebrowser-hook-command-that-does-not-exist"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, "/created/", http.NoBody)
+	req.Header.Set("X-Auth", signToken(t, perm, key))
+	rec := httptest.NewRecorder()
+	handle(resourcePostHandler(diskcache.NewNoOp()), "", st, &settings.Server{EnableExec: true}).ServeHTTP(rec, req)
+
+	// A missing after_upload command makes the request fail only if the hook ran.
+	// It avoids a platform-specific helper executable while still exercising the
+	// same path the web UI uses for directory uploads.
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected directory upload hook failure to return 500, got %d body=%q", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(userScope, "created")); err != nil {
+		t.Fatalf("expected directory to be created before its after hook, got %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #5300

## What changed
Directory creation through `POST /api/resources/<directory>/` now runs through the same `upload` hook lifecycle as file uploads.

## Root cause
The directory branch called `MkdirAll` directly and returned before `Runner.RunHook` could execute configured `before_upload` or `after_upload` commands.

## Validation
- `go test ./http -run '^TestResourcePostRunsUploadHooksForDirectories$' -count=1`
- `go test ./runner`
- `go build ./...`
- `git diff --check`

The dedicated regression test fails against the previous direct `MkdirAll` path (returns 200) and passes with the hook wrapper restored.

## Note
`go test ./http` still has unrelated Windows-only failures in existing archive, symlink-cleanup, and public-share tests; the focused regression passes on this checkout.