### PR TITLE
fix(video): increase skip amount to 30s and enlarge control bar for touch

### DIFF
--- a/frontend/src/components/files/VideoPlayer.vue
+++ b/frontend/src/components/files/VideoPlayer.vue
@@ -94,8 +94,8 @@ const getOptions = (...srcOpt: any[]) => {
   const options = {
     controlBar: {
       skipButtons: {
-        forward: 5,
-        backward: 5,
+        forward: 30,
+        backward: 30,
       },
     },
     html5: {

--- a/frontend/src/css/styles.css
+++ b/frontend/src/css/styles.css
@@ -241,6 +241,19 @@ main .spinner .bounce2 {
   margin-top: 40%;
 }
 
+/* video.js sizes the control bar and its buttons in em units off this
+   font-size (default 10px => a 30px-tall bar), which is too small to
+   comfortably tap on touch devices. */
+#previewer .video-js .vjs-control-bar {
+  font-size: 16px;
+}
+
+@media (pointer: coarse) {
+  #previewer .video-js .vjs-control-bar {
+    font-size: 20px;
+  }
+}
+
 #previewer .preview .info {
   position: absolute;
   top: 50%;


### PR DESCRIPTION
video.js only supports 5/10/30s skip buttons natively (hardcoded icons and validation), so 30s is used as the closest larger step. The control bar's font-size (which video.js scales all control sizes from) is bumped so buttons are easier to tap, especially on mobile.
